### PR TITLE
Smeftsim update

### DIFF
--- a/smeft.smeftsim-general.basis.json
+++ b/smeft.smeftsim-general.basis.json
@@ -5,10003 +5,10003 @@
     "description": "Basis used in the `SMEFTsim_general` UFO models, version 3.0.0 or later. Implements Warsaw basis with generic flavor indices for all fermions. $q,u,d$ are the left- and right-handed quark fields. $\\ell, e$ are left- and right-handed lepton fields. Quark fields are in the up-aligned basis. This basis definition corresponds to a fixed `LambdaSMEFT=1e+3` in the UFO models. Notation and conventions can vary compared to the Warsaw basis paper, see [arXiv:2012.11343](https://arxiv.org/abs/2012.11343) for all definitions."
   },
   "sectors": {
-     "dB=dL=0": {
-       "cG": {
-          "real": true,
-          "tex": "f^{ABC} G_\\mu^{A \\nu} G_\\nu^{B \\rho} G_\\rho^{C \\mu} / \\text{TeV}^2"
-       },
-       "cGtil": {
-          "real": true,
-          "tex": "f^{ABC} \\widetilde  G_\\mu^{A \\nu} G_\\nu^{B \\rho} G_\\rho^{C \\mu} / \\text{TeV}^2"
-       },
-       "cW": {
-          "real": true,
-          "tex": "\\varepsilon^{IJK} W_\\mu^{I \\nu} W_\\nu^{J \\rho} W_\\rho^{K \\mu} / \\text{TeV}^2"
-       },
-       "cWtil": {
-          "real": true,
-          "tex": "\\varepsilon^{IJK} \\widetilde W_\\mu^{I \\nu} W_\\nu^{J \\rho} W_\\rho^{K \\mu} / \\text{TeV}^2"
-       },
-       "cH": {
-          "real": true,
-          "tex": "(H^\\dagger H)^3 / \\text{TeV}^2"
-       },
-       "cHbox": {
-          "real": true,
-          "tex": "(H^\\dagger H) \\Box ( H^\\dagger H ) / \\text{TeV}^2"
-       },
-       "cHDD": {
-          "real": true,
-          "tex": "(D_\\mu H^\\dagger H) (H^\\dagger D^\\mu H) / \\text{TeV}^2"
-       },
-       "cHG": {
-          "real": true,
-          "tex": "G_{\\mu\\nu}^A G^{A \\mu\\nu} H^\\dagger H / \\text{TeV}^2"
-       },
-       "cHGtil": {
-          "real": true,
-          "tex": "\\widetilde G_{\\mu\\nu}^A G^{A \\mu\\nu} H^\\dagger H / \\text{TeV}^2"
-       },
-       "cHW": {
-          "real": true,
-          "tex": "W_{\\mu\\nu}^I W^{I \\mu\\nu} H^\\dagger H / \\text{TeV}^2"
-       },
-       "cHWtil": {
-          "real": true,
-          "tex": "\\widetilde W_{\\mu\\nu}^I W^{I \\mu\\nu} H^\\dagger H / \\text{TeV}^2"
-       },
-       "cHB": {
-          "real": true,
-          "tex": "B_{\\mu\\nu} B^{\\mu\\nu} H^\\dagger H / \\text{TeV}^2"
-       },
-       "cHBtil": {
-          "real": true,
-          "tex": "\\widetilde B_{\\mu\\nu} B^{\\mu\\nu} H^\\dagger H / \\text{TeV}^2"
-       },
-       "cHWB": {
-          "real": true,
-          "tex": "B_{\\mu\\nu} W^{I \\mu\\nu} H^\\dagger \\sigma^I H / \\text{TeV}^2"
-       },
-       "cHWBtil": {
-          "real": true,
-          "tex": "B_{\\mu\\nu} \\widetilde W^{I \\mu\\nu} H^\\dagger \\sigma^I H / \\text{TeV}^2"
-       },
-       "ceHRe11": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 H e_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceHRe22": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 H e_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceHRe33": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 H e_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceHRe12": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 H e_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceHRe13": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 H e_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceHRe21": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 H e_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceHRe23": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 H e_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceHRe31": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 H e_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceHRe32": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 H e_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceHIm11": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 H e_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceHIm22": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 H e_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceHIm33": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3 H e_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceHIm12": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 H e_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceHIm13": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 H e_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceHIm21": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 H e_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceHIm23": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 H e_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceHIm31": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3 H e_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceHIm32": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3 H e_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuHRe11": {
-          "real": true,
-          "tex": "(\\bar q_1 \\tilde H u_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuHRe22": {
-          "real": true,
-          "tex": "(\\bar q_2 \\tilde H u_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuHRe33": {
-          "real": true,
-          "tex": "(\\bar q_3 \\tilde H u_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuHRe12": {
-          "real": true,
-          "tex": "(\\bar q_1 \\tilde H u_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuHRe13": {
-          "real": true,
-          "tex": "(\\bar q_1 \\tilde H u_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuHRe21": {
-          "real": true,
-          "tex": "(\\bar q_2 \\tilde H u_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuHRe23": {
-          "real": true,
-          "tex": "(\\bar q_2 \\tilde H u_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuHRe31": {
-          "real": true,
-          "tex": "(\\bar q_3 \\tilde H u_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuHRe32": {
-          "real": true,
-          "tex": "(\\bar q_3 \\tilde H u_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuHIm11": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\tilde H u_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuHIm22": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\tilde H u_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuHIm33": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\tilde H u_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuHIm12": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\tilde H u_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuHIm13": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\tilde H u_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuHIm21": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\tilde H u_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuHIm23": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\tilde H u_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuHIm31": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\tilde H u_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuHIm32": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\tilde H u_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdHRe11": {
-          "real": true,
-          "tex": "(\\bar q_1 H d_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdHRe22": {
-          "real": true,
-          "tex": "(\\bar q_2 H d_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdHRe33": {
-          "real": true,
-          "tex": "(\\bar q_3 H d_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdHRe12": {
-          "real": true,
-          "tex": "(\\bar q_1 H d_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdHRe13": {
-          "real": true,
-          "tex": "(\\bar q_1 H d_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdHRe21": {
-          "real": true,
-          "tex": "(\\bar q_2 H d_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdHRe23": {
-          "real": true,
-          "tex": "(\\bar q_2 H d_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdHRe31": {
-          "real": true,
-          "tex": "(\\bar q_3 H d_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdHRe32": {
-          "real": true,
-          "tex": "(\\bar q_3 H d_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdHIm11": {
-          "real": true,
-          "tex": "i (\\bar q_1 H d_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdHIm22": {
-          "real": true,
-          "tex": "i (\\bar q_2 H d_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdHIm33": {
-          "real": true,
-          "tex": "i (\\bar q_3 H d_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdHIm12": {
-          "real": true,
-          "tex": "i (\\bar q_1 H d_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdHIm13": {
-          "real": true,
-          "tex": "i (\\bar q_1 H d_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdHIm21": {
-          "real": true,
-          "tex": "i (\\bar q_2 H d_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdHIm23": {
-          "real": true,
-          "tex": "i (\\bar q_2 H d_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdHIm31": {
-          "real": true,
-          "tex": "i (\\bar q_3 H d_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdHIm32": {
-          "real": true,
-          "tex": "i (\\bar q_3 H d_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceWRe11": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\sigma^I H \\sigma^{\\mu\\nu} e_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceWRe22": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\sigma^I H \\sigma^{\\mu\\nu} e_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceWRe33": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\sigma^I H \\sigma^{\\mu\\nu} e_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceWRe12": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\sigma^I H \\sigma^{\\mu\\nu} e_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceWRe13": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\sigma^I H \\sigma^{\\mu\\nu} e_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceWRe21": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\sigma^I H \\sigma^{\\mu\\nu} e_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceWRe23": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\sigma^I H \\sigma^{\\mu\\nu} e_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceWRe31": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\sigma^I H \\sigma^{\\mu\\nu} e_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceWRe32": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\sigma^I H \\sigma^{\\mu\\nu} e_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceWIm11": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\sigma^I H \\sigma^{\\mu\\nu} e_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceWIm22": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\sigma^I H \\sigma^{\\mu\\nu} e_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceWIm33": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3 \\sigma^I H \\sigma^{\\mu\\nu} e_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceWIm12": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\sigma^I H \\sigma^{\\mu\\nu} e_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceWIm13": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\sigma^I H \\sigma^{\\mu\\nu} e_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceWIm21": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\sigma^I H \\sigma^{\\mu\\nu} e_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceWIm23": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\sigma^I H \\sigma^{\\mu\\nu} e_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceWIm31": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3 \\sigma^I H \\sigma^{\\mu\\nu} e_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceWIm32": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3 \\sigma^I H \\sigma^{\\mu\\nu} e_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceBRe11": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 H  \\sigma^{\\mu\\nu} e_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceBRe22": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 H  \\sigma^{\\mu\\nu} e_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceBRe33": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 H  \\sigma^{\\mu\\nu} e_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceBRe12": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 H  \\sigma^{\\mu\\nu} e_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceBRe13": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 H  \\sigma^{\\mu\\nu} e_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceBRe21": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 H  \\sigma^{\\mu\\nu} e_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceBRe23": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 H  \\sigma^{\\mu\\nu} e_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceBRe31": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 H  \\sigma^{\\mu\\nu} e_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceBRe32": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 H  \\sigma^{\\mu\\nu} e_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceBIm11": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 H  \\sigma^{\\mu\\nu} e_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceBIm22": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 H  \\sigma^{\\mu\\nu} e_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceBIm33": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3 H  \\sigma^{\\mu\\nu} e_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceBIm12": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 H  \\sigma^{\\mu\\nu} e_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceBIm13": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 H  \\sigma^{\\mu\\nu} e_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceBIm21": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 H  \\sigma^{\\mu\\nu} e_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceBIm23": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 H  \\sigma^{\\mu\\nu} e_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceBIm31": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3 H  \\sigma^{\\mu\\nu} e_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceBIm32": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3 H  \\sigma^{\\mu\\nu} e_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuGRe11": {
-          "real": true,
-          "tex": "(\\bar q_1 \\tilde H \\sigma^{\\mu\\nu} T^A u_1) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuGRe22": {
-          "real": true,
-          "tex": "(\\bar q_2 \\tilde H \\sigma^{\\mu\\nu} T^A u_2) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuGRe33": {
-          "real": true,
-          "tex": "(\\bar q_3 \\tilde H \\sigma^{\\mu\\nu} T^A u_3) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuGRe12": {
-          "real": true,
-          "tex": "(\\bar q_1 \\tilde H \\sigma^{\\mu\\nu} T^A u_2) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuGRe13": {
-          "real": true,
-          "tex": "(\\bar q_1 \\tilde H \\sigma^{\\mu\\nu} T^A u_3) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuGRe21": {
-          "real": true,
-          "tex": "(\\bar q_2 \\tilde H \\sigma^{\\mu\\nu} T^A u_1) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuGRe23": {
-          "real": true,
-          "tex": "(\\bar q_2 \\tilde H \\sigma^{\\mu\\nu} T^A u_3) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuGRe31": {
-          "real": true,
-          "tex": "(\\bar q_3 \\tilde H \\sigma^{\\mu\\nu} T^A u_1) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuGRe32": {
-          "real": true,
-          "tex": "(\\bar q_3 \\tilde H \\sigma^{\\mu\\nu} T^A u_2) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuGIm11": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\tilde H \\sigma^{\\mu\\nu} T^A u_1) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuGIm22": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\tilde H \\sigma^{\\mu\\nu} T^A u_2) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuGIm33": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\tilde H \\sigma^{\\mu\\nu} T^A u_3) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuGIm12": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\tilde H \\sigma^{\\mu\\nu} T^A u_2) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuGIm13": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\tilde H \\sigma^{\\mu\\nu} T^A u_3) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuGIm21": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\tilde H \\sigma^{\\mu\\nu} T^A u_1) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuGIm23": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\tilde H \\sigma^{\\mu\\nu} T^A u_3) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuGIm31": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\tilde H \\sigma^{\\mu\\nu} T^A u_1) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuGIm32": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\tilde H \\sigma^{\\mu\\nu} T^A u_2) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuWRe11": {
-          "real": true,
-          "tex": "(\\bar q_1 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuWRe22": {
-          "real": true,
-          "tex": "(\\bar q_2 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuWRe33": {
-          "real": true,
-          "tex": "(\\bar q_3 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuWRe12": {
-          "real": true,
-          "tex": "(\\bar q_1 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuWRe13": {
-          "real": true,
-          "tex": "(\\bar q_1 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuWRe21": {
-          "real": true,
-          "tex": "(\\bar q_2 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuWRe23": {
-          "real": true,
-          "tex": "(\\bar q_2 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuWRe31": {
-          "real": true,
-          "tex": "(\\bar q_3 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuWRe32": {
-          "real": true,
-          "tex": "(\\bar q_3 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuWIm11": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuWIm22": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuWIm33": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuWIm12": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuWIm13": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuWIm21": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuWIm23": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuWIm31": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuWIm32": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuBRe11": {
-          "real": true,
-          "tex": "(\\bar q_1 \\tilde H  \\sigma^{\\mu\\nu} u_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuBRe22": {
-          "real": true,
-          "tex": "(\\bar q_2 \\tilde H  \\sigma^{\\mu\\nu} u_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuBRe33": {
-          "real": true,
-          "tex": "(\\bar q_3 \\tilde H  \\sigma^{\\mu\\nu} u_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuBRe12": {
-          "real": true,
-          "tex": "(\\bar q_1 \\tilde H  \\sigma^{\\mu\\nu} u_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuBRe13": {
-          "real": true,
-          "tex": "(\\bar q_1 \\tilde H  \\sigma^{\\mu\\nu} u_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuBRe21": {
-          "real": true,
-          "tex": "(\\bar q_2 \\tilde H  \\sigma^{\\mu\\nu} u_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuBRe23": {
-          "real": true,
-          "tex": "(\\bar q_2 \\tilde H  \\sigma^{\\mu\\nu} u_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuBRe31": {
-          "real": true,
-          "tex": "(\\bar q_3 \\tilde H  \\sigma^{\\mu\\nu} u_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuBRe32": {
-          "real": true,
-          "tex": "(\\bar q_3 \\tilde H  \\sigma^{\\mu\\nu} u_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuBIm11": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\tilde H  \\sigma^{\\mu\\nu} u_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuBIm22": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\tilde H  \\sigma^{\\mu\\nu} u_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuBIm33": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\tilde H  \\sigma^{\\mu\\nu} u_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuBIm12": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\tilde H  \\sigma^{\\mu\\nu} u_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuBIm13": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\tilde H  \\sigma^{\\mu\\nu} u_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuBIm21": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\tilde H  \\sigma^{\\mu\\nu} u_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuBIm23": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\tilde H  \\sigma^{\\mu\\nu} u_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuBIm31": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\tilde H  \\sigma^{\\mu\\nu} u_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuBIm32": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\tilde H  \\sigma^{\\mu\\nu} u_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-	   "cdGRe11": {
-          "real": true,
-          "tex": "(\\bar q_1 H \\sigma^{\\mu\\nu} T^A d_1) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdGRe22": {
-          "real": true,
-          "tex": "(\\bar q_2 H \\sigma^{\\mu\\nu} T^A d_2) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdGRe33": {
-          "real": true,
-          "tex": "(\\bar q_3 H \\sigma^{\\mu\\nu} T^A d_3) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdGRe12": {
-          "real": true,
-          "tex": "(\\bar q_1 H \\sigma^{\\mu\\nu} T^A d_2) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdGRe13": {
-          "real": true,
-          "tex": "(\\bar q_1 H \\sigma^{\\mu\\nu} T^A d_3) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdGRe21": {
-          "real": true,
-          "tex": "(\\bar q_2 H \\sigma^{\\mu\\nu} T^A d_1) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdGRe23": {
-          "real": true,
-          "tex": "(\\bar q_2 H \\sigma^{\\mu\\nu} T^A d_3) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdGRe31": {
-          "real": true,
-          "tex": "(\\bar q_3 H \\sigma^{\\mu\\nu} T^A d_1) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdGRe32": {
-          "real": true,
-          "tex": "(\\bar q_3 H \\sigma^{\\mu\\nu} T^A d_2) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdGIm11": {
-          "real": true,
-          "tex": "i (\\bar q_1 H \\sigma^{\\mu\\nu} T^A d_1) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdGIm22": {
-          "real": true,
-          "tex": "i (\\bar q_2 H \\sigma^{\\mu\\nu} T^A d_2) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdGIm33": {
-          "real": true,
-          "tex": "i (\\bar q_3 H \\sigma^{\\mu\\nu} T^A d_3) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdGIm12": {
-          "real": true,
-          "tex": "i (\\bar q_1 H \\sigma^{\\mu\\nu} T^A d_2) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdGIm13": {
-          "real": true,
-          "tex": "i (\\bar q_1 H \\sigma^{\\mu\\nu} T^A d_3) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdGIm21": {
-          "real": true,
-          "tex": "i (\\bar q_2 H \\sigma^{\\mu\\nu} T^A d_1) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdGIm23": {
-          "real": true,
-          "tex": "i (\\bar q_2 H \\sigma^{\\mu\\nu} T^A d_3) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdGIm31": {
-          "real": true,
-          "tex": "i (\\bar q_3 H \\sigma^{\\mu\\nu} T^A d_1) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdGIm32": {
-          "real": true,
-          "tex": "i (\\bar q_3 H \\sigma^{\\mu\\nu} T^A d_2) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdWRe11": {
-          "real": true,
-          "tex": "(\\bar q_1 \\sigma^I H \\sigma^{\\mu\\nu} d_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdWRe22": {
-          "real": true,
-          "tex": "(\\bar q_2 \\sigma^I H \\sigma^{\\mu\\nu} d_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdWRe33": {
-          "real": true,
-          "tex": "(\\bar q_3 \\sigma^I H \\sigma^{\\mu\\nu} d_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdWRe12": {
-          "real": true,
-          "tex": "(\\bar q_1 \\sigma^I H \\sigma^{\\mu\\nu} d_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdWRe13": {
-          "real": true,
-          "tex": "(\\bar q_1 \\sigma^I H \\sigma^{\\mu\\nu} d_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdWRe21": {
-          "real": true,
-          "tex": "(\\bar q_2 \\sigma^I H \\sigma^{\\mu\\nu} d_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdWRe23": {
-          "real": true,
-          "tex": "(\\bar q_2 \\sigma^I H \\sigma^{\\mu\\nu} d_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdWRe31": {
-          "real": true,
-          "tex": "(\\bar q_3 \\sigma^I H \\sigma^{\\mu\\nu} d_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdWRe32": {
-          "real": true,
-          "tex": "(\\bar q_3 \\sigma^I H \\sigma^{\\mu\\nu} d_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdWIm11": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\sigma^I H \\sigma^{\\mu\\nu} d_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdWIm22": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\sigma^I H \\sigma^{\\mu\\nu} d_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdWIm33": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\sigma^I H \\sigma^{\\mu\\nu} d_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdWIm12": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\sigma^I H \\sigma^{\\mu\\nu} d_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdWIm13": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\sigma^I H \\sigma^{\\mu\\nu} d_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdWIm21": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\sigma^I H \\sigma^{\\mu\\nu} d_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdWIm23": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\sigma^I H \\sigma^{\\mu\\nu} d_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdWIm31": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\sigma^I H \\sigma^{\\mu\\nu} d_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdWIm32": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\sigma^I H \\sigma^{\\mu\\nu} d_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdBRe11": {
-          "real": true,
-          "tex": "(\\bar q_1 H  \\sigma^{\\mu\\nu} d_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdBRe22": {
-          "real": true,
-          "tex": "(\\bar q_2 H  \\sigma^{\\mu\\nu} d_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdBRe33": {
-          "real": true,
-          "tex": "(\\bar q_3 H  \\sigma^{\\mu\\nu} d_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdBRe12": {
-          "real": true,
-          "tex": "(\\bar q_1 H  \\sigma^{\\mu\\nu} d_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdBRe13": {
-          "real": true,
-          "tex": "(\\bar q_1 H  \\sigma^{\\mu\\nu} d_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdBRe21": {
-          "real": true,
-          "tex": "(\\bar q_2 H  \\sigma^{\\mu\\nu} d_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdBRe23": {
-          "real": true,
-          "tex": "(\\bar q_2 H  \\sigma^{\\mu\\nu} d_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdBRe31": {
-          "real": true,
-          "tex": "(\\bar q_3 H  \\sigma^{\\mu\\nu} d_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdBRe32": {
-          "real": true,
-          "tex": "(\\bar q_3 H  \\sigma^{\\mu\\nu} d_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdBIm11": {
-          "real": true,
-          "tex": "i (\\bar q_1 H  \\sigma^{\\mu\\nu} d_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdBIm22": {
-          "real": true,
-          "tex": "i (\\bar q_2 H  \\sigma^{\\mu\\nu} d_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdBIm33": {
-          "real": true,
-          "tex": "i (\\bar q_3 H  \\sigma^{\\mu\\nu} d_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdBIm12": {
-          "real": true,
-          "tex": "i (\\bar q_1 H  \\sigma^{\\mu\\nu} d_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdBIm13": {
-          "real": true,
-          "tex": "i (\\bar q_1 H  \\sigma^{\\mu\\nu} d_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdBIm21": {
-          "real": true,
-          "tex": "i (\\bar q_2 H  \\sigma^{\\mu\\nu} d_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdBIm23": {
-          "real": true,
-          "tex": "i (\\bar q_2 H  \\sigma^{\\mu\\nu} d_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdBIm31": {
-          "real": true,
-          "tex": "i (\\bar q_3 H  \\sigma^{\\mu\\nu} d_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cdBIm32": {
-          "real": true,
-          "tex": "i (\\bar q_3 H  \\sigma^{\\mu\\nu} d_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHl1Re11": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_1 \\gamma^\\mu \\ell_1) / \\text{TeV}^2"
-       },
-       "cHl1Re22": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2"
-       },
-       "cHl1Re33": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2"
-       },
-       "cHl1Re12": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_1 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHl1Re13": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHl1Re23": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHl1Im12": {
-          "real": true,
-          "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_1 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHl1Im13": {
-          "real": true,
-          "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHl1Im23": {
-          "real": true,
-          "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHl3Re11": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_1 \\gamma^\\mu \\sigma^I \\ell_1) / \\text{TeV}^2"
-       },
-       "cHl3Re22": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_2 \\gamma^\\mu \\sigma^I \\ell_2) / \\text{TeV}^2"
-       },
-       "cHl3Re33": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_3 \\gamma^\\mu \\sigma^I \\ell_3) / \\text{TeV}^2"
-       },
-       "cHl3Re12": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_1 \\gamma^\\mu \\sigma^I \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHl3Re13": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_1 \\gamma^\\mu \\sigma^I \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHl3Re23": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_2 \\gamma^\\mu \\sigma^I \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHl3Im12": {
-          "real": true,
-          "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_1 \\gamma^\\mu \\sigma^I \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHl3Im13": {
-          "real": true,
-          "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_1 \\gamma^\\mu \\sigma^I \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHl3Im23": {
-          "real": true,
-          "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_2 \\gamma^\\mu \\sigma^I \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHq1Re11": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2"
-       },
-       "cHq1Re22": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2"
-       },
-       "cHq1Re33": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2"
-       },
-       "cHq1Re12": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHq1Re13": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHq1Re23": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHq1Im12": {
-          "real": true,
-          "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHq1Im13": {
-          "real": true,
-          "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHq1Im23": {
-          "real": true,
-          "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHq3Re11": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2"
-       },
-       "cHq3Re22": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2"
-       },
-       "cHq3Re33": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2"
-       },
-       "cHq3Re12": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHq3Re13": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHq3Re23": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHq3Im12": {
-          "real": true,
-          "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHq3Im13": {
-          "real": true,
-          "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHq3Im23": {
-          "real": true,
-          "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHeRe11": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2"
-       },
-       "cHeRe22": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2"
-       },
-       "cHeRe33": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2"
-       },
-       "cHeRe12": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHeRe13": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHeRe23": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHeIm12": {
-          "real": true,
-          "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHeIm13": {
-          "real": true,
-          "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHeIm23": {
-          "real": true,
-          "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHuRe11": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2"
-       },
-       "cHuRe22": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2"
-       },
-       "cHuRe33": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
-       },
-       "cHuRe12": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHuRe13": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHuRe23": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHuIm12": {
-          "real": true,
-          "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHuIm13": {
-          "real": true,
-          "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHuIm23": {
-          "real": true,
-          "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHdRe11": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
-       },
-       "cHdRe22": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
-       },
-       "cHdRe33": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
-       },
-       "cHdRe12": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHdRe13": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHdRe23": {
-          "real": true,
-          "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHdIm12": {
-          "real": true,
-          "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHdIm13": {
-          "real": true,
-          "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHdIm23": {
-          "real": true,
-          "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHudRe11": {
-          "real": true,
-          "tex": "(\\tilde H^\\dagger i D_\\mu H) (\\bar u_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHudRe22": {
-          "real": true,
-          "tex": "(\\tilde H^\\dagger i D_\\mu H) (\\bar u_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHudRe33": {
-          "real": true,
-          "tex": "(\\tilde H^\\dagger i D_\\mu H) (\\bar u_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHudRe12": {
-          "real": true,
-          "tex": "(\\tilde H^\\dagger i D_\\mu H) (\\bar u_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHudRe13": {
-          "real": true,
-          "tex": "(\\tilde H^\\dagger i D_\\mu H) (\\bar u_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHudRe21": {
-          "real": true,
-          "tex": "(\\tilde H^\\dagger i D_\\mu H) (\\bar u_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHudRe23": {
-          "real": true,
-          "tex": "(\\tilde H^\\dagger i D_\\mu H) (\\bar u_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHudRe31": {
-          "real": true,
-          "tex": "(\\tilde H^\\dagger i D_\\mu H) (\\bar u_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHudRe32": {
-          "real": true,
-          "tex": "(\\tilde H^\\dagger i D_\\mu H) (\\bar u_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHudIm11": {
-          "real": true,
-          "tex": "i (\\tilde H^\\dagger i D_\\mu H) (\\bar u_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHudIm22": {
-          "real": true,
-          "tex": "i (\\tilde H^\\dagger i D_\\mu H) (\\bar u_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHudIm33": {
-          "real": true,
-          "tex": "i (\\tilde H^\\dagger i D_\\mu H) (\\bar u_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHudIm12": {
-          "real": true,
-          "tex": "i (\\tilde H^\\dagger i D_\\mu H) (\\bar u_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHudIm13": {
-          "real": true,
-          "tex": "i (\\tilde H^\\dagger i D_\\mu H) (\\bar u_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHudIm21": {
-          "real": true,
-          "tex": "i (\\tilde H^\\dagger i D_\\mu H) (\\bar u_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHudIm23": {
-          "real": true,
-          "tex": "i (\\tilde H^\\dagger i D_\\mu H) (\\bar u_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHudIm31": {
-          "real": true,
-          "tex": "i (\\tilde H^\\dagger i D_\\mu H) (\\bar u_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cHudIm32": {
-          "real": true,
-          "tex": "i (\\tilde H^\\dagger i D_\\mu H) (\\bar u_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllRe1111": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_1 \\gamma^\\mu \\ell_1) / \\text{TeV}^2"
-       },
-       "cllRe2222": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2"
-       },
-       "cllRe3333": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2"
-       },
-       "cllRe1122": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2"
-       },
-       "cllRe1133": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2"
-       },
-       "cllRe2233": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2"
-       },
-       "cllRe1221": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_1) / \\text{TeV}^2"
-       },
-       "cllRe1331": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_1) / \\text{TeV}^2"
-       },
-       "cllRe2332": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2"
-       },
-       "cllRe1112": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_1 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllRe1113": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllRe1123": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllRe1212": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_1 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllRe1213": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllRe1222": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllRe1232": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllRe1233": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllRe1313": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllRe1322": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllRe1323": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllRe1333": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllRe2223": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllRe2323": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllRe3323": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllRe1231": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllRe1223": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllRe1332": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllIm1112": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_1 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllIm1113": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllIm1123": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllIm1212": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_1 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllIm1213": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllIm1222": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllIm1232": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllIm1233": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllIm1313": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllIm1322": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllIm1323": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllIm1333": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllIm2223": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllIm2323": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllIm3323": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllIm1231": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllIm1223": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cllIm1332": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re1111": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2"
-       },
-       "clq1Re1122": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2"
-       },
-       "clq1Re1133": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2"
-       },
-       "clq1Re2222": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2"
-       },
-       "clq1Re2233": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2"
-       },
-       "clq1Re3333": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2"
-       },
-       "clq1Re1221": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re1331": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re2332": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re2211": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2"
-       },
-       "clq1Re3311": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2"
-       },
-       "clq1Re3322": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2"
-       },
-       "clq1Re1112": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re1113": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re1123": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re1212": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re1213": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re1222": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re1232": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re1233": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re1313": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re1322": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re1323": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re1333": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re2223": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re2323": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re3323": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re1231": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re1223": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re1332": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re1211": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re1311": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re1312": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re1321": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re2212": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re2213": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re2311": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re2312": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re2313": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re2321": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re2322": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re2331": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re2333": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re3312": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Re3313": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im1221": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im1331": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im2332": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im1112": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im1113": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im1123": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im1212": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im1213": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im1222": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im1232": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im1233": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im1313": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im1322": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im1323": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im1333": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im2223": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im2323": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im3323": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im1231": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im1223": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im1332": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im1211": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im1311": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im1312": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im1321": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im2212": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im2213": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im2311": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im2312": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im2313": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im2321": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im2322": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im2331": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im2333": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im3312": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq1Im3313": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re1111": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_1)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2"
-       },
-       "clq3Re1122": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_1)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2"
-       },
-       "clq3Re1133": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_1)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2"
-       },
-       "clq3Re2222": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2"
-       },
-       "clq3Re2233": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2"
-       },
-       "clq3Re3333": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2"
-       },
-       "clq3Re1221": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re1331": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re2332": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re2211": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2"
-       },
-       "clq3Re3311": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2"
-       },
-       "clq3Re3322": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2"
-       },
-       "clq3Re1112": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_1)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re1113": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_1)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re1123": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_1)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re1212": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re1213": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re1222": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re1232": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re1233": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re1313": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re1322": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re1323": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re1333": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re2223": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re2323": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re3323": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re1231": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re1223": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re1332": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re1211": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re1311": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re1312": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re1321": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re2212": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re2213": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re2311": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re2312": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re2313": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re2321": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re2322": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re2331": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re2333": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re3312": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Re3313": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im1221": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im1331": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im2332": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im1112": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_1)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im1113": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_1)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im1123": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_1)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im1212": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im1213": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im1222": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im1232": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im1233": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im1313": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im1322": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im1323": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im1333": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im2223": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im2323": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im3323": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im1231": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im1223": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im1332": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im1211": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im1311": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im1312": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im1321": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im2212": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im2213": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im2311": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im2312": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im2313": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im2321": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im2322": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im2331": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im2333": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im3312": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clq3Im3313": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Re1111": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2"
-       },
-       "cqq1Re2222": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2"
-       },
-       "cqq1Re3333": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2"
-       },
-       "cqq1Re1122": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2"
-       },
-       "cqq1Re1133": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2"
-       },
-       "cqq1Re2233": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2"
-       },
-       "cqq1Re1221": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_1) / \\text{TeV}^2"
-       },
-       "cqq1Re1331": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2"
-       },
-       "cqq1Re2332": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2"
-       },
-       "cqq1Re1112": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Re1113": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Re1123": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Re1212": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Re1213": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Re1222": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Re1232": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Re1233": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Re1313": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Re1322": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Re1323": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Re1333": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Re2223": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Re2323": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Re3323": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Re1231": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Re1223": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Re1332": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Im1112": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Im1113": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Im1123": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Im1212": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Im1213": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Im1222": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Im1232": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Im1233": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Im1313": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Im1322": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Im1323": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Im1333": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Im2223": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Im2323": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Im3323": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\gamma_\\mu q_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Im1231": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Im1223": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq1Im1332": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Re1111": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2"
-       },
-       "cqq3Re2222": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2"
-       },
-       "cqq3Re3333": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu \\sigma^I q_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2"
-       },
-       "cqq3Re1122": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2"
-       },
-       "cqq3Re1133": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2"
-       },
-       "cqq3Re2233": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu \\sigma^I q_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2"
-       },
-       "cqq3Re1221": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2"
-       },
-       "cqq3Re1331": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2"
-       },
-       "cqq3Re2332": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu \\sigma^I q_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2"
-       },
-       "cqq3Re1112": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Re1113": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Re1123": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Re1212": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Re1213": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Re1222": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Re1232": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Re1233": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Re1313": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Re1322": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Re1323": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Re1333": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Re2223": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Re2323": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu \\sigma^I q_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Re3323": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu \\sigma^I q_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Re1231": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Re1223": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Re1332": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Im1112": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Im1113": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Im1123": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Im1212": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Im1213": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Im1222": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Im1232": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Im1233": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Im1313": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Im1322": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Im1323": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Im1333": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Im2223": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Im2323": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu \\sigma^I q_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Im3323": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\gamma_\\mu \\sigma^I q_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Im1231": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Im1223": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqq3Im1332": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeRe1111": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2"
-       },
-       "ceeRe2222": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2"
-       },
-       "ceeRe3333": {
-          "real": true,
-          "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2"
-       },
-       "ceeRe1122": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2"
-       },
-       "ceeRe1133": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2"
-       },
-       "ceeRe2233": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2"
-       },
-       "ceeRe1112": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeRe1113": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeRe1123": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeRe1212": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeRe1213": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeRe1222": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeRe1232": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeRe1233": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeRe1313": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeRe1322": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeRe1323": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeRe1333": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeRe2223": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeRe2323": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeRe3323": {
-          "real": true,
-          "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeIm1112": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeIm1113": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeIm1123": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeIm1212": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeIm1213": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeIm1222": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeIm1232": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeIm1233": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeIm1313": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeIm1322": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeIm1323": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeIm1333": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeIm2223": {
-          "real": true,
-          "tex": "i (\\bar e_2 \\gamma_\\mu e_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeIm2323": {
-          "real": true,
-          "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceeIm3323": {
-          "real": true,
-          "tex": "i (\\bar e_3 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuRe1111": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2"
-       },
-       "cuuRe2222": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2"
-       },
-       "cuuRe3333": {
-          "real": true,
-          "tex": "(\\bar u_3 \\gamma_\\mu u_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
-       },
-       "cuuRe1122": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2"
-       },
-       "cuuRe1133": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
-       },
-       "cuuRe2233": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu u_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
-       },
-       "cuuRe1221": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2"
-       },
-       "cuuRe1331": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2"
-       },
-       "cuuRe2332": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu u_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2"
-       },
-       "cuuRe1112": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuRe1113": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuRe1123": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuRe1212": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuRe1213": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuRe1222": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuRe1232": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuRe1233": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuRe1313": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuRe1322": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuRe1323": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuRe1333": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuRe2223": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuRe2323": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu u_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuRe3323": {
-          "real": true,
-          "tex": "(\\bar u_3 \\gamma_\\mu u_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuRe1231": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuRe1223": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuRe1332": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuIm1112": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_1)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuIm1113": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_1)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuIm1123": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_1)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuIm1212": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuIm1213": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuIm1222": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuIm1232": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuIm1233": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuIm1313": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuIm1322": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuIm1323": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuIm1333": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuIm2223": {
-          "real": true,
-          "tex": "i (\\bar u_2 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuIm2323": {
-          "real": true,
-          "tex": "i (\\bar u_2 \\gamma_\\mu u_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuIm3323": {
-          "real": true,
-          "tex": "i (\\bar u_3 \\gamma_\\mu u_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuIm1231": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuIm1223": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cuuIm1332": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddRe1111": {
-          "real": true,
-          "tex": "(\\bar d_1 \\gamma_\\mu d_1)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
-       },
-       "cddRe2222": {
-          "real": true,
-          "tex": "(\\bar d_2 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
-       },
-       "cddRe3333": {
-          "real": true,
-          "tex": "(\\bar d_3 \\gamma_\\mu d_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
-       },
-       "cddRe1122": {
-          "real": true,
-          "tex": "(\\bar d_1 \\gamma_\\mu d_1)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
-       },
-       "cddRe1133": {
-          "real": true,
-          "tex": "(\\bar d_1 \\gamma_\\mu d_1)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
-       },
-       "cddRe2233": {
-          "real": true,
-          "tex": "(\\bar d_2 \\gamma_\\mu d_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
-       },
-       "cddRe1221": {
-          "real": true,
-          "tex": "(\\bar d_1 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2"
-       },
-       "cddRe1331": {
-          "real": true,
-          "tex": "(\\bar d_1 \\gamma_\\mu d_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2"
-       },
-       "cddRe2332": {
-          "real": true,
-          "tex": "(\\bar d_2 \\gamma_\\mu d_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2"
-       },
-       "cddRe1112": {
-          "real": true,
-          "tex": "(\\bar d_1 \\gamma_\\mu d_1)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddRe1113": {
-          "real": true,
-          "tex": "(\\bar d_1 \\gamma_\\mu d_1)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddRe1123": {
-          "real": true,
-          "tex": "(\\bar d_1 \\gamma_\\mu d_1)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddRe1212": {
-          "real": true,
-          "tex": "(\\bar d_1 \\gamma_\\mu d_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddRe1213": {
-          "real": true,
-          "tex": "(\\bar d_1 \\gamma_\\mu d_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddRe1222": {
-          "real": true,
-          "tex": "(\\bar d_1 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddRe1232": {
-          "real": true,
-          "tex": "(\\bar d_1 \\gamma_\\mu d_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddRe1233": {
-          "real": true,
-          "tex": "(\\bar d_1 \\gamma_\\mu d_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddRe1313": {
-          "real": true,
-          "tex": "(\\bar d_1 \\gamma_\\mu d_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddRe1322": {
-          "real": true,
-          "tex": "(\\bar d_1 \\gamma_\\mu d_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddRe1323": {
-          "real": true,
-          "tex": "(\\bar d_1 \\gamma_\\mu d_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddRe1333": {
-          "real": true,
-          "tex": "(\\bar d_1 \\gamma_\\mu d_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddRe2223": {
-          "real": true,
-          "tex": "(\\bar d_2 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddRe2323": {
-          "real": true,
-          "tex": "(\\bar d_2 \\gamma_\\mu d_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddRe3323": {
-          "real": true,
-          "tex": "(\\bar d_3 \\gamma_\\mu d_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddRe1231": {
-          "real": true,
-          "tex": "(\\bar d_1 \\gamma_\\mu d_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddRe1223": {
-          "real": true,
-          "tex": "(\\bar d_1 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddRe1332": {
-          "real": true,
-          "tex": "(\\bar d_1 \\gamma_\\mu d_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddIm1112": {
-          "real": true,
-          "tex": "i (\\bar d_1 \\gamma_\\mu d_1)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddIm1113": {
-          "real": true,
-          "tex": "i (\\bar d_1 \\gamma_\\mu d_1)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddIm1123": {
-          "real": true,
-          "tex": "i (\\bar d_1 \\gamma_\\mu d_1)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddIm1212": {
-          "real": true,
-          "tex": "i (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddIm1213": {
-          "real": true,
-          "tex": "i (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddIm1222": {
-          "real": true,
-          "tex": "i (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddIm1232": {
-          "real": true,
-          "tex": "i (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddIm1233": {
-          "real": true,
-          "tex": "i (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddIm1313": {
-          "real": true,
-          "tex": "i (\\bar d_1 \\gamma_\\mu d_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddIm1322": {
-          "real": true,
-          "tex": "i (\\bar d_1 \\gamma_\\mu d_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddIm1323": {
-          "real": true,
-          "tex": "i (\\bar d_1 \\gamma_\\mu d_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddIm1333": {
-          "real": true,
-          "tex": "i (\\bar d_1 \\gamma_\\mu d_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddIm2223": {
-          "real": true,
-          "tex": "i (\\bar d_2 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddIm2323": {
-          "real": true,
-          "tex": "i (\\bar d_2 \\gamma_\\mu d_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddIm3323": {
-          "real": true,
-          "tex": "i (\\bar d_3 \\gamma_\\mu d_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddIm1231": {
-          "real": true,
-          "tex": "i (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddIm1223": {
-          "real": true,
-          "tex": "i (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cddIm1332": {
-          "real": true,
-          "tex": "i (\\bar d_1 \\gamma_\\mu d_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe1111": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2"
-       },
-       "ceuRe1122": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2"
-       },
-       "ceuRe1133": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
-       },
-       "ceuRe2222": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2"
-       },
-       "ceuRe2233": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
-       },
-       "ceuRe3333": {
-          "real": true,
-          "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
-       },
-       "ceuRe1221": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe1331": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe2332": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe2211": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2"
-       },
-       "ceuRe3311": {
-          "real": true,
-          "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2"
-       },
-       "ceuRe3322": {
-          "real": true,
-          "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2"
-       },
-       "ceuRe1112": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe1113": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe1123": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe1212": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe1213": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe1222": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe1232": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe1233": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe1313": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe1322": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe1323": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe1333": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe2223": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe2323": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe3323": {
-          "real": true,
-          "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe1231": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe1223": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe1332": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe1211": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe1311": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe1312": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe1321": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe2212": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe2213": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe2311": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe2312": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe2313": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe2321": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe2322": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe2331": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe2333": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe3312": {
-          "real": true,
-          "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuRe3313": {
-          "real": true,
-          "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm1221": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm1331": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm2332": {
-          "real": true,
-          "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm1112": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_1)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm1113": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_1)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm1123": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_1)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm1212": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm1213": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm1222": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm1232": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm1233": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm1313": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm1322": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm1323": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm1333": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm2223": {
-          "real": true,
-          "tex": "i (\\bar e_2 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm2323": {
-          "real": true,
-          "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm3323": {
-          "real": true,
-          "tex": "i (\\bar e_3 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm1231": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm1223": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm1332": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm1211": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm1311": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm1312": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm1321": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm2212": {
-          "real": true,
-          "tex": "i (\\bar e_2 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm2213": {
-          "real": true,
-          "tex": "i (\\bar e_2 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm2311": {
-          "real": true,
-          "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm2312": {
-          "real": true,
-          "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm2313": {
-          "real": true,
-          "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm2321": {
-          "real": true,
-          "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm2322": {
-          "real": true,
-          "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm2331": {
-          "real": true,
-          "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm2333": {
-          "real": true,
-          "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm3312": {
-          "real": true,
-          "tex": "i (\\bar e_3 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "ceuIm3313": {
-          "real": true,
-          "tex": "i (\\bar e_3 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe1111": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
-       },
-       "cedRe1122": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
-       },
-       "cedRe1133": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
-       },
-       "cedRe2222": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
-       },
-       "cedRe2233": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
-       },
-       "cedRe3333": {
-          "real": true,
-          "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
-       },
-       "cedRe1221": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe1331": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe2332": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe2211": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
-       },
-       "cedRe3311": {
-          "real": true,
-          "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
-       },
-       "cedRe3322": {
-          "real": true,
-          "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
-       },
-       "cedRe1112": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe1113": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe1123": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe1212": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe1213": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe1222": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe1232": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe1233": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe1313": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe1322": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe1323": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe1333": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe2223": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe2323": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe3323": {
-          "real": true,
-          "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe1231": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe1223": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe1332": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe1211": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe1311": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe1312": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe1321": {
-          "real": true,
-          "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe2212": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe2213": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe2311": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe2312": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe2313": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe2321": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe2322": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe2331": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe2333": {
-          "real": true,
-          "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe3312": {
-          "real": true,
-          "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedRe3313": {
-          "real": true,
-          "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm1221": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm1331": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm2332": {
-          "real": true,
-          "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm1112": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_1)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm1113": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_1)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm1123": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_1)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm1212": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm1213": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm1222": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm1232": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm1233": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm1313": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm1322": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm1323": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm1333": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm2223": {
-          "real": true,
-          "tex": "i (\\bar e_2 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm2323": {
-          "real": true,
-          "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm3323": {
-          "real": true,
-          "tex": "i (\\bar e_3 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm1231": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm1223": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm1332": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm1211": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm1311": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm1312": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm1321": {
-          "real": true,
-          "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm2212": {
-          "real": true,
-          "tex": "i (\\bar e_2 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm2213": {
-          "real": true,
-          "tex": "i (\\bar e_2 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm2311": {
-          "real": true,
-          "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm2312": {
-          "real": true,
-          "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm2313": {
-          "real": true,
-          "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm2321": {
-          "real": true,
-          "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm2322": {
-          "real": true,
-          "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm2331": {
-          "real": true,
-          "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm2333": {
-          "real": true,
-          "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm3312": {
-          "real": true,
-          "tex": "i (\\bar e_3 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cedIm3313": {
-          "real": true,
-          "tex": "i (\\bar e_3 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re1111": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
-       },
-       "cud1Re1122": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
-       },
-       "cud1Re1133": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
-       },
-       "cud1Re2222": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu u_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
-       },
-       "cud1Re2233": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu u_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
-       },
-       "cud1Re3333": {
-          "real": true,
-          "tex": "(\\bar u_3 \\gamma_\\mu u_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
-       },
-       "cud1Re1221": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re1331": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re2332": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu u_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re2211": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu u_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
-       },
-       "cud1Re3311": {
-          "real": true,
-          "tex": "(\\bar u_3 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
-       },
-       "cud1Re3322": {
-          "real": true,
-          "tex": "(\\bar u_3 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
-       },
-       "cud1Re1112": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re1113": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re1123": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re1212": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re1213": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re1222": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re1232": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re1233": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re1313": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re1322": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re1323": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re1333": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re2223": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu u_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re2323": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re3323": {
-          "real": true,
-          "tex": "(\\bar u_3 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re1231": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re1223": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re1332": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re1211": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re1311": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re1312": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re1321": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re2212": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu u_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re2213": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu u_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re2311": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re2312": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re2313": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re2321": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re2322": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re2331": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu u_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re2333": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu u_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re3312": {
-          "real": true,
-          "tex": "(\\bar u_3 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Re3313": {
-          "real": true,
-          "tex": "(\\bar u_3 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im1221": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im1331": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im2332": {
-          "real": true,
-          "tex": "i (\\bar u_2 \\gamma_\\mu u_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im1112": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_1)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im1113": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_1)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im1123": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_1)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im1212": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im1213": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im1222": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im1232": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im1233": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im1313": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im1322": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im1323": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im1333": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im2223": {
-          "real": true,
-          "tex": "i (\\bar u_2 \\gamma_\\mu u_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im2323": {
-          "real": true,
-          "tex": "i (\\bar u_2 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im3323": {
-          "real": true,
-          "tex": "i (\\bar u_3 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im1231": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im1223": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im1332": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im1211": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im1311": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im1312": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im1321": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im2212": {
-          "real": true,
-          "tex": "i (\\bar u_2 \\gamma_\\mu u_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im2213": {
-          "real": true,
-          "tex": "i (\\bar u_2 \\gamma_\\mu u_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im2311": {
-          "real": true,
-          "tex": "i (\\bar u_2 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im2312": {
-          "real": true,
-          "tex": "i (\\bar u_2 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im2313": {
-          "real": true,
-          "tex": "i (\\bar u_2 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im2321": {
-          "real": true,
-          "tex": "i (\\bar u_2 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im2322": {
-          "real": true,
-          "tex": "i (\\bar u_2 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im2331": {
-          "real": true,
-          "tex": "i (\\bar u_2 \\gamma_\\mu u_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im2333": {
-          "real": true,
-          "tex": "i (\\bar u_2 \\gamma_\\mu u_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im3312": {
-          "real": true,
-          "tex": "i (\\bar u_3 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud1Im3313": {
-          "real": true,
-          "tex": "i (\\bar u_3 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re1111": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu T^A u_1)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2"
-       },
-       "cud8Re1122": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu T^A u_1)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2"
-       },
-       "cud8Re1133": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu T^A u_1)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2"
-       },
-       "cud8Re2222": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu T^A u_2)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2"
-       },
-       "cud8Re2233": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu T^A u_2)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2"
-       },
-       "cud8Re3333": {
-          "real": true,
-          "tex": "(\\bar u_3 \\gamma_\\mu T^A u_3)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2"
-       },
-       "cud8Re1221": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_2 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re1331": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_3 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re2332": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_3 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re2211": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu T^A u_2)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2"
-       },
-       "cud8Re3311": {
-          "real": true,
-          "tex": "(\\bar u_3 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2"
-       },
-       "cud8Re3322": {
-          "real": true,
-          "tex": "(\\bar u_3 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2"
-       },
-       "cud8Re1112": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu T^A u_1)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re1113": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu T^A u_1)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re1123": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu T^A u_1)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re1212": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re1213": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re1222": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re1232": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_3 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re1233": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re1313": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re1322": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re1323": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re1333": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re2223": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu T^A u_2)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re2323": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re3323": {
-          "real": true,
-          "tex": "(\\bar u_3 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re1231": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_3 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re1223": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re1332": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_3 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re1211": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re1311": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re1312": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re1321": {
-          "real": true,
-          "tex": "(\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re2212": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu T^A u_2)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re2213": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu T^A u_2)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re2311": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re2312": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re2313": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re2321": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re2322": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re2331": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_3 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re2333": {
-          "real": true,
-          "tex": "(\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re3312": {
-          "real": true,
-          "tex": "(\\bar u_3 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Re3313": {
-          "real": true,
-          "tex": "(\\bar u_3 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im1221": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_2 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im1331": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_3 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im2332": {
-          "real": true,
-          "tex": "i (\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_3 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im1112": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_1)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im1113": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_1)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im1123": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_1)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im1212": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im1213": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im1222": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im1232": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_3 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im1233": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im1313": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im1322": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im1323": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im1333": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im2223": {
-          "real": true,
-          "tex": "i (\\bar u_2 \\gamma_\\mu T^A u_2)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im2323": {
-          "real": true,
-          "tex": "i (\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im3323": {
-          "real": true,
-          "tex": "i (\\bar u_3 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im1231": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_3 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im1223": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im1332": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_3 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im1211": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im1311": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im1312": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im1321": {
-          "real": true,
-          "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im2212": {
-          "real": true,
-          "tex": "i (\\bar u_2 \\gamma_\\mu T^A u_2)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im2213": {
-          "real": true,
-          "tex": "i (\\bar u_2 \\gamma_\\mu T^A u_2)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im2311": {
-          "real": true,
-          "tex": "i (\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im2312": {
-          "real": true,
-          "tex": "i (\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im2313": {
-          "real": true,
-          "tex": "i (\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im2321": {
-          "real": true,
-          "tex": "i (\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im2322": {
-          "real": true,
-          "tex": "i (\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im2331": {
-          "real": true,
-          "tex": "i (\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_3 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im2333": {
-          "real": true,
-          "tex": "i (\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im3312": {
-          "real": true,
-          "tex": "i (\\bar u_3 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cud8Im3313": {
-          "real": true,
-          "tex": "i (\\bar u_3 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe1111": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2"
-       },
-       "cleRe1122": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2"
-       },
-       "cleRe1133": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2"
-       },
-       "cleRe2222": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2"
-       },
-       "cleRe2233": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2"
-       },
-       "cleRe3333": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2"
-       },
-       "cleRe1221": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe1331": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe2332": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe2211": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2"
-       },
-       "cleRe3311": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2"
-       },
-       "cleRe3322": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2"
-       },
-       "cleRe1112": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe1113": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe1123": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe1212": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe1213": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe1222": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe1232": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe1233": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe1313": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe1322": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe1323": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe1333": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe2223": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe2323": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe3323": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe1231": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe1223": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe1332": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe1211": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe1311": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe1312": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe1321": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe2212": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe2213": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe2311": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe2312": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe2313": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe2321": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe2322": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe2331": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe2333": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe3312": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleRe3313": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm1221": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm1331": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm2332": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm1112": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm1113": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm1123": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm1212": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm1213": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm1222": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm1232": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm1233": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm1313": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm1322": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm1323": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm1333": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm2223": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm2323": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm3323": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm1231": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm1223": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm1332": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm1211": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm1311": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm1312": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm1321": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm2212": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm2213": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm2311": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm2312": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm2313": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm2321": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm2322": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm2331": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm2333": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm3312": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cleIm3313": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe1111": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2"
-       },
-       "cluRe1122": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2"
-       },
-       "cluRe1133": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
-       },
-       "cluRe2222": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2"
-       },
-       "cluRe2233": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
-       },
-       "cluRe3333": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
-       },
-       "cluRe1221": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe1331": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe2332": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe2211": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2"
-       },
-       "cluRe3311": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2"
-       },
-       "cluRe3322": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2"
-       },
-       "cluRe1112": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe1113": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe1123": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe1212": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe1213": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe1222": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe1232": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe1233": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe1313": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe1322": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe1323": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe1333": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe2223": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe2323": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe3323": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe1231": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe1223": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe1332": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe1211": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe1311": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe1312": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe1321": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe2212": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe2213": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe2311": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe2312": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe2313": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe2321": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe2322": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe2331": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe2333": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe3312": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluRe3313": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm1221": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm1331": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm2332": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm1112": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm1113": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm1123": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm1212": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm1213": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm1222": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm1232": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm1233": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm1313": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm1322": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm1323": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm1333": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm2223": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm2323": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm3323": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm1231": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm1223": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm1332": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm1211": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm1311": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm1312": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm1321": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm2212": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm2213": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm2311": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm2312": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm2313": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm2321": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm2322": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm2331": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm2333": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm3312": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cluIm3313": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe1111": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
-       },
-       "cldRe1122": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
-       },
-       "cldRe1133": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
-       },
-       "cldRe2222": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
-       },
-       "cldRe2233": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
-       },
-       "cldRe3333": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
-       },
-       "cldRe1221": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe1331": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe2332": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe2211": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
-       },
-       "cldRe3311": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
-       },
-       "cldRe3322": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
-       },
-       "cldRe1112": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe1113": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe1123": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe1212": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe1213": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe1222": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe1232": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe1233": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe1313": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe1322": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe1323": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe1333": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe2223": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe2323": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe3323": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe1231": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe1223": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe1332": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe1211": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe1311": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe1312": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe1321": {
-          "real": true,
-          "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe2212": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe2213": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe2311": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe2312": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe2313": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe2321": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe2322": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe2331": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe2333": {
-          "real": true,
-          "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe3312": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldRe3313": {
-          "real": true,
-          "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm1221": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm1331": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm2332": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm1112": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm1113": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm1123": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm1212": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm1213": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm1222": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm1232": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm1233": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm1313": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm1322": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm1323": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm1333": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm2223": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm2323": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm3323": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm1231": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm1223": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm1332": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm1211": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm1311": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm1312": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm1321": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm2212": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm2213": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm2311": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm2312": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm2313": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm2321": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm2322": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm2331": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm2333": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm3312": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cldIm3313": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe1111": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2"
-       },
-       "cqeRe1122": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2"
-       },
-       "cqeRe1133": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2"
-       },
-       "cqeRe2222": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2"
-       },
-       "cqeRe2233": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2"
-       },
-       "cqeRe3333": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2"
-       },
-       "cqeRe1221": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe1331": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe2332": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe2211": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2"
-       },
-       "cqeRe3311": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2"
-       },
-       "cqeRe3322": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2"
-       },
-       "cqeRe1112": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe1113": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe1123": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe1212": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe1213": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe1222": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe1232": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe1233": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe1313": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe1322": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe1323": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe1333": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe2223": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe2323": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe3323": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe1231": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe1223": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe1332": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe1211": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe1311": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe1312": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe1321": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe2212": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe2213": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe2311": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe2312": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe2313": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe2321": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe2322": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe2331": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe2333": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe3312": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeRe3313": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm1221": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm1331": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm2332": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm1112": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm1113": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm1123": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm1212": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm1213": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm1222": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm1232": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm1233": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm1313": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm1322": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm1323": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm1333": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm2223": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm2323": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm3323": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm1231": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm1223": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm1332": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm1211": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm1311": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm1312": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm1321": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm2212": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm2213": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm2311": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm2312": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm2313": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm2321": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm2322": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm2331": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm2333": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm3312": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqeIm3313": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re1111": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2"
-       },
-       "cqu1Re1122": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2"
-       },
-       "cqu1Re1133": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
-       },
-       "cqu1Re2222": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2"
-       },
-       "cqu1Re2233": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
-       },
-       "cqu1Re3333": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
-       },
-       "cqu1Re1221": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re1331": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re2332": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re2211": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2"
-       },
-       "cqu1Re3311": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2"
-       },
-       "cqu1Re3322": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2"
-       },
-       "cqu1Re1112": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re1113": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re1123": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re1212": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re1213": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re1222": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re1232": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re1233": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re1313": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re1322": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re1323": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re1333": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re2223": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re2323": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re3323": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re1231": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re1223": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re1332": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re1211": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re1311": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re1312": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re1321": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re2212": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re2213": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re2311": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re2312": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re2313": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re2321": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re2322": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re2331": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re2333": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re3312": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Re3313": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im1221": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im1331": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im2332": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im1112": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im1113": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im1123": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im1212": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im1213": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im1222": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im1232": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im1233": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im1313": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im1322": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im1323": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im1333": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im2223": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im2323": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im3323": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im1231": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im1223": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im1332": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im1211": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im1311": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im1312": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im1321": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im2212": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im2213": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im2311": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im2312": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im2313": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im2321": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im2322": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im2331": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im2333": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im3312": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu1Im3313": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re1111": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar u_1 \\gamma^\\mu T^A u_1) / \\text{TeV}^2"
-       },
-       "cqu8Re1122": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar u_2 \\gamma^\\mu T^A u_2) / \\text{TeV}^2"
-       },
-       "cqu8Re1133": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar u_3 \\gamma^\\mu T^A u_3) / \\text{TeV}^2"
-       },
-       "cqu8Re2222": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar u_2 \\gamma^\\mu T^A u_2) / \\text{TeV}^2"
-       },
-       "cqu8Re2233": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar u_3 \\gamma^\\mu T^A u_3) / \\text{TeV}^2"
-       },
-       "cqu8Re3333": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar u_3 \\gamma^\\mu T^A u_3) / \\text{TeV}^2"
-       },
-       "cqu8Re1221": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_2 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re1331": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_3 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re2332": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_3 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re2211": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar u_1 \\gamma^\\mu T^A u_1) / \\text{TeV}^2"
-       },
-       "cqu8Re3311": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_1) / \\text{TeV}^2"
-       },
-       "cqu8Re3322": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_2) / \\text{TeV}^2"
-       },
-       "cqu8Re1112": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar u_1 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re1113": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar u_1 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re1123": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar u_2 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re1212": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_1 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re1213": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_1 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re1222": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_2 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re1232": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_3 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re1233": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_3 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re1313": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re1322": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re1323": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re1333": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_3 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re2223": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar u_2 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re2323": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re3323": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re1231": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_3 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re1223": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_2 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re1332": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_3 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re1211": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_1 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re1311": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re1312": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re1321": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re2212": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar u_1 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re2213": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar u_1 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re2311": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re2312": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re2313": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re2321": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re2322": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re2331": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_3 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re2333": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_3 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re3312": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Re3313": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im1221": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_2 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im1331": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_3 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im2332": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_3 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im1112": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar u_1 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im1113": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar u_1 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im1123": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar u_2 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im1212": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_1 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im1213": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_1 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im1222": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_2 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im1232": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_3 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im1233": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_3 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im1313": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im1322": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im1323": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im1333": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_3 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im2223": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar u_2 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im2323": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im3323": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im1231": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_3 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im1223": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_2 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im1332": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_3 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im1211": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_1 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im1311": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im1312": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im1321": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im2212": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar u_1 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im2213": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar u_1 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im2311": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im2312": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im2313": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im2321": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im2322": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im2331": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_3 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im2333": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_3 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im3312": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqu8Im3313": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re1111": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
-       },
-       "cqd1Re1122": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
-       },
-       "cqd1Re1133": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
-       },
-       "cqd1Re2222": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
-       },
-       "cqd1Re2233": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
-       },
-       "cqd1Re3333": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
-       },
-       "cqd1Re1221": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re1331": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re2332": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re2211": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
-       },
-       "cqd1Re3311": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
-       },
-       "cqd1Re3322": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
-       },
-       "cqd1Re1112": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re1113": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re1123": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re1212": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re1213": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re1222": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re1232": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re1233": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re1313": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re1322": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re1323": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re1333": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re2223": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re2323": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re3323": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re1231": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re1223": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re1332": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re1211": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re1311": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re1312": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re1321": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re2212": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re2213": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re2311": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re2312": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re2313": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re2321": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re2322": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re2331": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re2333": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re3312": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Re3313": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im1221": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im1331": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im2332": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im1112": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im1113": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im1123": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im1212": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im1213": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im1222": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im1232": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im1233": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im1313": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im1322": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im1323": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im1333": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im2223": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im2323": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im3323": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im1231": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im1223": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im1332": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im1211": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im1311": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im1312": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im1321": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im2212": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im2213": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im2311": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im2312": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im2313": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im2321": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im2322": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im2331": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im2333": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im3312": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd1Im3313": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re1111": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2"
-       },
-       "cqd8Re1122": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2"
-       },
-       "cqd8Re1133": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2"
-       },
-       "cqd8Re2222": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2"
-       },
-       "cqd8Re2233": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2"
-       },
-       "cqd8Re3333": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2"
-       },
-       "cqd8Re1221": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_2 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re1331": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_3 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re2332": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_3 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re2211": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2"
-       },
-       "cqd8Re3311": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2"
-       },
-       "cqd8Re3322": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2"
-       },
-       "cqd8Re1112": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re1113": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re1123": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re1212": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re1213": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re1222": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re1232": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_3 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re1233": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re1313": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re1322": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re1323": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re1333": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re2223": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re2323": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re3323": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re1231": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_3 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re1223": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re1332": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_3 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re1211": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re1311": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re1312": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re1321": {
-          "real": true,
-          "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re2212": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re2213": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re2311": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re2312": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re2313": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re2321": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re2322": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re2331": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_3 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re2333": {
-          "real": true,
-          "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re3312": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Re3313": {
-          "real": true,
-          "tex": "(\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im1221": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_2 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im1331": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_3 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im2332": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_3 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im1112": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im1113": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im1123": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im1212": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im1213": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im1222": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im1232": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_3 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im1233": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im1313": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im1322": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im1323": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im1333": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im2223": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im2323": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im3323": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im1231": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_3 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im1223": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im1332": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_3 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im1211": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im1311": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im1312": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im1321": {
-          "real": true,
-          "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im2212": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im2213": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im2311": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im2312": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im2313": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im2321": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im2322": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im2331": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_3 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im2333": {
-          "real": true,
-          "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im3312": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cqd8Im3313": {
-          "real": true,
-          "tex": "i (\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe1111": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_1)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe1112": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_1)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe1113": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_1)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe1121": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_1)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe1122": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_1)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe1123": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_1)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe1131": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_1)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe1132": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_1)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe1133": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_1)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe1211": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_2)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe1212": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_2)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe1213": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_2)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe1221": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_2)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe1222": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_2)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe1223": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_2)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe1231": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_2)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe1232": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_2)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe1233": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_2)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe1311": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_3)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe1312": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_3)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe1313": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_3)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe1321": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_3)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe1322": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_3)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe1323": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_3)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe1331": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_3)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe1332": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_3)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe1333": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_3)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe2111": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_1)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe2112": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_1)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe2113": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_1)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe2121": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_1)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe2122": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_1)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe2123": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_1)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe2131": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_1)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe2132": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_1)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe2133": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_1)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe2211": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_2)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe2212": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_2)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe2213": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_2)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe2221": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_2)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe2222": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_2)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe2223": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_2)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe2231": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_2)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe2232": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_2)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe2233": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_2)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe2311": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_3)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe2312": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_3)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe2313": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_3)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe2321": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_3)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe2322": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_3)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe2323": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_3)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe2331": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_3)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe2332": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_3)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe2333": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_3)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe3111": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_1)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe3112": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_1)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe3113": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_1)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe3121": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_1)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe3122": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_1)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe3123": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_1)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe3131": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_1)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe3132": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_1)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe3133": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_1)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe3211": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_2)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe3212": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_2)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe3213": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_2)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe3221": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_2)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe3222": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_2)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe3223": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_2)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe3231": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_2)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe3232": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_2)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe3233": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_2)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe3311": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_3)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe3312": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_3)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe3313": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_3)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe3321": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_3)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe3322": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_3)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe3323": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_3)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe3331": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_3)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe3332": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_3)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqRe3333": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_3)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm1111": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_1)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm1112": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_1)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm1113": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_1)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm1121": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_1)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm1122": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_1)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm1123": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_1)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm1131": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_1)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm1132": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_1)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm1133": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_1)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm1211": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm1212": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm1213": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm1221": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm1222": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm1223": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm1231": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm1232": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm1233": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm1311": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm1312": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm1313": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm1321": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm1322": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm1323": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm1331": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm1332": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm1333": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm2111": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm2112": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm2113": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm2121": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm2122": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm2123": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm2131": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm2132": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm2133": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm2211": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_2)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm2212": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_2)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm2213": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_2)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm2221": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_2)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm2222": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_2)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm2223": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_2)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm2231": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_2)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm2232": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_2)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm2233": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_2)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm2311": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm2312": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm2313": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm2321": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm2322": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm2323": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm2331": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm2332": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm2333": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm3111": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm3112": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm3113": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm3121": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm3122": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm3123": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm3131": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm3132": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm3133": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm3211": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm3212": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm3213": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm3221": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm3222": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm3223": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm3231": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm3232": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm3233": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm3311": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_3)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm3312": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_3)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm3313": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_3)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm3321": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_3)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm3322": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_3)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm3323": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_3)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm3331": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_3)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm3332": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_3)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cledqIm3333": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_3)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re1111": {
-          "real": true,
-          "tex": "(\\bar q_1^I u_1)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re1112": {
-          "real": true,
-          "tex": "(\\bar q_1^I u_1)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re1113": {
-          "real": true,
-          "tex": "(\\bar q_1^I u_1)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re1121": {
-          "real": true,
-          "tex": "(\\bar q_1^I u_1)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re1122": {
-          "real": true,
-          "tex": "(\\bar q_1^I u_1)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re1123": {
-          "real": true,
-          "tex": "(\\bar q_1^I u_1)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re1131": {
-          "real": true,
-          "tex": "(\\bar q_1^I u_1)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re1132": {
-          "real": true,
-          "tex": "(\\bar q_1^I u_1)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re1133": {
-          "real": true,
-          "tex": "(\\bar q_1^I u_1)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re1211": {
-          "real": true,
-          "tex": "(\\bar q_1^I u_2)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re1212": {
-          "real": true,
-          "tex": "(\\bar q_1^I u_2)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re1213": {
-          "real": true,
-          "tex": "(\\bar q_1^I u_2)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re1221": {
-          "real": true,
-          "tex": "(\\bar q_1^I u_2)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re1222": {
-          "real": true,
-          "tex": "(\\bar q_1^I u_2)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re1223": {
-          "real": true,
-          "tex": "(\\bar q_1^I u_2)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re1231": {
-          "real": true,
-          "tex": "(\\bar q_1^I u_2)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re1232": {
-          "real": true,
-          "tex": "(\\bar q_1^I u_2)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re1233": {
-          "real": true,
-          "tex": "(\\bar q_1^I u_2)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re1311": {
-          "real": true,
-          "tex": "(\\bar q_1^I u_3)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re1312": {
-          "real": true,
-          "tex": "(\\bar q_1^I u_3)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re1313": {
-          "real": true,
-          "tex": "(\\bar q_1^I u_3)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re1321": {
-          "real": true,
-          "tex": "(\\bar q_1^I u_3)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re1322": {
-          "real": true,
-          "tex": "(\\bar q_1^I u_3)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re1323": {
-          "real": true,
-          "tex": "(\\bar q_1^I u_3)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re1331": {
-          "real": true,
-          "tex": "(\\bar q_1^I u_3)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re1332": {
-          "real": true,
-          "tex": "(\\bar q_1^I u_3)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re1333": {
-          "real": true,
-          "tex": "(\\bar q_1^I u_3)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re2111": {
-          "real": true,
-          "tex": "(\\bar q_2^I u_1)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re2112": {
-          "real": true,
-          "tex": "(\\bar q_2^I u_1)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re2113": {
-          "real": true,
-          "tex": "(\\bar q_2^I u_1)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re2121": {
-          "real": true,
-          "tex": "(\\bar q_2^I u_1)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re2122": {
-          "real": true,
-          "tex": "(\\bar q_2^I u_1)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re2123": {
-          "real": true,
-          "tex": "(\\bar q_2^I u_1)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re2131": {
-          "real": true,
-          "tex": "(\\bar q_2^I u_1)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re2132": {
-          "real": true,
-          "tex": "(\\bar q_2^I u_1)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re2133": {
-          "real": true,
-          "tex": "(\\bar q_2^I u_1)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re2211": {
-          "real": true,
-          "tex": "(\\bar q_2^I u_2)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re2212": {
-          "real": true,
-          "tex": "(\\bar q_2^I u_2)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re2213": {
-          "real": true,
-          "tex": "(\\bar q_2^I u_2)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re2221": {
-          "real": true,
-          "tex": "(\\bar q_2^I u_2)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re2222": {
-          "real": true,
-          "tex": "(\\bar q_2^I u_2)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re2223": {
-          "real": true,
-          "tex": "(\\bar q_2^I u_2)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re2231": {
-          "real": true,
-          "tex": "(\\bar q_2^I u_2)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re2232": {
-          "real": true,
-          "tex": "(\\bar q_2^I u_2)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re2233": {
-          "real": true,
-          "tex": "(\\bar q_2^I u_2)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re2311": {
-          "real": true,
-          "tex": "(\\bar q_2^I u_3)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re2312": {
-          "real": true,
-          "tex": "(\\bar q_2^I u_3)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re2313": {
-          "real": true,
-          "tex": "(\\bar q_2^I u_3)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re2321": {
-          "real": true,
-          "tex": "(\\bar q_2^I u_3)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re2322": {
-          "real": true,
-          "tex": "(\\bar q_2^I u_3)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re2323": {
-          "real": true,
-          "tex": "(\\bar q_2^I u_3)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re2331": {
-          "real": true,
-          "tex": "(\\bar q_2^I u_3)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re2332": {
-          "real": true,
-          "tex": "(\\bar q_2^I u_3)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re2333": {
-          "real": true,
-          "tex": "(\\bar q_2^I u_3)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re3111": {
-          "real": true,
-          "tex": "(\\bar q_3^I u_1)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re3112": {
-          "real": true,
-          "tex": "(\\bar q_3^I u_1)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re3113": {
-          "real": true,
-          "tex": "(\\bar q_3^I u_1)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re3121": {
-          "real": true,
-          "tex": "(\\bar q_3^I u_1)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re3122": {
-          "real": true,
-          "tex": "(\\bar q_3^I u_1)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re3123": {
-          "real": true,
-          "tex": "(\\bar q_3^I u_1)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re3131": {
-          "real": true,
-          "tex": "(\\bar q_3^I u_1)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re3132": {
-          "real": true,
-          "tex": "(\\bar q_3^I u_1)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re3133": {
-          "real": true,
-          "tex": "(\\bar q_3^I u_1)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re3211": {
-          "real": true,
-          "tex": "(\\bar q_3^I u_2)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re3212": {
-          "real": true,
-          "tex": "(\\bar q_3^I u_2)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re3213": {
-          "real": true,
-          "tex": "(\\bar q_3^I u_2)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re3221": {
-          "real": true,
-          "tex": "(\\bar q_3^I u_2)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re3222": {
-          "real": true,
-          "tex": "(\\bar q_3^I u_2)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re3223": {
-          "real": true,
-          "tex": "(\\bar q_3^I u_2)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re3231": {
-          "real": true,
-          "tex": "(\\bar q_3^I u_2)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re3232": {
-          "real": true,
-          "tex": "(\\bar q_3^I u_2)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re3233": {
-          "real": true,
-          "tex": "(\\bar q_3^I u_2)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re3311": {
-          "real": true,
-          "tex": "(\\bar q_3^I u_3)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re3312": {
-          "real": true,
-          "tex": "(\\bar q_3^I u_3)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re3313": {
-          "real": true,
-          "tex": "(\\bar q_3^I u_3)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re3321": {
-          "real": true,
-          "tex": "(\\bar q_3^I u_3)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re3322": {
-          "real": true,
-          "tex": "(\\bar q_3^I u_3)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re3323": {
-          "real": true,
-          "tex": "(\\bar q_3^I u_3)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re3331": {
-          "real": true,
-          "tex": "(\\bar q_3^I u_3)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re3332": {
-          "real": true,
-          "tex": "(\\bar q_3^I u_3)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Re3333": {
-          "real": true,
-          "tex": "(\\bar q_3^I u_3)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im1111": {
-          "real": true,
-          "tex": "i (\\bar q_1^I u_1)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im1112": {
-          "real": true,
-          "tex": "i (\\bar q_1^I u_1)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im1113": {
-          "real": true,
-          "tex": "i (\\bar q_1^I u_1)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im1121": {
-          "real": true,
-          "tex": "i (\\bar q_1^I u_1)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im1122": {
-          "real": true,
-          "tex": "i (\\bar q_1^I u_1)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im1123": {
-          "real": true,
-          "tex": "i (\\bar q_1^I u_1)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im1131": {
-          "real": true,
-          "tex": "i (\\bar q_1^I u_1)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im1132": {
-          "real": true,
-          "tex": "i (\\bar q_1^I u_1)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im1133": {
-          "real": true,
-          "tex": "i (\\bar q_1^I u_1)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im1211": {
-          "real": true,
-          "tex": "i (\\bar q_1^I u_2)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im1212": {
-          "real": true,
-          "tex": "i (\\bar q_1^I u_2)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im1213": {
-          "real": true,
-          "tex": "i (\\bar q_1^I u_2)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im1221": {
-          "real": true,
-          "tex": "i (\\bar q_1^I u_2)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im1222": {
-          "real": true,
-          "tex": "i (\\bar q_1^I u_2)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im1223": {
-          "real": true,
-          "tex": "i (\\bar q_1^I u_2)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im1231": {
-          "real": true,
-          "tex": "i (\\bar q_1^I u_2)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im1232": {
-          "real": true,
-          "tex": "i (\\bar q_1^I u_2)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im1233": {
-          "real": true,
-          "tex": "i (\\bar q_1^I u_2)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im1311": {
-          "real": true,
-          "tex": "i (\\bar q_1^I u_3)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im1312": {
-          "real": true,
-          "tex": "i (\\bar q_1^I u_3)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im1313": {
-          "real": true,
-          "tex": "i (\\bar q_1^I u_3)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im1321": {
-          "real": true,
-          "tex": "i (\\bar q_1^I u_3)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im1322": {
-          "real": true,
-          "tex": "i (\\bar q_1^I u_3)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im1323": {
-          "real": true,
-          "tex": "i (\\bar q_1^I u_3)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im1331": {
-          "real": true,
-          "tex": "i (\\bar q_1^I u_3)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im1332": {
-          "real": true,
-          "tex": "i (\\bar q_1^I u_3)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im1333": {
-          "real": true,
-          "tex": "i (\\bar q_1^I u_3)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im2111": {
-          "real": true,
-          "tex": "i (\\bar q_2^I u_1)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im2112": {
-          "real": true,
-          "tex": "i (\\bar q_2^I u_1)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im2113": {
-          "real": true,
-          "tex": "i (\\bar q_2^I u_1)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im2121": {
-          "real": true,
-          "tex": "i (\\bar q_2^I u_1)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im2122": {
-          "real": true,
-          "tex": "i (\\bar q_2^I u_1)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im2123": {
-          "real": true,
-          "tex": "i (\\bar q_2^I u_1)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im2131": {
-          "real": true,
-          "tex": "i (\\bar q_2^I u_1)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im2132": {
-          "real": true,
-          "tex": "i (\\bar q_2^I u_1)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im2133": {
-          "real": true,
-          "tex": "i (\\bar q_2^I u_1)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im2211": {
-          "real": true,
-          "tex": "i (\\bar q_2^I u_2)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im2212": {
-          "real": true,
-          "tex": "i (\\bar q_2^I u_2)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im2213": {
-          "real": true,
-          "tex": "i (\\bar q_2^I u_2)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im2221": {
-          "real": true,
-          "tex": "i (\\bar q_2^I u_2)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im2222": {
-          "real": true,
-          "tex": "i (\\bar q_2^I u_2)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im2223": {
-          "real": true,
-          "tex": "i (\\bar q_2^I u_2)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im2231": {
-          "real": true,
-          "tex": "i (\\bar q_2^I u_2)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im2232": {
-          "real": true,
-          "tex": "i (\\bar q_2^I u_2)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im2233": {
-          "real": true,
-          "tex": "i (\\bar q_2^I u_2)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im2311": {
-          "real": true,
-          "tex": "i (\\bar q_2^I u_3)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im2312": {
-          "real": true,
-          "tex": "i (\\bar q_2^I u_3)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im2313": {
-          "real": true,
-          "tex": "i (\\bar q_2^I u_3)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im2321": {
-          "real": true,
-          "tex": "i (\\bar q_2^I u_3)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im2322": {
-          "real": true,
-          "tex": "i (\\bar q_2^I u_3)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im2323": {
-          "real": true,
-          "tex": "i (\\bar q_2^I u_3)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im2331": {
-          "real": true,
-          "tex": "i (\\bar q_2^I u_3)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im2332": {
-          "real": true,
-          "tex": "i (\\bar q_2^I u_3)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im2333": {
-          "real": true,
-          "tex": "i (\\bar q_2^I u_3)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im3111": {
-          "real": true,
-          "tex": "i (\\bar q_3^I u_1)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im3112": {
-          "real": true,
-          "tex": "i (\\bar q_3^I u_1)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im3113": {
-          "real": true,
-          "tex": "i (\\bar q_3^I u_1)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im3121": {
-          "real": true,
-          "tex": "i (\\bar q_3^I u_1)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im3122": {
-          "real": true,
-          "tex": "i (\\bar q_3^I u_1)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im3123": {
-          "real": true,
-          "tex": "i (\\bar q_3^I u_1)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im3131": {
-          "real": true,
-          "tex": "i (\\bar q_3^I u_1)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im3132": {
-          "real": true,
-          "tex": "i (\\bar q_3^I u_1)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im3133": {
-          "real": true,
-          "tex": "i (\\bar q_3^I u_1)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im3211": {
-          "real": true,
-          "tex": "i (\\bar q_3^I u_2)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im3212": {
-          "real": true,
-          "tex": "i (\\bar q_3^I u_2)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im3213": {
-          "real": true,
-          "tex": "i (\\bar q_3^I u_2)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im3221": {
-          "real": true,
-          "tex": "i (\\bar q_3^I u_2)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im3222": {
-          "real": true,
-          "tex": "i (\\bar q_3^I u_2)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im3223": {
-          "real": true,
-          "tex": "i (\\bar q_3^I u_2)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im3231": {
-          "real": true,
-          "tex": "i (\\bar q_3^I u_2)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im3232": {
-          "real": true,
-          "tex": "i (\\bar q_3^I u_2)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im3233": {
-          "real": true,
-          "tex": "i (\\bar q_3^I u_2)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im3311": {
-          "real": true,
-          "tex": "i (\\bar q_3^I u_3)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im3312": {
-          "real": true,
-          "tex": "i (\\bar q_3^I u_3)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im3313": {
-          "real": true,
-          "tex": "i (\\bar q_3^I u_3)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im3321": {
-          "real": true,
-          "tex": "i (\\bar q_3^I u_3)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im3322": {
-          "real": true,
-          "tex": "i (\\bar q_3^I u_3)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im3323": {
-          "real": true,
-          "tex": "i (\\bar q_3^I u_3)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im3331": {
-          "real": true,
-          "tex": "i (\\bar q_3^I u_3)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im3332": {
-          "real": true,
-          "tex": "i (\\bar q_3^I u_3)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd1Im3333": {
-          "real": true,
-          "tex": "i (\\bar q_3^I u_3)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re1111": {
-          "real": true,
-          "tex": "(\\bar q_1^I T^A u_1)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re1112": {
-          "real": true,
-          "tex": "(\\bar q_1^I T^A u_1)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re1113": {
-          "real": true,
-          "tex": "(\\bar q_1^I T^A u_1)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re1121": {
-          "real": true,
-          "tex": "(\\bar q_1^I T^A u_1)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re1122": {
-          "real": true,
-          "tex": "(\\bar q_1^I T^A u_1)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re1123": {
-          "real": true,
-          "tex": "(\\bar q_1^I T^A u_1)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re1131": {
-          "real": true,
-          "tex": "(\\bar q_1^I T^A u_1)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re1132": {
-          "real": true,
-          "tex": "(\\bar q_1^I T^A u_1)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re1133": {
-          "real": true,
-          "tex": "(\\bar q_1^I T^A u_1)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re1211": {
-          "real": true,
-          "tex": "(\\bar q_1^I T^A u_2)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re1212": {
-          "real": true,
-          "tex": "(\\bar q_1^I T^A u_2)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re1213": {
-          "real": true,
-          "tex": "(\\bar q_1^I T^A u_2)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re1221": {
-          "real": true,
-          "tex": "(\\bar q_1^I T^A u_2)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re1222": {
-          "real": true,
-          "tex": "(\\bar q_1^I T^A u_2)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re1223": {
-          "real": true,
-          "tex": "(\\bar q_1^I T^A u_2)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re1231": {
-          "real": true,
-          "tex": "(\\bar q_1^I T^A u_2)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re1232": {
-          "real": true,
-          "tex": "(\\bar q_1^I T^A u_2)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re1233": {
-          "real": true,
-          "tex": "(\\bar q_1^I T^A u_2)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re1311": {
-          "real": true,
-          "tex": "(\\bar q_1^I T^A u_3)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re1312": {
-          "real": true,
-          "tex": "(\\bar q_1^I T^A u_3)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re1313": {
-          "real": true,
-          "tex": "(\\bar q_1^I T^A u_3)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re1321": {
-          "real": true,
-          "tex": "(\\bar q_1^I T^A u_3)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re1322": {
-          "real": true,
-          "tex": "(\\bar q_1^I T^A u_3)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re1323": {
-          "real": true,
-          "tex": "(\\bar q_1^I T^A u_3)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re1331": {
-          "real": true,
-          "tex": "(\\bar q_1^I T^A u_3)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re1332": {
-          "real": true,
-          "tex": "(\\bar q_1^I T^A u_3)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re1333": {
-          "real": true,
-          "tex": "(\\bar q_1^I T^A u_3)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re2111": {
-          "real": true,
-          "tex": "(\\bar q_2^I T^A u_1)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re2112": {
-          "real": true,
-          "tex": "(\\bar q_2^I T^A u_1)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re2113": {
-          "real": true,
-          "tex": "(\\bar q_2^I T^A u_1)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re2121": {
-          "real": true,
-          "tex": "(\\bar q_2^I T^A u_1)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re2122": {
-          "real": true,
-          "tex": "(\\bar q_2^I T^A u_1)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re2123": {
-          "real": true,
-          "tex": "(\\bar q_2^I T^A u_1)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re2131": {
-          "real": true,
-          "tex": "(\\bar q_2^I T^A u_1)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re2132": {
-          "real": true,
-          "tex": "(\\bar q_2^I T^A u_1)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re2133": {
-          "real": true,
-          "tex": "(\\bar q_2^I T^A u_1)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re2211": {
-          "real": true,
-          "tex": "(\\bar q_2^I T^A u_2)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re2212": {
-          "real": true,
-          "tex": "(\\bar q_2^I T^A u_2)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re2213": {
-          "real": true,
-          "tex": "(\\bar q_2^I T^A u_2)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re2221": {
-          "real": true,
-          "tex": "(\\bar q_2^I T^A u_2)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re2222": {
-          "real": true,
-          "tex": "(\\bar q_2^I T^A u_2)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re2223": {
-          "real": true,
-          "tex": "(\\bar q_2^I T^A u_2)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re2231": {
-          "real": true,
-          "tex": "(\\bar q_2^I T^A u_2)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re2232": {
-          "real": true,
-          "tex": "(\\bar q_2^I T^A u_2)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re2233": {
-          "real": true,
-          "tex": "(\\bar q_2^I T^A u_2)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re2311": {
-          "real": true,
-          "tex": "(\\bar q_2^I T^A u_3)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re2312": {
-          "real": true,
-          "tex": "(\\bar q_2^I T^A u_3)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re2313": {
-          "real": true,
-          "tex": "(\\bar q_2^I T^A u_3)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re2321": {
-          "real": true,
-          "tex": "(\\bar q_2^I T^A u_3)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re2322": {
-          "real": true,
-          "tex": "(\\bar q_2^I T^A u_3)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re2323": {
-          "real": true,
-          "tex": "(\\bar q_2^I T^A u_3)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re2331": {
-          "real": true,
-          "tex": "(\\bar q_2^I T^A u_3)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re2332": {
-          "real": true,
-          "tex": "(\\bar q_2^I T^A u_3)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re2333": {
-          "real": true,
-          "tex": "(\\bar q_2^I T^A u_3)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re3111": {
-          "real": true,
-          "tex": "(\\bar q_3^I T^A u_1)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re3112": {
-          "real": true,
-          "tex": "(\\bar q_3^I T^A u_1)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re3113": {
-          "real": true,
-          "tex": "(\\bar q_3^I T^A u_1)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re3121": {
-          "real": true,
-          "tex": "(\\bar q_3^I T^A u_1)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re3122": {
-          "real": true,
-          "tex": "(\\bar q_3^I T^A u_1)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re3123": {
-          "real": true,
-          "tex": "(\\bar q_3^I T^A u_1)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re3131": {
-          "real": true,
-          "tex": "(\\bar q_3^I T^A u_1)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re3132": {
-          "real": true,
-          "tex": "(\\bar q_3^I T^A u_1)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re3133": {
-          "real": true,
-          "tex": "(\\bar q_3^I T^A u_1)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re3211": {
-          "real": true,
-          "tex": "(\\bar q_3^I T^A u_2)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re3212": {
-          "real": true,
-          "tex": "(\\bar q_3^I T^A u_2)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re3213": {
-          "real": true,
-          "tex": "(\\bar q_3^I T^A u_2)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re3221": {
-          "real": true,
-          "tex": "(\\bar q_3^I T^A u_2)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re3222": {
-          "real": true,
-          "tex": "(\\bar q_3^I T^A u_2)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re3223": {
-          "real": true,
-          "tex": "(\\bar q_3^I T^A u_2)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re3231": {
-          "real": true,
-          "tex": "(\\bar q_3^I T^A u_2)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re3232": {
-          "real": true,
-          "tex": "(\\bar q_3^I T^A u_2)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re3233": {
-          "real": true,
-          "tex": "(\\bar q_3^I T^A u_2)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re3311": {
-          "real": true,
-          "tex": "(\\bar q_3^I T^A u_3)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re3312": {
-          "real": true,
-          "tex": "(\\bar q_3^I T^A u_3)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re3313": {
-          "real": true,
-          "tex": "(\\bar q_3^I T^A u_3)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re3321": {
-          "real": true,
-          "tex": "(\\bar q_3^I T^A u_3)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re3322": {
-          "real": true,
-          "tex": "(\\bar q_3^I T^A u_3)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re3323": {
-          "real": true,
-          "tex": "(\\bar q_3^I T^A u_3)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re3331": {
-          "real": true,
-          "tex": "(\\bar q_3^I T^A u_3)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re3332": {
-          "real": true,
-          "tex": "(\\bar q_3^I T^A u_3)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Re3333": {
-          "real": true,
-          "tex": "(\\bar q_3^I T^A u_3)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im1111": {
-          "real": true,
-          "tex": "i (\\bar q_1^I T^A u_1)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im1112": {
-          "real": true,
-          "tex": "i (\\bar q_1^I T^A u_1)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im1113": {
-          "real": true,
-          "tex": "i (\\bar q_1^I T^A u_1)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im1121": {
-          "real": true,
-          "tex": "i (\\bar q_1^I T^A u_1)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im1122": {
-          "real": true,
-          "tex": "i (\\bar q_1^I T^A u_1)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im1123": {
-          "real": true,
-          "tex": "i (\\bar q_1^I T^A u_1)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im1131": {
-          "real": true,
-          "tex": "i (\\bar q_1^I T^A u_1)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im1132": {
-          "real": true,
-          "tex": "i (\\bar q_1^I T^A u_1)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im1133": {
-          "real": true,
-          "tex": "i (\\bar q_1^I T^A u_1)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im1211": {
-          "real": true,
-          "tex": "i (\\bar q_1^I T^A u_2)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im1212": {
-          "real": true,
-          "tex": "i (\\bar q_1^I T^A u_2)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im1213": {
-          "real": true,
-          "tex": "i (\\bar q_1^I T^A u_2)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im1221": {
-          "real": true,
-          "tex": "i (\\bar q_1^I T^A u_2)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im1222": {
-          "real": true,
-          "tex": "i (\\bar q_1^I T^A u_2)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im1223": {
-          "real": true,
-          "tex": "i (\\bar q_1^I T^A u_2)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im1231": {
-          "real": true,
-          "tex": "i (\\bar q_1^I T^A u_2)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im1232": {
-          "real": true,
-          "tex": "i (\\bar q_1^I T^A u_2)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im1233": {
-          "real": true,
-          "tex": "i (\\bar q_1^I T^A u_2)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im1311": {
-          "real": true,
-          "tex": "i (\\bar q_1^I T^A u_3)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im1312": {
-          "real": true,
-          "tex": "i (\\bar q_1^I T^A u_3)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im1313": {
-          "real": true,
-          "tex": "i (\\bar q_1^I T^A u_3)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im1321": {
-          "real": true,
-          "tex": "i (\\bar q_1^I T^A u_3)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im1322": {
-          "real": true,
-          "tex": "i (\\bar q_1^I T^A u_3)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im1323": {
-          "real": true,
-          "tex": "i (\\bar q_1^I T^A u_3)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im1331": {
-          "real": true,
-          "tex": "i (\\bar q_1^I T^A u_3)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im1332": {
-          "real": true,
-          "tex": "i (\\bar q_1^I T^A u_3)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im1333": {
-          "real": true,
-          "tex": "i (\\bar q_1^I T^A u_3)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im2111": {
-          "real": true,
-          "tex": "i (\\bar q_2^I T^A u_1)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im2112": {
-          "real": true,
-          "tex": "i (\\bar q_2^I T^A u_1)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im2113": {
-          "real": true,
-          "tex": "i (\\bar q_2^I T^A u_1)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im2121": {
-          "real": true,
-          "tex": "i (\\bar q_2^I T^A u_1)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im2122": {
-          "real": true,
-          "tex": "i (\\bar q_2^I T^A u_1)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im2123": {
-          "real": true,
-          "tex": "i (\\bar q_2^I T^A u_1)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im2131": {
-          "real": true,
-          "tex": "i (\\bar q_2^I T^A u_1)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im2132": {
-          "real": true,
-          "tex": "i (\\bar q_2^I T^A u_1)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im2133": {
-          "real": true,
-          "tex": "i (\\bar q_2^I T^A u_1)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im2211": {
-          "real": true,
-          "tex": "i (\\bar q_2^I T^A u_2)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im2212": {
-          "real": true,
-          "tex": "i (\\bar q_2^I T^A u_2)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im2213": {
-          "real": true,
-          "tex": "i (\\bar q_2^I T^A u_2)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im2221": {
-          "real": true,
-          "tex": "i (\\bar q_2^I T^A u_2)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im2222": {
-          "real": true,
-          "tex": "i (\\bar q_2^I T^A u_2)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im2223": {
-          "real": true,
-          "tex": "i (\\bar q_2^I T^A u_2)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im2231": {
-          "real": true,
-          "tex": "i (\\bar q_2^I T^A u_2)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im2232": {
-          "real": true,
-          "tex": "i (\\bar q_2^I T^A u_2)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im2233": {
-          "real": true,
-          "tex": "i (\\bar q_2^I T^A u_2)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im2311": {
-          "real": true,
-          "tex": "i (\\bar q_2^I T^A u_3)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im2312": {
-          "real": true,
-          "tex": "i (\\bar q_2^I T^A u_3)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im2313": {
-          "real": true,
-          "tex": "i (\\bar q_2^I T^A u_3)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im2321": {
-          "real": true,
-          "tex": "i (\\bar q_2^I T^A u_3)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im2322": {
-          "real": true,
-          "tex": "i (\\bar q_2^I T^A u_3)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im2323": {
-          "real": true,
-          "tex": "i (\\bar q_2^I T^A u_3)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im2331": {
-          "real": true,
-          "tex": "i (\\bar q_2^I T^A u_3)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im2332": {
-          "real": true,
-          "tex": "i (\\bar q_2^I T^A u_3)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im2333": {
-          "real": true,
-          "tex": "i (\\bar q_2^I T^A u_3)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im3111": {
-          "real": true,
-          "tex": "i (\\bar q_3^I T^A u_1)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im3112": {
-          "real": true,
-          "tex": "i (\\bar q_3^I T^A u_1)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im3113": {
-          "real": true,
-          "tex": "i (\\bar q_3^I T^A u_1)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im3121": {
-          "real": true,
-          "tex": "i (\\bar q_3^I T^A u_1)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im3122": {
-          "real": true,
-          "tex": "i (\\bar q_3^I T^A u_1)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im3123": {
-          "real": true,
-          "tex": "i (\\bar q_3^I T^A u_1)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im3131": {
-          "real": true,
-          "tex": "i (\\bar q_3^I T^A u_1)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im3132": {
-          "real": true,
-          "tex": "i (\\bar q_3^I T^A u_1)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im3133": {
-          "real": true,
-          "tex": "i (\\bar q_3^I T^A u_1)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im3211": {
-          "real": true,
-          "tex": "i (\\bar q_3^I T^A u_2)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im3212": {
-          "real": true,
-          "tex": "i (\\bar q_3^I T^A u_2)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im3213": {
-          "real": true,
-          "tex": "i (\\bar q_3^I T^A u_2)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im3221": {
-          "real": true,
-          "tex": "i (\\bar q_3^I T^A u_2)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im3222": {
-          "real": true,
-          "tex": "i (\\bar q_3^I T^A u_2)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im3223": {
-          "real": true,
-          "tex": "i (\\bar q_3^I T^A u_2)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im3231": {
-          "real": true,
-          "tex": "i (\\bar q_3^I T^A u_2)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im3232": {
-          "real": true,
-          "tex": "i (\\bar q_3^I T^A u_2)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im3233": {
-          "real": true,
-          "tex": "i (\\bar q_3^I T^A u_2)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im3311": {
-          "real": true,
-          "tex": "i (\\bar q_3^I T^A u_3)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im3312": {
-          "real": true,
-          "tex": "i (\\bar q_3^I T^A u_3)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im3313": {
-          "real": true,
-          "tex": "i (\\bar q_3^I T^A u_3)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im3321": {
-          "real": true,
-          "tex": "i (\\bar q_3^I T^A u_3)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im3322": {
-          "real": true,
-          "tex": "i (\\bar q_3^I T^A u_3)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im3323": {
-          "real": true,
-          "tex": "i (\\bar q_3^I T^A u_3)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im3331": {
-          "real": true,
-          "tex": "i (\\bar q_3^I T^A u_3)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im3332": {
-          "real": true,
-          "tex": "i (\\bar q_3^I T^A u_3)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "cquqd8Im3333": {
-          "real": true,
-          "tex": "i (\\bar q_3^I T^A u_3)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re1111": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_1)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re1112": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_1)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re1113": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_1)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re1121": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_1)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re1122": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_1)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re1123": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_1)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re1131": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_1)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re1132": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_1)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re1133": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_1)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re1211": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re1212": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re1213": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re1221": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re1222": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re1223": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re1231": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re1232": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re1233": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re1311": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re1312": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re1313": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re1321": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re1322": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re1323": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re1331": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re1332": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re1333": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re2111": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re2112": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re2113": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re2121": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re2122": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re2123": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re2131": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re2132": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re2133": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re2211": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_2)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re2212": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_2)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re2213": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_2)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re2221": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_2)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re2222": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_2)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re2223": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_2)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re2231": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_2)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re2232": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_2)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re2233": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_2)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re2311": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re2312": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re2313": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re2321": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re2322": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re2323": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re2331": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re2332": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re2333": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re3111": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re3112": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re3113": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re3121": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re3122": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re3123": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re3131": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re3132": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re3133": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re3211": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re3212": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re3213": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re3221": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re3222": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re3223": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re3231": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re3232": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re3233": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re3311": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_3)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re3312": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_3)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re3313": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_3)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re3321": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_3)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re3322": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_3)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re3323": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_3)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re3331": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_3)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re3332": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_3)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Re3333": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I e_3)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im1111": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_1)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im1112": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_1)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im1113": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_1)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im1121": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_1)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im1122": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_1)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im1123": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_1)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im1131": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_1)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im1132": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_1)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im1133": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_1)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im1211": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im1212": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im1213": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im1221": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im1222": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im1223": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im1231": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im1232": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im1233": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im1311": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im1312": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im1313": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im1321": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im1322": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im1323": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im1331": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im1332": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im1333": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im2111": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im2112": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im2113": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im2121": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im2122": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im2123": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im2131": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im2132": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im2133": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im2211": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_2)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im2212": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_2)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im2213": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_2)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im2221": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_2)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im2222": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_2)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im2223": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_2)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im2231": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_2)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im2232": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_2)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im2233": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_2)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im2311": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im2312": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im2313": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im2321": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im2322": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im2323": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im2331": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im2332": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im2333": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im3111": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im3112": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im3113": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im3121": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im3122": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im3123": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im3131": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im3132": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im3133": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im3211": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im3212": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im3213": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im3221": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im3222": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im3223": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im3231": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im3232": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im3233": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im3311": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_3)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im3312": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_3)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im3313": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_3)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im3321": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_3)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im3322": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_3)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im3323": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_3)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im3331": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_3)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im3332": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_3)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ1Im3333": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I e_3)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re1111": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re1112": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re1113": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re1121": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re1122": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re1123": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re1131": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re1132": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re1133": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re1211": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re1212": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re1213": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re1221": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re1222": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re1223": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re1231": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re1232": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re1233": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re1311": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re1312": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re1313": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re1321": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re1322": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re1323": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re1331": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re1332": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re1333": {
-          "real": true,
-          "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re2111": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re2112": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re2113": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re2121": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re2122": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re2123": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re2131": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re2132": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re2133": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re2211": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re2212": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re2213": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re2221": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re2222": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re2223": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re2231": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re2232": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re2233": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re2311": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re2312": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re2313": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re2321": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re2322": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re2323": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re2331": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re2332": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re2333": {
-          "real": true,
-          "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re3111": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re3112": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re3113": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re3121": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re3122": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re3123": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re3131": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re3132": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re3133": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re3211": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re3212": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re3213": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re3221": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re3222": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re3223": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re3231": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re3232": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re3233": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re3311": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re3312": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re3313": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re3321": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re3322": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re3323": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re3331": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re3332": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Re3333": {
-          "real": true,
-          "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im1111": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im1112": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im1113": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im1121": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im1122": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im1123": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im1131": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im1132": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im1133": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im1211": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im1212": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im1213": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im1221": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im1222": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im1223": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im1231": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im1232": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im1233": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im1311": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im1312": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im1313": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im1321": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im1322": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im1323": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im1331": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im1332": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im1333": {
-          "real": true,
-          "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im2111": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im2112": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im2113": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im2121": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im2122": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im2123": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im2131": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im2132": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im2133": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im2211": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im2212": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im2213": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im2221": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im2222": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im2223": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im2231": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im2232": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im2233": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im2311": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im2312": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im2313": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im2321": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im2322": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im2323": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im2331": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im2332": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im2333": {
-          "real": true,
-          "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im3111": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im3112": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im3113": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im3121": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im3122": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im3123": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im3131": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im3132": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im3133": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im3211": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im3212": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im3213": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im3221": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im3222": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im3223": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im3231": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im3232": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im3233": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im3311": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im3312": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im3313": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im3321": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im3322": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im3323": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im3331": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im3332": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       },
-       "clequ3Im3333": {
-          "real": true,
-          "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-       }
-     }
+    "dB=dL=0": {
+      "cG": {
+        "real": true,
+        "tex": "f^{ABC} G_\\mu^{A \\nu} G_\\nu^{B \\rho} G_\\rho^{C \\mu} / \\text{TeV}^2"
+      },
+      "cGtil": {
+        "real": true,
+        "tex": "f^{ABC} \\widetilde  G_\\mu^{A \\nu} G_\\nu^{B \\rho} G_\\rho^{C \\mu} / \\text{TeV}^2"
+      },
+      "cW": {
+        "real": true,
+        "tex": "\\varepsilon^{IJK} W_\\mu^{I \\nu} W_\\nu^{J \\rho} W_\\rho^{K \\mu} / \\text{TeV}^2"
+      },
+      "cWtil": {
+        "real": true,
+        "tex": "\\varepsilon^{IJK} \\widetilde W_\\mu^{I \\nu} W_\\nu^{J \\rho} W_\\rho^{K \\mu} / \\text{TeV}^2"
+      },
+      "cH": {
+        "real": true,
+        "tex": "(H^\\dagger H)^3 / \\text{TeV}^2"
+      },
+      "cHbox": {
+        "real": true,
+        "tex": "(H^\\dagger H) \\Box ( H^\\dagger H ) / \\text{TeV}^2"
+      },
+      "cHDD": {
+        "real": true,
+        "tex": "(D_\\mu H^\\dagger H) (H^\\dagger D^\\mu H) / \\text{TeV}^2"
+      },
+      "cHG": {
+        "real": true,
+        "tex": "G_{\\mu\\nu}^A G^{A \\mu\\nu} H^\\dagger H / \\text{TeV}^2"
+      },
+      "cHGtil": {
+        "real": true,
+        "tex": "\\widetilde G_{\\mu\\nu}^A G^{A \\mu\\nu} H^\\dagger H / \\text{TeV}^2"
+      },
+      "cHW": {
+        "real": true,
+        "tex": "W_{\\mu\\nu}^I W^{I \\mu\\nu} H^\\dagger H / \\text{TeV}^2"
+      },
+      "cHWtil": {
+        "real": true,
+        "tex": "\\widetilde W_{\\mu\\nu}^I W^{I \\mu\\nu} H^\\dagger H / \\text{TeV}^2"
+      },
+      "cHB": {
+        "real": true,
+        "tex": "B_{\\mu\\nu} B^{\\mu\\nu} H^\\dagger H / \\text{TeV}^2"
+      },
+      "cHBtil": {
+        "real": true,
+        "tex": "\\widetilde B_{\\mu\\nu} B^{\\mu\\nu} H^\\dagger H / \\text{TeV}^2"
+      },
+      "cHWB": {
+        "real": true,
+        "tex": "B_{\\mu\\nu} W^{I \\mu\\nu} H^\\dagger \\sigma^I H / \\text{TeV}^2"
+      },
+      "cHWBtil": {
+        "real": true,
+        "tex": "B_{\\mu\\nu} \\widetilde W^{I \\mu\\nu} H^\\dagger \\sigma^I H / \\text{TeV}^2"
+      },
+      "ceHRe11": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 H e_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceHRe22": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 H e_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceHRe33": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 H e_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceHRe12": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 H e_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceHRe13": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 H e_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceHRe21": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 H e_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceHRe23": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 H e_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceHRe31": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 H e_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceHRe32": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 H e_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceHIm11": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 H e_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceHIm22": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 H e_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceHIm33": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 H e_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceHIm12": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 H e_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceHIm13": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 H e_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceHIm21": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 H e_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceHIm23": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 H e_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceHIm31": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 H e_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceHIm32": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 H e_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuHRe11": {
+        "real": true,
+        "tex": "(\\bar q_1 \\tilde H u_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuHRe22": {
+        "real": true,
+        "tex": "(\\bar q_2 \\tilde H u_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuHRe33": {
+        "real": true,
+        "tex": "(\\bar q_3 \\tilde H u_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuHRe12": {
+        "real": true,
+        "tex": "(\\bar q_1 \\tilde H u_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuHRe13": {
+        "real": true,
+        "tex": "(\\bar q_1 \\tilde H u_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuHRe21": {
+        "real": true,
+        "tex": "(\\bar q_2 \\tilde H u_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuHRe23": {
+        "real": true,
+        "tex": "(\\bar q_2 \\tilde H u_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuHRe31": {
+        "real": true,
+        "tex": "(\\bar q_3 \\tilde H u_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuHRe32": {
+        "real": true,
+        "tex": "(\\bar q_3 \\tilde H u_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuHIm11": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\tilde H u_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuHIm22": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\tilde H u_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuHIm33": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\tilde H u_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuHIm12": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\tilde H u_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuHIm13": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\tilde H u_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuHIm21": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\tilde H u_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuHIm23": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\tilde H u_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuHIm31": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\tilde H u_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuHIm32": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\tilde H u_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdHRe11": {
+        "real": true,
+        "tex": "(\\bar q_1 H d_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdHRe22": {
+        "real": true,
+        "tex": "(\\bar q_2 H d_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdHRe33": {
+        "real": true,
+        "tex": "(\\bar q_3 H d_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdHRe12": {
+        "real": true,
+        "tex": "(\\bar q_1 H d_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdHRe13": {
+        "real": true,
+        "tex": "(\\bar q_1 H d_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdHRe21": {
+        "real": true,
+        "tex": "(\\bar q_2 H d_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdHRe23": {
+        "real": true,
+        "tex": "(\\bar q_2 H d_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdHRe31": {
+        "real": true,
+        "tex": "(\\bar q_3 H d_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdHRe32": {
+        "real": true,
+        "tex": "(\\bar q_3 H d_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdHIm11": {
+        "real": true,
+        "tex": "i (\\bar q_1 H d_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdHIm22": {
+        "real": true,
+        "tex": "i (\\bar q_2 H d_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdHIm33": {
+        "real": true,
+        "tex": "i (\\bar q_3 H d_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdHIm12": {
+        "real": true,
+        "tex": "i (\\bar q_1 H d_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdHIm13": {
+        "real": true,
+        "tex": "i (\\bar q_1 H d_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdHIm21": {
+        "real": true,
+        "tex": "i (\\bar q_2 H d_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdHIm23": {
+        "real": true,
+        "tex": "i (\\bar q_2 H d_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdHIm31": {
+        "real": true,
+        "tex": "i (\\bar q_3 H d_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdHIm32": {
+        "real": true,
+        "tex": "i (\\bar q_3 H d_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceWRe11": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\sigma^I H \\sigma^{\\mu\\nu} e_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceWRe22": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\sigma^I H \\sigma^{\\mu\\nu} e_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceWRe33": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\sigma^I H \\sigma^{\\mu\\nu} e_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceWRe12": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\sigma^I H \\sigma^{\\mu\\nu} e_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceWRe13": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\sigma^I H \\sigma^{\\mu\\nu} e_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceWRe21": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\sigma^I H \\sigma^{\\mu\\nu} e_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceWRe23": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\sigma^I H \\sigma^{\\mu\\nu} e_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceWRe31": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\sigma^I H \\sigma^{\\mu\\nu} e_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceWRe32": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\sigma^I H \\sigma^{\\mu\\nu} e_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceWIm11": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\sigma^I H \\sigma^{\\mu\\nu} e_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceWIm22": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\sigma^I H \\sigma^{\\mu\\nu} e_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceWIm33": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 \\sigma^I H \\sigma^{\\mu\\nu} e_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceWIm12": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\sigma^I H \\sigma^{\\mu\\nu} e_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceWIm13": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\sigma^I H \\sigma^{\\mu\\nu} e_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceWIm21": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\sigma^I H \\sigma^{\\mu\\nu} e_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceWIm23": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\sigma^I H \\sigma^{\\mu\\nu} e_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceWIm31": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 \\sigma^I H \\sigma^{\\mu\\nu} e_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceWIm32": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 \\sigma^I H \\sigma^{\\mu\\nu} e_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceBRe11": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 H  \\sigma^{\\mu\\nu} e_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceBRe22": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 H  \\sigma^{\\mu\\nu} e_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceBRe33": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 H  \\sigma^{\\mu\\nu} e_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceBRe12": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 H  \\sigma^{\\mu\\nu} e_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceBRe13": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 H  \\sigma^{\\mu\\nu} e_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceBRe21": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 H  \\sigma^{\\mu\\nu} e_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceBRe23": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 H  \\sigma^{\\mu\\nu} e_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceBRe31": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 H  \\sigma^{\\mu\\nu} e_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceBRe32": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 H  \\sigma^{\\mu\\nu} e_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceBIm11": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 H  \\sigma^{\\mu\\nu} e_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceBIm22": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 H  \\sigma^{\\mu\\nu} e_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceBIm33": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 H  \\sigma^{\\mu\\nu} e_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceBIm12": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 H  \\sigma^{\\mu\\nu} e_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceBIm13": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 H  \\sigma^{\\mu\\nu} e_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceBIm21": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 H  \\sigma^{\\mu\\nu} e_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceBIm23": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 H  \\sigma^{\\mu\\nu} e_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceBIm31": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 H  \\sigma^{\\mu\\nu} e_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceBIm32": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 H  \\sigma^{\\mu\\nu} e_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuGRe11": {
+        "real": true,
+        "tex": "(\\bar q_1 \\tilde H \\sigma^{\\mu\\nu} T^A u_1) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuGRe22": {
+        "real": true,
+        "tex": "(\\bar q_2 \\tilde H \\sigma^{\\mu\\nu} T^A u_2) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuGRe33": {
+        "real": true,
+        "tex": "(\\bar q_3 \\tilde H \\sigma^{\\mu\\nu} T^A u_3) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuGRe12": {
+        "real": true,
+        "tex": "(\\bar q_1 \\tilde H \\sigma^{\\mu\\nu} T^A u_2) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuGRe13": {
+        "real": true,
+        "tex": "(\\bar q_1 \\tilde H \\sigma^{\\mu\\nu} T^A u_3) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuGRe21": {
+        "real": true,
+        "tex": "(\\bar q_2 \\tilde H \\sigma^{\\mu\\nu} T^A u_1) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuGRe23": {
+        "real": true,
+        "tex": "(\\bar q_2 \\tilde H \\sigma^{\\mu\\nu} T^A u_3) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuGRe31": {
+        "real": true,
+        "tex": "(\\bar q_3 \\tilde H \\sigma^{\\mu\\nu} T^A u_1) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuGRe32": {
+        "real": true,
+        "tex": "(\\bar q_3 \\tilde H \\sigma^{\\mu\\nu} T^A u_2) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuGIm11": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\tilde H \\sigma^{\\mu\\nu} T^A u_1) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuGIm22": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\tilde H \\sigma^{\\mu\\nu} T^A u_2) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuGIm33": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\tilde H \\sigma^{\\mu\\nu} T^A u_3) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuGIm12": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\tilde H \\sigma^{\\mu\\nu} T^A u_2) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuGIm13": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\tilde H \\sigma^{\\mu\\nu} T^A u_3) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuGIm21": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\tilde H \\sigma^{\\mu\\nu} T^A u_1) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuGIm23": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\tilde H \\sigma^{\\mu\\nu} T^A u_3) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuGIm31": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\tilde H \\sigma^{\\mu\\nu} T^A u_1) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuGIm32": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\tilde H \\sigma^{\\mu\\nu} T^A u_2) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuWRe11": {
+        "real": true,
+        "tex": "(\\bar q_1 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuWRe22": {
+        "real": true,
+        "tex": "(\\bar q_2 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuWRe33": {
+        "real": true,
+        "tex": "(\\bar q_3 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuWRe12": {
+        "real": true,
+        "tex": "(\\bar q_1 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuWRe13": {
+        "real": true,
+        "tex": "(\\bar q_1 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuWRe21": {
+        "real": true,
+        "tex": "(\\bar q_2 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuWRe23": {
+        "real": true,
+        "tex": "(\\bar q_2 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuWRe31": {
+        "real": true,
+        "tex": "(\\bar q_3 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuWRe32": {
+        "real": true,
+        "tex": "(\\bar q_3 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuWIm11": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuWIm22": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuWIm33": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuWIm12": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuWIm13": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuWIm21": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuWIm23": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuWIm31": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuWIm32": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\sigma^I \\tilde H \\sigma^{\\mu\\nu} u_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuBRe11": {
+        "real": true,
+        "tex": "(\\bar q_1 \\tilde H  \\sigma^{\\mu\\nu} u_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuBRe22": {
+        "real": true,
+        "tex": "(\\bar q_2 \\tilde H  \\sigma^{\\mu\\nu} u_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuBRe33": {
+        "real": true,
+        "tex": "(\\bar q_3 \\tilde H  \\sigma^{\\mu\\nu} u_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuBRe12": {
+        "real": true,
+        "tex": "(\\bar q_1 \\tilde H  \\sigma^{\\mu\\nu} u_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuBRe13": {
+        "real": true,
+        "tex": "(\\bar q_1 \\tilde H  \\sigma^{\\mu\\nu} u_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuBRe21": {
+        "real": true,
+        "tex": "(\\bar q_2 \\tilde H  \\sigma^{\\mu\\nu} u_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuBRe23": {
+        "real": true,
+        "tex": "(\\bar q_2 \\tilde H  \\sigma^{\\mu\\nu} u_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuBRe31": {
+        "real": true,
+        "tex": "(\\bar q_3 \\tilde H  \\sigma^{\\mu\\nu} u_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuBRe32": {
+        "real": true,
+        "tex": "(\\bar q_3 \\tilde H  \\sigma^{\\mu\\nu} u_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuBIm11": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\tilde H  \\sigma^{\\mu\\nu} u_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuBIm22": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\tilde H  \\sigma^{\\mu\\nu} u_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuBIm33": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\tilde H  \\sigma^{\\mu\\nu} u_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuBIm12": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\tilde H  \\sigma^{\\mu\\nu} u_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuBIm13": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\tilde H  \\sigma^{\\mu\\nu} u_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuBIm21": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\tilde H  \\sigma^{\\mu\\nu} u_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuBIm23": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\tilde H  \\sigma^{\\mu\\nu} u_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuBIm31": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\tilde H  \\sigma^{\\mu\\nu} u_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuBIm32": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\tilde H  \\sigma^{\\mu\\nu} u_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdGRe11": {
+        "real": true,
+        "tex": "(\\bar q_1 H \\sigma^{\\mu\\nu} T^A d_1) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdGRe22": {
+        "real": true,
+        "tex": "(\\bar q_2 H \\sigma^{\\mu\\nu} T^A d_2) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdGRe33": {
+        "real": true,
+        "tex": "(\\bar q_3 H \\sigma^{\\mu\\nu} T^A d_3) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdGRe12": {
+        "real": true,
+        "tex": "(\\bar q_1 H \\sigma^{\\mu\\nu} T^A d_2) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdGRe13": {
+        "real": true,
+        "tex": "(\\bar q_1 H \\sigma^{\\mu\\nu} T^A d_3) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdGRe21": {
+        "real": true,
+        "tex": "(\\bar q_2 H \\sigma^{\\mu\\nu} T^A d_1) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdGRe23": {
+        "real": true,
+        "tex": "(\\bar q_2 H \\sigma^{\\mu\\nu} T^A d_3) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdGRe31": {
+        "real": true,
+        "tex": "(\\bar q_3 H \\sigma^{\\mu\\nu} T^A d_1) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdGRe32": {
+        "real": true,
+        "tex": "(\\bar q_3 H \\sigma^{\\mu\\nu} T^A d_2) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdGIm11": {
+        "real": true,
+        "tex": "i (\\bar q_1 H \\sigma^{\\mu\\nu} T^A d_1) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdGIm22": {
+        "real": true,
+        "tex": "i (\\bar q_2 H \\sigma^{\\mu\\nu} T^A d_2) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdGIm33": {
+        "real": true,
+        "tex": "i (\\bar q_3 H \\sigma^{\\mu\\nu} T^A d_3) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdGIm12": {
+        "real": true,
+        "tex": "i (\\bar q_1 H \\sigma^{\\mu\\nu} T^A d_2) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdGIm13": {
+        "real": true,
+        "tex": "i (\\bar q_1 H \\sigma^{\\mu\\nu} T^A d_3) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdGIm21": {
+        "real": true,
+        "tex": "i (\\bar q_2 H \\sigma^{\\mu\\nu} T^A d_1) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdGIm23": {
+        "real": true,
+        "tex": "i (\\bar q_2 H \\sigma^{\\mu\\nu} T^A d_3) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdGIm31": {
+        "real": true,
+        "tex": "i (\\bar q_3 H \\sigma^{\\mu\\nu} T^A d_1) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdGIm32": {
+        "real": true,
+        "tex": "i (\\bar q_3 H \\sigma^{\\mu\\nu} T^A d_2) G^A_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdWRe11": {
+        "real": true,
+        "tex": "(\\bar q_1 \\sigma^I H \\sigma^{\\mu\\nu} d_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdWRe22": {
+        "real": true,
+        "tex": "(\\bar q_2 \\sigma^I H \\sigma^{\\mu\\nu} d_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdWRe33": {
+        "real": true,
+        "tex": "(\\bar q_3 \\sigma^I H \\sigma^{\\mu\\nu} d_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdWRe12": {
+        "real": true,
+        "tex": "(\\bar q_1 \\sigma^I H \\sigma^{\\mu\\nu} d_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdWRe13": {
+        "real": true,
+        "tex": "(\\bar q_1 \\sigma^I H \\sigma^{\\mu\\nu} d_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdWRe21": {
+        "real": true,
+        "tex": "(\\bar q_2 \\sigma^I H \\sigma^{\\mu\\nu} d_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdWRe23": {
+        "real": true,
+        "tex": "(\\bar q_2 \\sigma^I H \\sigma^{\\mu\\nu} d_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdWRe31": {
+        "real": true,
+        "tex": "(\\bar q_3 \\sigma^I H \\sigma^{\\mu\\nu} d_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdWRe32": {
+        "real": true,
+        "tex": "(\\bar q_3 \\sigma^I H \\sigma^{\\mu\\nu} d_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdWIm11": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\sigma^I H \\sigma^{\\mu\\nu} d_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdWIm22": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\sigma^I H \\sigma^{\\mu\\nu} d_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdWIm33": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\sigma^I H \\sigma^{\\mu\\nu} d_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdWIm12": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\sigma^I H \\sigma^{\\mu\\nu} d_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdWIm13": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\sigma^I H \\sigma^{\\mu\\nu} d_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdWIm21": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\sigma^I H \\sigma^{\\mu\\nu} d_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdWIm23": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\sigma^I H \\sigma^{\\mu\\nu} d_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdWIm31": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\sigma^I H \\sigma^{\\mu\\nu} d_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdWIm32": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\sigma^I H \\sigma^{\\mu\\nu} d_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdBRe11": {
+        "real": true,
+        "tex": "(\\bar q_1 H  \\sigma^{\\mu\\nu} d_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdBRe22": {
+        "real": true,
+        "tex": "(\\bar q_2 H  \\sigma^{\\mu\\nu} d_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdBRe33": {
+        "real": true,
+        "tex": "(\\bar q_3 H  \\sigma^{\\mu\\nu} d_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdBRe12": {
+        "real": true,
+        "tex": "(\\bar q_1 H  \\sigma^{\\mu\\nu} d_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdBRe13": {
+        "real": true,
+        "tex": "(\\bar q_1 H  \\sigma^{\\mu\\nu} d_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdBRe21": {
+        "real": true,
+        "tex": "(\\bar q_2 H  \\sigma^{\\mu\\nu} d_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdBRe23": {
+        "real": true,
+        "tex": "(\\bar q_2 H  \\sigma^{\\mu\\nu} d_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdBRe31": {
+        "real": true,
+        "tex": "(\\bar q_3 H  \\sigma^{\\mu\\nu} d_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdBRe32": {
+        "real": true,
+        "tex": "(\\bar q_3 H  \\sigma^{\\mu\\nu} d_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdBIm11": {
+        "real": true,
+        "tex": "i (\\bar q_1 H  \\sigma^{\\mu\\nu} d_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdBIm22": {
+        "real": true,
+        "tex": "i (\\bar q_2 H  \\sigma^{\\mu\\nu} d_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdBIm33": {
+        "real": true,
+        "tex": "i (\\bar q_3 H  \\sigma^{\\mu\\nu} d_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdBIm12": {
+        "real": true,
+        "tex": "i (\\bar q_1 H  \\sigma^{\\mu\\nu} d_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdBIm13": {
+        "real": true,
+        "tex": "i (\\bar q_1 H  \\sigma^{\\mu\\nu} d_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdBIm21": {
+        "real": true,
+        "tex": "i (\\bar q_2 H  \\sigma^{\\mu\\nu} d_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdBIm23": {
+        "real": true,
+        "tex": "i (\\bar q_2 H  \\sigma^{\\mu\\nu} d_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdBIm31": {
+        "real": true,
+        "tex": "i (\\bar q_3 H  \\sigma^{\\mu\\nu} d_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cdBIm32": {
+        "real": true,
+        "tex": "i (\\bar q_3 H  \\sigma^{\\mu\\nu} d_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHl1Re11": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_1 \\gamma^\\mu \\ell_1) / \\text{TeV}^2"
+      },
+      "cHl1Re22": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2"
+      },
+      "cHl1Re33": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2"
+      },
+      "cHl1Re12": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_1 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHl1Re13": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHl1Re23": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHl1Im12": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_1 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHl1Im13": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHl1Im23": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHl3Re11": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_1 \\gamma^\\mu \\sigma^I \\ell_1) / \\text{TeV}^2"
+      },
+      "cHl3Re22": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_2 \\gamma^\\mu \\sigma^I \\ell_2) / \\text{TeV}^2"
+      },
+      "cHl3Re33": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_3 \\gamma^\\mu \\sigma^I \\ell_3) / \\text{TeV}^2"
+      },
+      "cHl3Re12": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_1 \\gamma^\\mu \\sigma^I \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHl3Re13": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_1 \\gamma^\\mu \\sigma^I \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHl3Re23": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_2 \\gamma^\\mu \\sigma^I \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHl3Im12": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_1 \\gamma^\\mu \\sigma^I \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHl3Im13": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_1 \\gamma^\\mu \\sigma^I \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHl3Im23": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_2 \\gamma^\\mu \\sigma^I \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHq1Re11": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2"
+      },
+      "cHq1Re22": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2"
+      },
+      "cHq1Re33": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2"
+      },
+      "cHq1Re12": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHq1Re13": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHq1Re23": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHq1Im12": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHq1Im13": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHq1Im23": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHq3Re11": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2"
+      },
+      "cHq3Re22": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2"
+      },
+      "cHq3Re33": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2"
+      },
+      "cHq3Re12": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHq3Re13": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHq3Re23": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHq3Im12": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHq3Im13": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHq3Im23": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHeRe11": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2"
+      },
+      "cHeRe22": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2"
+      },
+      "cHeRe33": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2"
+      },
+      "cHeRe12": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHeRe13": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHeRe23": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHeIm12": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHeIm13": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHeIm23": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHuRe11": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2"
+      },
+      "cHuRe22": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2"
+      },
+      "cHuRe33": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
+      },
+      "cHuRe12": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHuRe13": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHuRe23": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHuIm12": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHuIm13": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHuIm23": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHdRe11": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
+      },
+      "cHdRe22": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
+      },
+      "cHdRe33": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
+      },
+      "cHdRe12": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHdRe13": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHdRe23": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHdIm12": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHdIm13": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHdIm23": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHudRe11": {
+        "real": true,
+        "tex": "(\\tilde H^\\dagger i D_\\mu H) (\\bar u_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHudRe22": {
+        "real": true,
+        "tex": "(\\tilde H^\\dagger i D_\\mu H) (\\bar u_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHudRe33": {
+        "real": true,
+        "tex": "(\\tilde H^\\dagger i D_\\mu H) (\\bar u_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHudRe12": {
+        "real": true,
+        "tex": "(\\tilde H^\\dagger i D_\\mu H) (\\bar u_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHudRe13": {
+        "real": true,
+        "tex": "(\\tilde H^\\dagger i D_\\mu H) (\\bar u_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHudRe21": {
+        "real": true,
+        "tex": "(\\tilde H^\\dagger i D_\\mu H) (\\bar u_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHudRe23": {
+        "real": true,
+        "tex": "(\\tilde H^\\dagger i D_\\mu H) (\\bar u_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHudRe31": {
+        "real": true,
+        "tex": "(\\tilde H^\\dagger i D_\\mu H) (\\bar u_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHudRe32": {
+        "real": true,
+        "tex": "(\\tilde H^\\dagger i D_\\mu H) (\\bar u_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHudIm11": {
+        "real": true,
+        "tex": "i (\\tilde H^\\dagger i D_\\mu H) (\\bar u_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHudIm22": {
+        "real": true,
+        "tex": "i (\\tilde H^\\dagger i D_\\mu H) (\\bar u_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHudIm33": {
+        "real": true,
+        "tex": "i (\\tilde H^\\dagger i D_\\mu H) (\\bar u_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHudIm12": {
+        "real": true,
+        "tex": "i (\\tilde H^\\dagger i D_\\mu H) (\\bar u_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHudIm13": {
+        "real": true,
+        "tex": "i (\\tilde H^\\dagger i D_\\mu H) (\\bar u_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHudIm21": {
+        "real": true,
+        "tex": "i (\\tilde H^\\dagger i D_\\mu H) (\\bar u_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHudIm23": {
+        "real": true,
+        "tex": "i (\\tilde H^\\dagger i D_\\mu H) (\\bar u_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHudIm31": {
+        "real": true,
+        "tex": "i (\\tilde H^\\dagger i D_\\mu H) (\\bar u_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHudIm32": {
+        "real": true,
+        "tex": "i (\\tilde H^\\dagger i D_\\mu H) (\\bar u_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe1111": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_1 \\gamma^\\mu \\ell_1) / \\text{TeV}^2"
+      },
+      "cllRe2222": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2"
+      },
+      "cllRe3333": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2"
+      },
+      "cllRe1122": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2"
+      },
+      "cllRe1133": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2"
+      },
+      "cllRe2233": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2"
+      },
+      "cllRe1221": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_1) / \\text{TeV}^2"
+      },
+      "cllRe1331": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_1) / \\text{TeV}^2"
+      },
+      "cllRe2332": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2"
+      },
+      "cllRe1112": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_1 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe1113": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe1123": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe1212": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_1 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe1213": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe1222": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe1232": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe1233": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe1313": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe1322": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe1323": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe1333": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe2223": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe2323": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe3323": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe1231": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe1223": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe1332": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm1112": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_1 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm1113": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm1123": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm1212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_1 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm1213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm1222": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm1232": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm1233": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm1313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm1322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm1323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm1333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm2223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm2323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm3323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm1231": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm1223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm1332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1111": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2"
+      },
+      "clq1Re1122": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2"
+      },
+      "clq1Re1133": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2"
+      },
+      "clq1Re2222": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2"
+      },
+      "clq1Re2233": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2"
+      },
+      "clq1Re3333": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2"
+      },
+      "clq1Re1221": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1331": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re2332": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re2211": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2"
+      },
+      "clq1Re3311": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2"
+      },
+      "clq1Re3322": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2"
+      },
+      "clq1Re1112": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1113": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1123": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1212": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1213": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1222": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1232": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1233": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1313": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1322": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1323": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1333": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re2223": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re2323": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re3323": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1231": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1223": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1332": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1211": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1311": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1312": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1321": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re2212": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re2213": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re2311": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re2312": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re2313": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re2321": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re2322": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re2331": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re2333": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re3312": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re3313": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1221": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im2332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1112": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1113": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1123": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1222": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1232": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1233": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im2223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im2323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im3323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1231": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1211": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im2212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im2213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im2311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im2312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im2313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im2321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im2322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im2331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im2333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im3312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im3313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1111": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_1)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2"
+      },
+      "clq3Re1122": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_1)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2"
+      },
+      "clq3Re1133": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_1)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2"
+      },
+      "clq3Re2222": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2"
+      },
+      "clq3Re2233": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2"
+      },
+      "clq3Re3333": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2"
+      },
+      "clq3Re1221": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1331": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re2332": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re2211": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2"
+      },
+      "clq3Re3311": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2"
+      },
+      "clq3Re3322": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2"
+      },
+      "clq3Re1112": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_1)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1113": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_1)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1123": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_1)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1212": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1213": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1222": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1232": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1233": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1313": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1322": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1323": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1333": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re2223": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re2323": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re3323": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1231": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1223": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1332": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1211": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1311": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1312": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1321": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re2212": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re2213": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re2311": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re2312": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re2313": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re2321": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re2322": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re2331": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re2333": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re3312": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re3313": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1221": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im2332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1112": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_1)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1113": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_1)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1123": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_1)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1222": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1232": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1233": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im2223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im2323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im3323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1231": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1211": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im2212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im2213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im2311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im2312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im2313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im2321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im2322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im2331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im2333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im3312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im3313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Re1111": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2"
+      },
+      "cqq1Re2222": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2"
+      },
+      "cqq1Re3333": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2"
+      },
+      "cqq1Re1122": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2"
+      },
+      "cqq1Re1133": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2"
+      },
+      "cqq1Re2233": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2"
+      },
+      "cqq1Re1221": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_1) / \\text{TeV}^2"
+      },
+      "cqq1Re1331": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2"
+      },
+      "cqq1Re2332": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2"
+      },
+      "cqq1Re1112": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Re1113": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Re1123": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Re1212": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Re1213": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Re1222": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Re1232": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Re1233": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Re1313": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Re1322": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Re1323": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Re1333": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Re2223": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Re2323": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Re3323": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Re1231": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Re1223": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Re1332": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Im1112": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Im1113": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Im1123": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Im1212": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Im1213": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Im1222": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Im1232": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Im1233": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Im1313": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Im1322": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Im1323": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Im1333": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Im2223": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Im2323": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Im3323": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\gamma_\\mu q_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Im1231": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Im1223": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq1Im1332": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Re1111": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2"
+      },
+      "cqq3Re2222": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2"
+      },
+      "cqq3Re3333": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu \\sigma^I q_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2"
+      },
+      "cqq3Re1122": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2"
+      },
+      "cqq3Re1133": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2"
+      },
+      "cqq3Re2233": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu \\sigma^I q_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2"
+      },
+      "cqq3Re1221": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2"
+      },
+      "cqq3Re1331": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2"
+      },
+      "cqq3Re2332": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu \\sigma^I q_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2"
+      },
+      "cqq3Re1112": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Re1113": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Re1123": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Re1212": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Re1213": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Re1222": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Re1232": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Re1233": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Re1313": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Re1322": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Re1323": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Re1333": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Re2223": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Re2323": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu \\sigma^I q_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Re3323": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu \\sigma^I q_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Re1231": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Re1223": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Re1332": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Im1112": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Im1113": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Im1123": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Im1212": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Im1213": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Im1222": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Im1232": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Im1233": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Im1313": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Im1322": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Im1323": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Im1333": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Im2223": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Im2323": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu \\sigma^I q_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Im3323": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\gamma_\\mu \\sigma^I q_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Im1231": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Im1223": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqq3Im1332": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeRe1111": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2"
+      },
+      "ceeRe2222": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2"
+      },
+      "ceeRe3333": {
+        "real": true,
+        "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2"
+      },
+      "ceeRe1122": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2"
+      },
+      "ceeRe1133": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2"
+      },
+      "ceeRe2233": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2"
+      },
+      "ceeRe1112": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeRe1113": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeRe1123": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeRe1212": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeRe1213": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeRe1222": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeRe1232": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeRe1233": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeRe1313": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeRe1322": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeRe1323": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeRe1333": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeRe2223": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeRe2323": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeRe3323": {
+        "real": true,
+        "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeIm1112": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeIm1113": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeIm1123": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeIm1212": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeIm1213": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeIm1222": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeIm1232": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeIm1233": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeIm1313": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeIm1322": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeIm1323": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeIm1333": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeIm2223": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeIm2323": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeIm3323": {
+        "real": true,
+        "tex": "i (\\bar e_3 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuRe1111": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2"
+      },
+      "cuuRe2222": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2"
+      },
+      "cuuRe3333": {
+        "real": true,
+        "tex": "(\\bar u_3 \\gamma_\\mu u_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
+      },
+      "cuuRe1122": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2"
+      },
+      "cuuRe1133": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
+      },
+      "cuuRe2233": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu u_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
+      },
+      "cuuRe1221": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2"
+      },
+      "cuuRe1331": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2"
+      },
+      "cuuRe2332": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu u_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2"
+      },
+      "cuuRe1112": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuRe1113": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuRe1123": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuRe1212": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuRe1213": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuRe1222": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuRe1232": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuRe1233": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuRe1313": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuRe1322": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuRe1323": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuRe1333": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuRe2223": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuRe2323": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu u_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuRe3323": {
+        "real": true,
+        "tex": "(\\bar u_3 \\gamma_\\mu u_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuRe1231": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuRe1223": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuRe1332": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuIm1112": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_1)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuIm1113": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_1)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuIm1123": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_1)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuIm1212": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuIm1213": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuIm1222": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuIm1232": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuIm1233": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuIm1313": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuIm1322": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuIm1323": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuIm1333": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuIm2223": {
+        "real": true,
+        "tex": "i (\\bar u_2 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuIm2323": {
+        "real": true,
+        "tex": "i (\\bar u_2 \\gamma_\\mu u_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuIm3323": {
+        "real": true,
+        "tex": "i (\\bar u_3 \\gamma_\\mu u_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuIm1231": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuIm1223": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cuuIm1332": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddRe1111": {
+        "real": true,
+        "tex": "(\\bar d_1 \\gamma_\\mu d_1)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
+      },
+      "cddRe2222": {
+        "real": true,
+        "tex": "(\\bar d_2 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
+      },
+      "cddRe3333": {
+        "real": true,
+        "tex": "(\\bar d_3 \\gamma_\\mu d_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
+      },
+      "cddRe1122": {
+        "real": true,
+        "tex": "(\\bar d_1 \\gamma_\\mu d_1)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
+      },
+      "cddRe1133": {
+        "real": true,
+        "tex": "(\\bar d_1 \\gamma_\\mu d_1)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
+      },
+      "cddRe2233": {
+        "real": true,
+        "tex": "(\\bar d_2 \\gamma_\\mu d_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
+      },
+      "cddRe1221": {
+        "real": true,
+        "tex": "(\\bar d_1 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2"
+      },
+      "cddRe1331": {
+        "real": true,
+        "tex": "(\\bar d_1 \\gamma_\\mu d_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2"
+      },
+      "cddRe2332": {
+        "real": true,
+        "tex": "(\\bar d_2 \\gamma_\\mu d_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2"
+      },
+      "cddRe1112": {
+        "real": true,
+        "tex": "(\\bar d_1 \\gamma_\\mu d_1)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddRe1113": {
+        "real": true,
+        "tex": "(\\bar d_1 \\gamma_\\mu d_1)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddRe1123": {
+        "real": true,
+        "tex": "(\\bar d_1 \\gamma_\\mu d_1)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddRe1212": {
+        "real": true,
+        "tex": "(\\bar d_1 \\gamma_\\mu d_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddRe1213": {
+        "real": true,
+        "tex": "(\\bar d_1 \\gamma_\\mu d_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddRe1222": {
+        "real": true,
+        "tex": "(\\bar d_1 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddRe1232": {
+        "real": true,
+        "tex": "(\\bar d_1 \\gamma_\\mu d_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddRe1233": {
+        "real": true,
+        "tex": "(\\bar d_1 \\gamma_\\mu d_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddRe1313": {
+        "real": true,
+        "tex": "(\\bar d_1 \\gamma_\\mu d_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddRe1322": {
+        "real": true,
+        "tex": "(\\bar d_1 \\gamma_\\mu d_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddRe1323": {
+        "real": true,
+        "tex": "(\\bar d_1 \\gamma_\\mu d_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddRe1333": {
+        "real": true,
+        "tex": "(\\bar d_1 \\gamma_\\mu d_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddRe2223": {
+        "real": true,
+        "tex": "(\\bar d_2 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddRe2323": {
+        "real": true,
+        "tex": "(\\bar d_2 \\gamma_\\mu d_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddRe3323": {
+        "real": true,
+        "tex": "(\\bar d_3 \\gamma_\\mu d_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddRe1231": {
+        "real": true,
+        "tex": "(\\bar d_1 \\gamma_\\mu d_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddRe1223": {
+        "real": true,
+        "tex": "(\\bar d_1 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddRe1332": {
+        "real": true,
+        "tex": "(\\bar d_1 \\gamma_\\mu d_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddIm1112": {
+        "real": true,
+        "tex": "i (\\bar d_1 \\gamma_\\mu d_1)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddIm1113": {
+        "real": true,
+        "tex": "i (\\bar d_1 \\gamma_\\mu d_1)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddIm1123": {
+        "real": true,
+        "tex": "i (\\bar d_1 \\gamma_\\mu d_1)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddIm1212": {
+        "real": true,
+        "tex": "i (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddIm1213": {
+        "real": true,
+        "tex": "i (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddIm1222": {
+        "real": true,
+        "tex": "i (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddIm1232": {
+        "real": true,
+        "tex": "i (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddIm1233": {
+        "real": true,
+        "tex": "i (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddIm1313": {
+        "real": true,
+        "tex": "i (\\bar d_1 \\gamma_\\mu d_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddIm1322": {
+        "real": true,
+        "tex": "i (\\bar d_1 \\gamma_\\mu d_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddIm1323": {
+        "real": true,
+        "tex": "i (\\bar d_1 \\gamma_\\mu d_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddIm1333": {
+        "real": true,
+        "tex": "i (\\bar d_1 \\gamma_\\mu d_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddIm2223": {
+        "real": true,
+        "tex": "i (\\bar d_2 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddIm2323": {
+        "real": true,
+        "tex": "i (\\bar d_2 \\gamma_\\mu d_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddIm3323": {
+        "real": true,
+        "tex": "i (\\bar d_3 \\gamma_\\mu d_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddIm1231": {
+        "real": true,
+        "tex": "i (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddIm1223": {
+        "real": true,
+        "tex": "i (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cddIm1332": {
+        "real": true,
+        "tex": "i (\\bar d_1 \\gamma_\\mu d_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1111": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2"
+      },
+      "ceuRe1122": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2"
+      },
+      "ceuRe1133": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
+      },
+      "ceuRe2222": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2"
+      },
+      "ceuRe2233": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
+      },
+      "ceuRe3333": {
+        "real": true,
+        "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
+      },
+      "ceuRe1221": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1331": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe2332": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe2211": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2"
+      },
+      "ceuRe3311": {
+        "real": true,
+        "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2"
+      },
+      "ceuRe3322": {
+        "real": true,
+        "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2"
+      },
+      "ceuRe1112": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1113": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1123": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1212": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1213": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1222": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1232": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1233": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1313": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1322": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1323": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1333": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe2223": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe2323": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe3323": {
+        "real": true,
+        "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1231": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1223": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1332": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1211": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1311": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1312": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1321": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe2212": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe2213": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe2311": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe2312": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe2313": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe2321": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe2322": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe2331": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe2333": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe3312": {
+        "real": true,
+        "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe3313": {
+        "real": true,
+        "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1221": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1331": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm2332": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1112": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_1)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1113": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_1)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1123": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_1)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1212": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1213": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1222": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1232": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1233": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1313": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1322": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1323": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1333": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm2223": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm2323": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm3323": {
+        "real": true,
+        "tex": "i (\\bar e_3 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1231": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1223": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1332": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1211": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1311": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1312": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1321": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm2212": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm2213": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm2311": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm2312": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm2313": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm2321": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm2322": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm2331": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm2333": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm3312": {
+        "real": true,
+        "tex": "i (\\bar e_3 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm3313": {
+        "real": true,
+        "tex": "i (\\bar e_3 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1111": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
+      },
+      "cedRe1122": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
+      },
+      "cedRe1133": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
+      },
+      "cedRe2222": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
+      },
+      "cedRe2233": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
+      },
+      "cedRe3333": {
+        "real": true,
+        "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
+      },
+      "cedRe1221": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1331": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe2332": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe2211": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
+      },
+      "cedRe3311": {
+        "real": true,
+        "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
+      },
+      "cedRe3322": {
+        "real": true,
+        "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
+      },
+      "cedRe1112": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1113": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1123": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1212": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1213": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1222": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1232": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1233": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1313": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1322": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1323": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1333": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe2223": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe2323": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe3323": {
+        "real": true,
+        "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1231": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1223": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1332": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1211": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1311": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1312": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1321": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe2212": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe2213": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe2311": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe2312": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe2313": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe2321": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe2322": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe2331": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe2333": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe3312": {
+        "real": true,
+        "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe3313": {
+        "real": true,
+        "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1221": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1331": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm2332": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1112": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_1)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1113": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_1)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1123": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_1)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1212": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1213": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1222": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1232": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1233": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1313": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1322": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1323": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1333": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm2223": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm2323": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm3323": {
+        "real": true,
+        "tex": "i (\\bar e_3 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1231": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1223": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1332": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1211": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1311": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1312": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1321": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm2212": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm2213": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm2311": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm2312": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm2313": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm2321": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm2322": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm2331": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm2333": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm3312": {
+        "real": true,
+        "tex": "i (\\bar e_3 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm3313": {
+        "real": true,
+        "tex": "i (\\bar e_3 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re1111": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
+      },
+      "cud1Re1122": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
+      },
+      "cud1Re1133": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
+      },
+      "cud1Re2222": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu u_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
+      },
+      "cud1Re2233": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu u_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
+      },
+      "cud1Re3333": {
+        "real": true,
+        "tex": "(\\bar u_3 \\gamma_\\mu u_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
+      },
+      "cud1Re1221": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re1331": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re2332": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu u_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re2211": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu u_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
+      },
+      "cud1Re3311": {
+        "real": true,
+        "tex": "(\\bar u_3 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
+      },
+      "cud1Re3322": {
+        "real": true,
+        "tex": "(\\bar u_3 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
+      },
+      "cud1Re1112": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re1113": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re1123": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re1212": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re1213": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re1222": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re1232": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re1233": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re1313": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re1322": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re1323": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re1333": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re2223": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu u_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re2323": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re3323": {
+        "real": true,
+        "tex": "(\\bar u_3 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re1231": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re1223": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re1332": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re1211": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re1311": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re1312": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re1321": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re2212": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu u_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re2213": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu u_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re2311": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re2312": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re2313": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re2321": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re2322": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re2331": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu u_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re2333": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu u_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re3312": {
+        "real": true,
+        "tex": "(\\bar u_3 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Re3313": {
+        "real": true,
+        "tex": "(\\bar u_3 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im1221": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im1331": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im2332": {
+        "real": true,
+        "tex": "i (\\bar u_2 \\gamma_\\mu u_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im1112": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_1)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im1113": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_1)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im1123": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_1)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im1212": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im1213": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im1222": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im1232": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im1233": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im1313": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im1322": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im1323": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im1333": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im2223": {
+        "real": true,
+        "tex": "i (\\bar u_2 \\gamma_\\mu u_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im2323": {
+        "real": true,
+        "tex": "i (\\bar u_2 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im3323": {
+        "real": true,
+        "tex": "i (\\bar u_3 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im1231": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im1223": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im1332": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im1211": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im1311": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im1312": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im1321": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im2212": {
+        "real": true,
+        "tex": "i (\\bar u_2 \\gamma_\\mu u_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im2213": {
+        "real": true,
+        "tex": "i (\\bar u_2 \\gamma_\\mu u_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im2311": {
+        "real": true,
+        "tex": "i (\\bar u_2 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im2312": {
+        "real": true,
+        "tex": "i (\\bar u_2 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im2313": {
+        "real": true,
+        "tex": "i (\\bar u_2 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im2321": {
+        "real": true,
+        "tex": "i (\\bar u_2 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im2322": {
+        "real": true,
+        "tex": "i (\\bar u_2 \\gamma_\\mu u_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im2331": {
+        "real": true,
+        "tex": "i (\\bar u_2 \\gamma_\\mu u_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im2333": {
+        "real": true,
+        "tex": "i (\\bar u_2 \\gamma_\\mu u_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im3312": {
+        "real": true,
+        "tex": "i (\\bar u_3 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud1Im3313": {
+        "real": true,
+        "tex": "i (\\bar u_3 \\gamma_\\mu u_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re1111": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu T^A u_1)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2"
+      },
+      "cud8Re1122": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu T^A u_1)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2"
+      },
+      "cud8Re1133": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu T^A u_1)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2"
+      },
+      "cud8Re2222": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu T^A u_2)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2"
+      },
+      "cud8Re2233": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu T^A u_2)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2"
+      },
+      "cud8Re3333": {
+        "real": true,
+        "tex": "(\\bar u_3 \\gamma_\\mu T^A u_3)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2"
+      },
+      "cud8Re1221": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_2 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re1331": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_3 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re2332": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_3 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re2211": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu T^A u_2)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2"
+      },
+      "cud8Re3311": {
+        "real": true,
+        "tex": "(\\bar u_3 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2"
+      },
+      "cud8Re3322": {
+        "real": true,
+        "tex": "(\\bar u_3 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2"
+      },
+      "cud8Re1112": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu T^A u_1)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re1113": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu T^A u_1)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re1123": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu T^A u_1)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re1212": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re1213": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re1222": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re1232": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_3 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re1233": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re1313": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re1322": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re1323": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re1333": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re2223": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu T^A u_2)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re2323": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re3323": {
+        "real": true,
+        "tex": "(\\bar u_3 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re1231": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_3 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re1223": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re1332": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_3 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re1211": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re1311": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re1312": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re1321": {
+        "real": true,
+        "tex": "(\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re2212": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu T^A u_2)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re2213": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu T^A u_2)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re2311": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re2312": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re2313": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re2321": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re2322": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re2331": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_3 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re2333": {
+        "real": true,
+        "tex": "(\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re3312": {
+        "real": true,
+        "tex": "(\\bar u_3 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Re3313": {
+        "real": true,
+        "tex": "(\\bar u_3 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im1221": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_2 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im1331": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_3 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im2332": {
+        "real": true,
+        "tex": "i (\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_3 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im1112": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_1)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im1113": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_1)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im1123": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_1)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im1212": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im1213": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im1222": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im1232": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_3 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im1233": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im1313": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im1322": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im1323": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im1333": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im2223": {
+        "real": true,
+        "tex": "i (\\bar u_2 \\gamma_\\mu T^A u_2)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im2323": {
+        "real": true,
+        "tex": "i (\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im3323": {
+        "real": true,
+        "tex": "i (\\bar u_3 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im1231": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_3 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im1223": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im1332": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_3 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im1211": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_2)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im1311": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im1312": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im1321": {
+        "real": true,
+        "tex": "i (\\bar u_1 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im2212": {
+        "real": true,
+        "tex": "i (\\bar u_2 \\gamma_\\mu T^A u_2)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im2213": {
+        "real": true,
+        "tex": "i (\\bar u_2 \\gamma_\\mu T^A u_2)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im2311": {
+        "real": true,
+        "tex": "i (\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im2312": {
+        "real": true,
+        "tex": "i (\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im2313": {
+        "real": true,
+        "tex": "i (\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im2321": {
+        "real": true,
+        "tex": "i (\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im2322": {
+        "real": true,
+        "tex": "i (\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im2331": {
+        "real": true,
+        "tex": "i (\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_3 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im2333": {
+        "real": true,
+        "tex": "i (\\bar u_2 \\gamma_\\mu T^A u_3)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im3312": {
+        "real": true,
+        "tex": "i (\\bar u_3 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cud8Im3313": {
+        "real": true,
+        "tex": "i (\\bar u_3 \\gamma_\\mu T^A u_3)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1111": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2"
+      },
+      "cleRe1122": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2"
+      },
+      "cleRe1133": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2"
+      },
+      "cleRe2222": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2"
+      },
+      "cleRe2233": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2"
+      },
+      "cleRe3333": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2"
+      },
+      "cleRe1221": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1331": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe2332": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe2211": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2"
+      },
+      "cleRe3311": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2"
+      },
+      "cleRe3322": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2"
+      },
+      "cleRe1112": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1113": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1123": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1212": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1213": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1222": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1232": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1233": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1313": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1322": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1323": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1333": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe2223": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe2323": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe3323": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1231": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1223": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1332": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1211": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1311": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1312": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1321": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe2212": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe2213": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe2311": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe2312": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe2313": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe2321": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe2322": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe2331": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe2333": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe3312": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe3313": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1221": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm2332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1112": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1113": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1123": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1222": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1232": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1233": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm2223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm2323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm3323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1231": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1211": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm2212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm2213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm2311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm2312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm2313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm2321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm2322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm2331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm2333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm3312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm3313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1111": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2"
+      },
+      "cluRe1122": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2"
+      },
+      "cluRe1133": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
+      },
+      "cluRe2222": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2"
+      },
+      "cluRe2233": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
+      },
+      "cluRe3333": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
+      },
+      "cluRe1221": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1331": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe2332": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe2211": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2"
+      },
+      "cluRe3311": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2"
+      },
+      "cluRe3322": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2"
+      },
+      "cluRe1112": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1113": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1123": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1212": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1213": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1222": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1232": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1233": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1313": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1322": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1323": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1333": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe2223": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe2323": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe3323": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1231": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1223": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1332": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1211": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1311": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1312": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1321": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe2212": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe2213": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe2311": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe2312": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe2313": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe2321": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe2322": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe2331": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe2333": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe3312": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe3313": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1221": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm2332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1112": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1113": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1123": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1222": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1232": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1233": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm2223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm2323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm3323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1231": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1211": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm2212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm2213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm2311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm2312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm2313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm2321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm2322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm2331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm2333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm3312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm3313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1111": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
+      },
+      "cldRe1122": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
+      },
+      "cldRe1133": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
+      },
+      "cldRe2222": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
+      },
+      "cldRe2233": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
+      },
+      "cldRe3333": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
+      },
+      "cldRe1221": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1331": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe2332": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe2211": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
+      },
+      "cldRe3311": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
+      },
+      "cldRe3322": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
+      },
+      "cldRe1112": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1113": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1123": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1212": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1213": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1222": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1232": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1233": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1313": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1322": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1323": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1333": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe2223": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe2323": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe3323": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1231": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1223": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1332": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1211": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1311": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1312": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1321": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe2212": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe2213": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe2311": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe2312": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe2313": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe2321": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe2322": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe2331": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe2333": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe3312": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe3313": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1221": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm2332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1112": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1113": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1123": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1222": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1232": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1233": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm2223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm2323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm3323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1231": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1211": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm2212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm2213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm2311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm2312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm2313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm2321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm2322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm2331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm2333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm3312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm3313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1111": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2"
+      },
+      "cqeRe1122": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2"
+      },
+      "cqeRe1133": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2"
+      },
+      "cqeRe2222": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2"
+      },
+      "cqeRe2233": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2"
+      },
+      "cqeRe3333": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2"
+      },
+      "cqeRe1221": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1331": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe2332": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe2211": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2"
+      },
+      "cqeRe3311": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2"
+      },
+      "cqeRe3322": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2"
+      },
+      "cqeRe1112": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1113": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1123": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1212": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1213": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1222": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1232": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1233": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1313": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1322": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1323": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1333": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe2223": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe2323": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe3323": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1231": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1223": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1332": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1211": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1311": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1312": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1321": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe2212": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe2213": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe2311": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe2312": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe2313": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe2321": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe2322": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe2331": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe2333": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe3312": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe3313": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1221": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1331": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm2332": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1112": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1113": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1123": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1212": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1213": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1222": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1232": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1233": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1313": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1322": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1323": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1333": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm2223": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm2323": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm3323": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1231": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1223": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1332": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1211": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1311": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1312": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1321": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm2212": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm2213": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm2311": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm2312": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm2313": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm2321": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm2322": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm2331": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm2333": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm3312": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm3313": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re1111": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2"
+      },
+      "cqu1Re1122": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2"
+      },
+      "cqu1Re1133": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
+      },
+      "cqu1Re2222": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2"
+      },
+      "cqu1Re2233": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
+      },
+      "cqu1Re3333": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
+      },
+      "cqu1Re1221": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re1331": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re2332": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re2211": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2"
+      },
+      "cqu1Re3311": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2"
+      },
+      "cqu1Re3322": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2"
+      },
+      "cqu1Re1112": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re1113": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re1123": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re1212": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re1213": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re1222": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re1232": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re1233": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re1313": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re1322": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re1323": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re1333": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re2223": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re2323": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re3323": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re1231": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re1223": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re1332": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re1211": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re1311": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re1312": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re1321": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re2212": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re2213": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re2311": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re2312": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re2313": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re2321": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re2322": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re2331": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re2333": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re3312": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Re3313": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im1221": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im1331": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im2332": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im1112": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im1113": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im1123": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im1212": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im1213": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im1222": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im1232": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im1233": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im1313": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im1322": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im1323": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im1333": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im2223": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im2323": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im3323": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im1231": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im1223": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im1332": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im1211": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im1311": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im1312": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im1321": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im2212": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im2213": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im2311": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im2312": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im2313": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im2321": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im2322": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im2331": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im2333": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im3312": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu1Im3313": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\gamma_\\mu q_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re1111": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar u_1 \\gamma^\\mu T^A u_1) / \\text{TeV}^2"
+      },
+      "cqu8Re1122": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar u_2 \\gamma^\\mu T^A u_2) / \\text{TeV}^2"
+      },
+      "cqu8Re1133": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar u_3 \\gamma^\\mu T^A u_3) / \\text{TeV}^2"
+      },
+      "cqu8Re2222": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar u_2 \\gamma^\\mu T^A u_2) / \\text{TeV}^2"
+      },
+      "cqu8Re2233": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar u_3 \\gamma^\\mu T^A u_3) / \\text{TeV}^2"
+      },
+      "cqu8Re3333": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar u_3 \\gamma^\\mu T^A u_3) / \\text{TeV}^2"
+      },
+      "cqu8Re1221": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_2 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re1331": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_3 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re2332": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_3 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re2211": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar u_1 \\gamma^\\mu T^A u_1) / \\text{TeV}^2"
+      },
+      "cqu8Re3311": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_1) / \\text{TeV}^2"
+      },
+      "cqu8Re3322": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_2) / \\text{TeV}^2"
+      },
+      "cqu8Re1112": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar u_1 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re1113": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar u_1 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re1123": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar u_2 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re1212": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_1 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re1213": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_1 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re1222": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_2 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re1232": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_3 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re1233": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_3 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re1313": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re1322": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re1323": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re1333": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_3 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re2223": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar u_2 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re2323": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re3323": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re1231": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_3 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re1223": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_2 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re1332": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_3 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re1211": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_1 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re1311": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re1312": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re1321": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re2212": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar u_1 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re2213": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar u_1 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re2311": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re2312": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re2313": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re2321": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re2322": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re2331": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_3 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re2333": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_3 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re3312": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Re3313": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im1221": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_2 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im1331": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_3 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im2332": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_3 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im1112": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar u_1 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im1113": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar u_1 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im1123": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar u_2 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im1212": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_1 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im1213": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_1 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im1222": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_2 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im1232": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_3 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im1233": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_3 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im1313": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im1322": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im1323": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im1333": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_3 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im2223": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar u_2 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im2323": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im3323": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im1231": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_3 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im1223": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_2 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im1332": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_3 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im1211": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar u_1 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im1311": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im1312": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im1321": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im2212": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar u_1 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im2213": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar u_1 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im2311": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im2312": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im2313": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im2321": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im2322": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_2 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im2331": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_3 \\gamma^\\mu T^A u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im2333": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar u_3 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im3312": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqu8Im3313": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar u_1 \\gamma^\\mu T^A u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re1111": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
+      },
+      "cqd1Re1122": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
+      },
+      "cqd1Re1133": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
+      },
+      "cqd1Re2222": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
+      },
+      "cqd1Re2233": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
+      },
+      "cqd1Re3333": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
+      },
+      "cqd1Re1221": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re1331": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re2332": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re2211": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
+      },
+      "cqd1Re3311": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
+      },
+      "cqd1Re3322": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
+      },
+      "cqd1Re1112": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re1113": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re1123": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re1212": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re1213": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re1222": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re1232": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re1233": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re1313": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re1322": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re1323": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re1333": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re2223": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re2323": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re3323": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re1231": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re1223": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re1332": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re1211": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re1311": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re1312": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re1321": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re2212": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re2213": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re2311": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re2312": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re2313": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re2321": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re2322": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re2331": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re2333": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re3312": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Re3313": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im1221": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im1331": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im2332": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im1112": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im1113": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im1123": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im1212": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im1213": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im1222": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im1232": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im1233": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im1313": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im1322": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im1323": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im1333": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im2223": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im2323": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im3323": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im1231": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im1223": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im1332": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im1211": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im1311": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im1312": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im1321": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im2212": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im2213": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im2311": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im2312": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im2313": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im2321": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im2322": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im2331": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im2333": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im3312": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd1Im3313": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\gamma_\\mu q_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re1111": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2"
+      },
+      "cqd8Re1122": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2"
+      },
+      "cqd8Re1133": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2"
+      },
+      "cqd8Re2222": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2"
+      },
+      "cqd8Re2233": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2"
+      },
+      "cqd8Re3333": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2"
+      },
+      "cqd8Re1221": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_2 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re1331": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_3 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re2332": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_3 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re2211": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2"
+      },
+      "cqd8Re3311": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2"
+      },
+      "cqd8Re3322": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2"
+      },
+      "cqd8Re1112": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re1113": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re1123": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re1212": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re1213": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re1222": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re1232": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_3 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re1233": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re1313": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re1322": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re1323": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re1333": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re2223": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re2323": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re3323": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re1231": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_3 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re1223": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re1332": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_3 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re1211": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re1311": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re1312": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re1321": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re2212": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re2213": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re2311": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re2312": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re2313": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re2321": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re2322": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re2331": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_3 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re2333": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re3312": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Re3313": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im1221": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_2 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im1331": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_3 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im2332": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_3 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im1112": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im1113": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im1123": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_1)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im1212": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im1213": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im1222": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im1232": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_3 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im1233": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im1313": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im1322": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im1323": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im1333": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im2223": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im2323": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im3323": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im1231": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_3 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im1223": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_2 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im1332": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_3 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im1211": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_2)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im1311": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im1312": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im1321": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im2212": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im2213": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_2)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im2311": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im2312": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im2313": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im2321": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im2322": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_2 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im2331": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_3 \\gamma^\\mu T^A d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im2333": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu T^A q_3)(\\bar d_3 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im3312": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqd8Im3313": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\gamma_\\mu T^A q_3)(\\bar d_1 \\gamma^\\mu T^A d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1111": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_1)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1112": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_1)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1113": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_1)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1121": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_1)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1122": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_1)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1123": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_1)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1131": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_1)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1132": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_1)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1133": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_1)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1211": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1212": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1213": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1221": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1222": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1223": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1231": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1232": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1233": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1311": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1312": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1313": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1321": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1322": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1323": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1331": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1332": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1333": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2111": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2112": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2113": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2121": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2122": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2123": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2131": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2132": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2133": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2211": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_2)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2212": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_2)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2213": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_2)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2221": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_2)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2222": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_2)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2223": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_2)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2231": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_2)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2232": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_2)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2233": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_2)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2311": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2312": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2313": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2321": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2322": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2323": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2331": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2332": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2333": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3111": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3112": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3113": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3121": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3122": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3123": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3131": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3132": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3133": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3211": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3212": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3213": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3221": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3222": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3223": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3231": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3232": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3233": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3311": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_3)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3312": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_3)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3313": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_3)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3321": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_3)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3322": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_3)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3323": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_3)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3331": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_3)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3332": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_3)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3333": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_3)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1111": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_1)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1112": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_1)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1113": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_1)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1121": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_1)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1122": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_1)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1123": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_1)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1131": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_1)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1132": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_1)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1133": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_1)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1211": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1221": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1222": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1231": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1232": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1233": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2111": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2112": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2113": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2121": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2122": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2123": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2131": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2132": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2133": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2211": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_2)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_2)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_2)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2221": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_2)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2222": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_2)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_2)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2231": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_2)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2232": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_2)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2233": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_2)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3111": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3112": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3113": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3121": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3122": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3123": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3131": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3132": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3133": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3211": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3221": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3222": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3231": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3232": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3233": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_3)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_3)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_3)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_3)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_3)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_3)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_3)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_3)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_3)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re1111": {
+        "real": true,
+        "tex": "(\\bar q_1^I u_1)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re1112": {
+        "real": true,
+        "tex": "(\\bar q_1^I u_1)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re1113": {
+        "real": true,
+        "tex": "(\\bar q_1^I u_1)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re1121": {
+        "real": true,
+        "tex": "(\\bar q_1^I u_1)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re1122": {
+        "real": true,
+        "tex": "(\\bar q_1^I u_1)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re1123": {
+        "real": true,
+        "tex": "(\\bar q_1^I u_1)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re1131": {
+        "real": true,
+        "tex": "(\\bar q_1^I u_1)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re1132": {
+        "real": true,
+        "tex": "(\\bar q_1^I u_1)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re1133": {
+        "real": true,
+        "tex": "(\\bar q_1^I u_1)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re1211": {
+        "real": true,
+        "tex": "(\\bar q_1^I u_2)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re1212": {
+        "real": true,
+        "tex": "(\\bar q_1^I u_2)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re1213": {
+        "real": true,
+        "tex": "(\\bar q_1^I u_2)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re1221": {
+        "real": true,
+        "tex": "(\\bar q_1^I u_2)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re1222": {
+        "real": true,
+        "tex": "(\\bar q_1^I u_2)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re1223": {
+        "real": true,
+        "tex": "(\\bar q_1^I u_2)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re1231": {
+        "real": true,
+        "tex": "(\\bar q_1^I u_2)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re1232": {
+        "real": true,
+        "tex": "(\\bar q_1^I u_2)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re1233": {
+        "real": true,
+        "tex": "(\\bar q_1^I u_2)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re1311": {
+        "real": true,
+        "tex": "(\\bar q_1^I u_3)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re1312": {
+        "real": true,
+        "tex": "(\\bar q_1^I u_3)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re1313": {
+        "real": true,
+        "tex": "(\\bar q_1^I u_3)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re1321": {
+        "real": true,
+        "tex": "(\\bar q_1^I u_3)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re1322": {
+        "real": true,
+        "tex": "(\\bar q_1^I u_3)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re1323": {
+        "real": true,
+        "tex": "(\\bar q_1^I u_3)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re1331": {
+        "real": true,
+        "tex": "(\\bar q_1^I u_3)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re1332": {
+        "real": true,
+        "tex": "(\\bar q_1^I u_3)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re1333": {
+        "real": true,
+        "tex": "(\\bar q_1^I u_3)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re2111": {
+        "real": true,
+        "tex": "(\\bar q_2^I u_1)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re2112": {
+        "real": true,
+        "tex": "(\\bar q_2^I u_1)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re2113": {
+        "real": true,
+        "tex": "(\\bar q_2^I u_1)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re2121": {
+        "real": true,
+        "tex": "(\\bar q_2^I u_1)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re2122": {
+        "real": true,
+        "tex": "(\\bar q_2^I u_1)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re2123": {
+        "real": true,
+        "tex": "(\\bar q_2^I u_1)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re2131": {
+        "real": true,
+        "tex": "(\\bar q_2^I u_1)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re2132": {
+        "real": true,
+        "tex": "(\\bar q_2^I u_1)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re2133": {
+        "real": true,
+        "tex": "(\\bar q_2^I u_1)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re2211": {
+        "real": true,
+        "tex": "(\\bar q_2^I u_2)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re2212": {
+        "real": true,
+        "tex": "(\\bar q_2^I u_2)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re2213": {
+        "real": true,
+        "tex": "(\\bar q_2^I u_2)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re2221": {
+        "real": true,
+        "tex": "(\\bar q_2^I u_2)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re2222": {
+        "real": true,
+        "tex": "(\\bar q_2^I u_2)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re2223": {
+        "real": true,
+        "tex": "(\\bar q_2^I u_2)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re2231": {
+        "real": true,
+        "tex": "(\\bar q_2^I u_2)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re2232": {
+        "real": true,
+        "tex": "(\\bar q_2^I u_2)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re2233": {
+        "real": true,
+        "tex": "(\\bar q_2^I u_2)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re2311": {
+        "real": true,
+        "tex": "(\\bar q_2^I u_3)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re2312": {
+        "real": true,
+        "tex": "(\\bar q_2^I u_3)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re2313": {
+        "real": true,
+        "tex": "(\\bar q_2^I u_3)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re2321": {
+        "real": true,
+        "tex": "(\\bar q_2^I u_3)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re2322": {
+        "real": true,
+        "tex": "(\\bar q_2^I u_3)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re2323": {
+        "real": true,
+        "tex": "(\\bar q_2^I u_3)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re2331": {
+        "real": true,
+        "tex": "(\\bar q_2^I u_3)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re2332": {
+        "real": true,
+        "tex": "(\\bar q_2^I u_3)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re2333": {
+        "real": true,
+        "tex": "(\\bar q_2^I u_3)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re3111": {
+        "real": true,
+        "tex": "(\\bar q_3^I u_1)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re3112": {
+        "real": true,
+        "tex": "(\\bar q_3^I u_1)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re3113": {
+        "real": true,
+        "tex": "(\\bar q_3^I u_1)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re3121": {
+        "real": true,
+        "tex": "(\\bar q_3^I u_1)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re3122": {
+        "real": true,
+        "tex": "(\\bar q_3^I u_1)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re3123": {
+        "real": true,
+        "tex": "(\\bar q_3^I u_1)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re3131": {
+        "real": true,
+        "tex": "(\\bar q_3^I u_1)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re3132": {
+        "real": true,
+        "tex": "(\\bar q_3^I u_1)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re3133": {
+        "real": true,
+        "tex": "(\\bar q_3^I u_1)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re3211": {
+        "real": true,
+        "tex": "(\\bar q_3^I u_2)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re3212": {
+        "real": true,
+        "tex": "(\\bar q_3^I u_2)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re3213": {
+        "real": true,
+        "tex": "(\\bar q_3^I u_2)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re3221": {
+        "real": true,
+        "tex": "(\\bar q_3^I u_2)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re3222": {
+        "real": true,
+        "tex": "(\\bar q_3^I u_2)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re3223": {
+        "real": true,
+        "tex": "(\\bar q_3^I u_2)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re3231": {
+        "real": true,
+        "tex": "(\\bar q_3^I u_2)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re3232": {
+        "real": true,
+        "tex": "(\\bar q_3^I u_2)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re3233": {
+        "real": true,
+        "tex": "(\\bar q_3^I u_2)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re3311": {
+        "real": true,
+        "tex": "(\\bar q_3^I u_3)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re3312": {
+        "real": true,
+        "tex": "(\\bar q_3^I u_3)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re3313": {
+        "real": true,
+        "tex": "(\\bar q_3^I u_3)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re3321": {
+        "real": true,
+        "tex": "(\\bar q_3^I u_3)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re3322": {
+        "real": true,
+        "tex": "(\\bar q_3^I u_3)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re3323": {
+        "real": true,
+        "tex": "(\\bar q_3^I u_3)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re3331": {
+        "real": true,
+        "tex": "(\\bar q_3^I u_3)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re3332": {
+        "real": true,
+        "tex": "(\\bar q_3^I u_3)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Re3333": {
+        "real": true,
+        "tex": "(\\bar q_3^I u_3)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im1111": {
+        "real": true,
+        "tex": "i (\\bar q_1^I u_1)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im1112": {
+        "real": true,
+        "tex": "i (\\bar q_1^I u_1)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im1113": {
+        "real": true,
+        "tex": "i (\\bar q_1^I u_1)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im1121": {
+        "real": true,
+        "tex": "i (\\bar q_1^I u_1)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im1122": {
+        "real": true,
+        "tex": "i (\\bar q_1^I u_1)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im1123": {
+        "real": true,
+        "tex": "i (\\bar q_1^I u_1)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im1131": {
+        "real": true,
+        "tex": "i (\\bar q_1^I u_1)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im1132": {
+        "real": true,
+        "tex": "i (\\bar q_1^I u_1)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im1133": {
+        "real": true,
+        "tex": "i (\\bar q_1^I u_1)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im1211": {
+        "real": true,
+        "tex": "i (\\bar q_1^I u_2)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im1212": {
+        "real": true,
+        "tex": "i (\\bar q_1^I u_2)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im1213": {
+        "real": true,
+        "tex": "i (\\bar q_1^I u_2)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im1221": {
+        "real": true,
+        "tex": "i (\\bar q_1^I u_2)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im1222": {
+        "real": true,
+        "tex": "i (\\bar q_1^I u_2)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im1223": {
+        "real": true,
+        "tex": "i (\\bar q_1^I u_2)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im1231": {
+        "real": true,
+        "tex": "i (\\bar q_1^I u_2)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im1232": {
+        "real": true,
+        "tex": "i (\\bar q_1^I u_2)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im1233": {
+        "real": true,
+        "tex": "i (\\bar q_1^I u_2)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im1311": {
+        "real": true,
+        "tex": "i (\\bar q_1^I u_3)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im1312": {
+        "real": true,
+        "tex": "i (\\bar q_1^I u_3)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im1313": {
+        "real": true,
+        "tex": "i (\\bar q_1^I u_3)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im1321": {
+        "real": true,
+        "tex": "i (\\bar q_1^I u_3)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im1322": {
+        "real": true,
+        "tex": "i (\\bar q_1^I u_3)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im1323": {
+        "real": true,
+        "tex": "i (\\bar q_1^I u_3)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im1331": {
+        "real": true,
+        "tex": "i (\\bar q_1^I u_3)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im1332": {
+        "real": true,
+        "tex": "i (\\bar q_1^I u_3)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im1333": {
+        "real": true,
+        "tex": "i (\\bar q_1^I u_3)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im2111": {
+        "real": true,
+        "tex": "i (\\bar q_2^I u_1)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im2112": {
+        "real": true,
+        "tex": "i (\\bar q_2^I u_1)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im2113": {
+        "real": true,
+        "tex": "i (\\bar q_2^I u_1)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im2121": {
+        "real": true,
+        "tex": "i (\\bar q_2^I u_1)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im2122": {
+        "real": true,
+        "tex": "i (\\bar q_2^I u_1)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im2123": {
+        "real": true,
+        "tex": "i (\\bar q_2^I u_1)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im2131": {
+        "real": true,
+        "tex": "i (\\bar q_2^I u_1)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im2132": {
+        "real": true,
+        "tex": "i (\\bar q_2^I u_1)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im2133": {
+        "real": true,
+        "tex": "i (\\bar q_2^I u_1)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im2211": {
+        "real": true,
+        "tex": "i (\\bar q_2^I u_2)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im2212": {
+        "real": true,
+        "tex": "i (\\bar q_2^I u_2)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im2213": {
+        "real": true,
+        "tex": "i (\\bar q_2^I u_2)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im2221": {
+        "real": true,
+        "tex": "i (\\bar q_2^I u_2)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im2222": {
+        "real": true,
+        "tex": "i (\\bar q_2^I u_2)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im2223": {
+        "real": true,
+        "tex": "i (\\bar q_2^I u_2)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im2231": {
+        "real": true,
+        "tex": "i (\\bar q_2^I u_2)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im2232": {
+        "real": true,
+        "tex": "i (\\bar q_2^I u_2)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im2233": {
+        "real": true,
+        "tex": "i (\\bar q_2^I u_2)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im2311": {
+        "real": true,
+        "tex": "i (\\bar q_2^I u_3)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im2312": {
+        "real": true,
+        "tex": "i (\\bar q_2^I u_3)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im2313": {
+        "real": true,
+        "tex": "i (\\bar q_2^I u_3)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im2321": {
+        "real": true,
+        "tex": "i (\\bar q_2^I u_3)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im2322": {
+        "real": true,
+        "tex": "i (\\bar q_2^I u_3)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im2323": {
+        "real": true,
+        "tex": "i (\\bar q_2^I u_3)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im2331": {
+        "real": true,
+        "tex": "i (\\bar q_2^I u_3)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im2332": {
+        "real": true,
+        "tex": "i (\\bar q_2^I u_3)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im2333": {
+        "real": true,
+        "tex": "i (\\bar q_2^I u_3)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im3111": {
+        "real": true,
+        "tex": "i (\\bar q_3^I u_1)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im3112": {
+        "real": true,
+        "tex": "i (\\bar q_3^I u_1)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im3113": {
+        "real": true,
+        "tex": "i (\\bar q_3^I u_1)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im3121": {
+        "real": true,
+        "tex": "i (\\bar q_3^I u_1)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im3122": {
+        "real": true,
+        "tex": "i (\\bar q_3^I u_1)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im3123": {
+        "real": true,
+        "tex": "i (\\bar q_3^I u_1)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im3131": {
+        "real": true,
+        "tex": "i (\\bar q_3^I u_1)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im3132": {
+        "real": true,
+        "tex": "i (\\bar q_3^I u_1)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im3133": {
+        "real": true,
+        "tex": "i (\\bar q_3^I u_1)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im3211": {
+        "real": true,
+        "tex": "i (\\bar q_3^I u_2)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im3212": {
+        "real": true,
+        "tex": "i (\\bar q_3^I u_2)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im3213": {
+        "real": true,
+        "tex": "i (\\bar q_3^I u_2)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im3221": {
+        "real": true,
+        "tex": "i (\\bar q_3^I u_2)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im3222": {
+        "real": true,
+        "tex": "i (\\bar q_3^I u_2)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im3223": {
+        "real": true,
+        "tex": "i (\\bar q_3^I u_2)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im3231": {
+        "real": true,
+        "tex": "i (\\bar q_3^I u_2)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im3232": {
+        "real": true,
+        "tex": "i (\\bar q_3^I u_2)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im3233": {
+        "real": true,
+        "tex": "i (\\bar q_3^I u_2)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im3311": {
+        "real": true,
+        "tex": "i (\\bar q_3^I u_3)(\\bar q^J_1 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im3312": {
+        "real": true,
+        "tex": "i (\\bar q_3^I u_3)(\\bar q^J_1 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im3313": {
+        "real": true,
+        "tex": "i (\\bar q_3^I u_3)(\\bar q^J_1 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im3321": {
+        "real": true,
+        "tex": "i (\\bar q_3^I u_3)(\\bar q^J_2 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im3322": {
+        "real": true,
+        "tex": "i (\\bar q_3^I u_3)(\\bar q^J_2 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im3323": {
+        "real": true,
+        "tex": "i (\\bar q_3^I u_3)(\\bar q^J_2 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im3331": {
+        "real": true,
+        "tex": "i (\\bar q_3^I u_3)(\\bar q^J_3 d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im3332": {
+        "real": true,
+        "tex": "i (\\bar q_3^I u_3)(\\bar q^J_3 d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd1Im3333": {
+        "real": true,
+        "tex": "i (\\bar q_3^I u_3)(\\bar q^J_3 d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re1111": {
+        "real": true,
+        "tex": "(\\bar q_1^I T^A u_1)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re1112": {
+        "real": true,
+        "tex": "(\\bar q_1^I T^A u_1)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re1113": {
+        "real": true,
+        "tex": "(\\bar q_1^I T^A u_1)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re1121": {
+        "real": true,
+        "tex": "(\\bar q_1^I T^A u_1)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re1122": {
+        "real": true,
+        "tex": "(\\bar q_1^I T^A u_1)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re1123": {
+        "real": true,
+        "tex": "(\\bar q_1^I T^A u_1)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re1131": {
+        "real": true,
+        "tex": "(\\bar q_1^I T^A u_1)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re1132": {
+        "real": true,
+        "tex": "(\\bar q_1^I T^A u_1)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re1133": {
+        "real": true,
+        "tex": "(\\bar q_1^I T^A u_1)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re1211": {
+        "real": true,
+        "tex": "(\\bar q_1^I T^A u_2)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re1212": {
+        "real": true,
+        "tex": "(\\bar q_1^I T^A u_2)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re1213": {
+        "real": true,
+        "tex": "(\\bar q_1^I T^A u_2)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re1221": {
+        "real": true,
+        "tex": "(\\bar q_1^I T^A u_2)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re1222": {
+        "real": true,
+        "tex": "(\\bar q_1^I T^A u_2)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re1223": {
+        "real": true,
+        "tex": "(\\bar q_1^I T^A u_2)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re1231": {
+        "real": true,
+        "tex": "(\\bar q_1^I T^A u_2)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re1232": {
+        "real": true,
+        "tex": "(\\bar q_1^I T^A u_2)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re1233": {
+        "real": true,
+        "tex": "(\\bar q_1^I T^A u_2)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re1311": {
+        "real": true,
+        "tex": "(\\bar q_1^I T^A u_3)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re1312": {
+        "real": true,
+        "tex": "(\\bar q_1^I T^A u_3)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re1313": {
+        "real": true,
+        "tex": "(\\bar q_1^I T^A u_3)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re1321": {
+        "real": true,
+        "tex": "(\\bar q_1^I T^A u_3)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re1322": {
+        "real": true,
+        "tex": "(\\bar q_1^I T^A u_3)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re1323": {
+        "real": true,
+        "tex": "(\\bar q_1^I T^A u_3)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re1331": {
+        "real": true,
+        "tex": "(\\bar q_1^I T^A u_3)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re1332": {
+        "real": true,
+        "tex": "(\\bar q_1^I T^A u_3)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re1333": {
+        "real": true,
+        "tex": "(\\bar q_1^I T^A u_3)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re2111": {
+        "real": true,
+        "tex": "(\\bar q_2^I T^A u_1)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re2112": {
+        "real": true,
+        "tex": "(\\bar q_2^I T^A u_1)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re2113": {
+        "real": true,
+        "tex": "(\\bar q_2^I T^A u_1)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re2121": {
+        "real": true,
+        "tex": "(\\bar q_2^I T^A u_1)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re2122": {
+        "real": true,
+        "tex": "(\\bar q_2^I T^A u_1)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re2123": {
+        "real": true,
+        "tex": "(\\bar q_2^I T^A u_1)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re2131": {
+        "real": true,
+        "tex": "(\\bar q_2^I T^A u_1)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re2132": {
+        "real": true,
+        "tex": "(\\bar q_2^I T^A u_1)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re2133": {
+        "real": true,
+        "tex": "(\\bar q_2^I T^A u_1)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re2211": {
+        "real": true,
+        "tex": "(\\bar q_2^I T^A u_2)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re2212": {
+        "real": true,
+        "tex": "(\\bar q_2^I T^A u_2)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re2213": {
+        "real": true,
+        "tex": "(\\bar q_2^I T^A u_2)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re2221": {
+        "real": true,
+        "tex": "(\\bar q_2^I T^A u_2)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re2222": {
+        "real": true,
+        "tex": "(\\bar q_2^I T^A u_2)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re2223": {
+        "real": true,
+        "tex": "(\\bar q_2^I T^A u_2)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re2231": {
+        "real": true,
+        "tex": "(\\bar q_2^I T^A u_2)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re2232": {
+        "real": true,
+        "tex": "(\\bar q_2^I T^A u_2)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re2233": {
+        "real": true,
+        "tex": "(\\bar q_2^I T^A u_2)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re2311": {
+        "real": true,
+        "tex": "(\\bar q_2^I T^A u_3)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re2312": {
+        "real": true,
+        "tex": "(\\bar q_2^I T^A u_3)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re2313": {
+        "real": true,
+        "tex": "(\\bar q_2^I T^A u_3)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re2321": {
+        "real": true,
+        "tex": "(\\bar q_2^I T^A u_3)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re2322": {
+        "real": true,
+        "tex": "(\\bar q_2^I T^A u_3)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re2323": {
+        "real": true,
+        "tex": "(\\bar q_2^I T^A u_3)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re2331": {
+        "real": true,
+        "tex": "(\\bar q_2^I T^A u_3)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re2332": {
+        "real": true,
+        "tex": "(\\bar q_2^I T^A u_3)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re2333": {
+        "real": true,
+        "tex": "(\\bar q_2^I T^A u_3)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re3111": {
+        "real": true,
+        "tex": "(\\bar q_3^I T^A u_1)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re3112": {
+        "real": true,
+        "tex": "(\\bar q_3^I T^A u_1)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re3113": {
+        "real": true,
+        "tex": "(\\bar q_3^I T^A u_1)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re3121": {
+        "real": true,
+        "tex": "(\\bar q_3^I T^A u_1)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re3122": {
+        "real": true,
+        "tex": "(\\bar q_3^I T^A u_1)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re3123": {
+        "real": true,
+        "tex": "(\\bar q_3^I T^A u_1)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re3131": {
+        "real": true,
+        "tex": "(\\bar q_3^I T^A u_1)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re3132": {
+        "real": true,
+        "tex": "(\\bar q_3^I T^A u_1)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re3133": {
+        "real": true,
+        "tex": "(\\bar q_3^I T^A u_1)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re3211": {
+        "real": true,
+        "tex": "(\\bar q_3^I T^A u_2)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re3212": {
+        "real": true,
+        "tex": "(\\bar q_3^I T^A u_2)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re3213": {
+        "real": true,
+        "tex": "(\\bar q_3^I T^A u_2)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re3221": {
+        "real": true,
+        "tex": "(\\bar q_3^I T^A u_2)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re3222": {
+        "real": true,
+        "tex": "(\\bar q_3^I T^A u_2)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re3223": {
+        "real": true,
+        "tex": "(\\bar q_3^I T^A u_2)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re3231": {
+        "real": true,
+        "tex": "(\\bar q_3^I T^A u_2)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re3232": {
+        "real": true,
+        "tex": "(\\bar q_3^I T^A u_2)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re3233": {
+        "real": true,
+        "tex": "(\\bar q_3^I T^A u_2)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re3311": {
+        "real": true,
+        "tex": "(\\bar q_3^I T^A u_3)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re3312": {
+        "real": true,
+        "tex": "(\\bar q_3^I T^A u_3)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re3313": {
+        "real": true,
+        "tex": "(\\bar q_3^I T^A u_3)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re3321": {
+        "real": true,
+        "tex": "(\\bar q_3^I T^A u_3)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re3322": {
+        "real": true,
+        "tex": "(\\bar q_3^I T^A u_3)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re3323": {
+        "real": true,
+        "tex": "(\\bar q_3^I T^A u_3)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re3331": {
+        "real": true,
+        "tex": "(\\bar q_3^I T^A u_3)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re3332": {
+        "real": true,
+        "tex": "(\\bar q_3^I T^A u_3)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Re3333": {
+        "real": true,
+        "tex": "(\\bar q_3^I T^A u_3)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im1111": {
+        "real": true,
+        "tex": "i (\\bar q_1^I T^A u_1)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im1112": {
+        "real": true,
+        "tex": "i (\\bar q_1^I T^A u_1)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im1113": {
+        "real": true,
+        "tex": "i (\\bar q_1^I T^A u_1)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im1121": {
+        "real": true,
+        "tex": "i (\\bar q_1^I T^A u_1)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im1122": {
+        "real": true,
+        "tex": "i (\\bar q_1^I T^A u_1)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im1123": {
+        "real": true,
+        "tex": "i (\\bar q_1^I T^A u_1)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im1131": {
+        "real": true,
+        "tex": "i (\\bar q_1^I T^A u_1)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im1132": {
+        "real": true,
+        "tex": "i (\\bar q_1^I T^A u_1)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im1133": {
+        "real": true,
+        "tex": "i (\\bar q_1^I T^A u_1)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im1211": {
+        "real": true,
+        "tex": "i (\\bar q_1^I T^A u_2)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im1212": {
+        "real": true,
+        "tex": "i (\\bar q_1^I T^A u_2)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im1213": {
+        "real": true,
+        "tex": "i (\\bar q_1^I T^A u_2)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im1221": {
+        "real": true,
+        "tex": "i (\\bar q_1^I T^A u_2)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im1222": {
+        "real": true,
+        "tex": "i (\\bar q_1^I T^A u_2)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im1223": {
+        "real": true,
+        "tex": "i (\\bar q_1^I T^A u_2)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im1231": {
+        "real": true,
+        "tex": "i (\\bar q_1^I T^A u_2)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im1232": {
+        "real": true,
+        "tex": "i (\\bar q_1^I T^A u_2)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im1233": {
+        "real": true,
+        "tex": "i (\\bar q_1^I T^A u_2)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im1311": {
+        "real": true,
+        "tex": "i (\\bar q_1^I T^A u_3)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im1312": {
+        "real": true,
+        "tex": "i (\\bar q_1^I T^A u_3)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im1313": {
+        "real": true,
+        "tex": "i (\\bar q_1^I T^A u_3)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im1321": {
+        "real": true,
+        "tex": "i (\\bar q_1^I T^A u_3)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im1322": {
+        "real": true,
+        "tex": "i (\\bar q_1^I T^A u_3)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im1323": {
+        "real": true,
+        "tex": "i (\\bar q_1^I T^A u_3)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im1331": {
+        "real": true,
+        "tex": "i (\\bar q_1^I T^A u_3)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im1332": {
+        "real": true,
+        "tex": "i (\\bar q_1^I T^A u_3)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im1333": {
+        "real": true,
+        "tex": "i (\\bar q_1^I T^A u_3)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im2111": {
+        "real": true,
+        "tex": "i (\\bar q_2^I T^A u_1)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im2112": {
+        "real": true,
+        "tex": "i (\\bar q_2^I T^A u_1)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im2113": {
+        "real": true,
+        "tex": "i (\\bar q_2^I T^A u_1)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im2121": {
+        "real": true,
+        "tex": "i (\\bar q_2^I T^A u_1)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im2122": {
+        "real": true,
+        "tex": "i (\\bar q_2^I T^A u_1)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im2123": {
+        "real": true,
+        "tex": "i (\\bar q_2^I T^A u_1)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im2131": {
+        "real": true,
+        "tex": "i (\\bar q_2^I T^A u_1)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im2132": {
+        "real": true,
+        "tex": "i (\\bar q_2^I T^A u_1)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im2133": {
+        "real": true,
+        "tex": "i (\\bar q_2^I T^A u_1)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im2211": {
+        "real": true,
+        "tex": "i (\\bar q_2^I T^A u_2)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im2212": {
+        "real": true,
+        "tex": "i (\\bar q_2^I T^A u_2)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im2213": {
+        "real": true,
+        "tex": "i (\\bar q_2^I T^A u_2)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im2221": {
+        "real": true,
+        "tex": "i (\\bar q_2^I T^A u_2)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im2222": {
+        "real": true,
+        "tex": "i (\\bar q_2^I T^A u_2)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im2223": {
+        "real": true,
+        "tex": "i (\\bar q_2^I T^A u_2)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im2231": {
+        "real": true,
+        "tex": "i (\\bar q_2^I T^A u_2)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im2232": {
+        "real": true,
+        "tex": "i (\\bar q_2^I T^A u_2)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im2233": {
+        "real": true,
+        "tex": "i (\\bar q_2^I T^A u_2)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im2311": {
+        "real": true,
+        "tex": "i (\\bar q_2^I T^A u_3)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im2312": {
+        "real": true,
+        "tex": "i (\\bar q_2^I T^A u_3)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im2313": {
+        "real": true,
+        "tex": "i (\\bar q_2^I T^A u_3)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im2321": {
+        "real": true,
+        "tex": "i (\\bar q_2^I T^A u_3)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im2322": {
+        "real": true,
+        "tex": "i (\\bar q_2^I T^A u_3)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im2323": {
+        "real": true,
+        "tex": "i (\\bar q_2^I T^A u_3)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im2331": {
+        "real": true,
+        "tex": "i (\\bar q_2^I T^A u_3)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im2332": {
+        "real": true,
+        "tex": "i (\\bar q_2^I T^A u_3)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im2333": {
+        "real": true,
+        "tex": "i (\\bar q_2^I T^A u_3)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im3111": {
+        "real": true,
+        "tex": "i (\\bar q_3^I T^A u_1)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im3112": {
+        "real": true,
+        "tex": "i (\\bar q_3^I T^A u_1)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im3113": {
+        "real": true,
+        "tex": "i (\\bar q_3^I T^A u_1)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im3121": {
+        "real": true,
+        "tex": "i (\\bar q_3^I T^A u_1)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im3122": {
+        "real": true,
+        "tex": "i (\\bar q_3^I T^A u_1)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im3123": {
+        "real": true,
+        "tex": "i (\\bar q_3^I T^A u_1)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im3131": {
+        "real": true,
+        "tex": "i (\\bar q_3^I T^A u_1)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im3132": {
+        "real": true,
+        "tex": "i (\\bar q_3^I T^A u_1)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im3133": {
+        "real": true,
+        "tex": "i (\\bar q_3^I T^A u_1)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im3211": {
+        "real": true,
+        "tex": "i (\\bar q_3^I T^A u_2)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im3212": {
+        "real": true,
+        "tex": "i (\\bar q_3^I T^A u_2)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im3213": {
+        "real": true,
+        "tex": "i (\\bar q_3^I T^A u_2)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im3221": {
+        "real": true,
+        "tex": "i (\\bar q_3^I T^A u_2)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im3222": {
+        "real": true,
+        "tex": "i (\\bar q_3^I T^A u_2)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im3223": {
+        "real": true,
+        "tex": "i (\\bar q_3^I T^A u_2)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im3231": {
+        "real": true,
+        "tex": "i (\\bar q_3^I T^A u_2)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im3232": {
+        "real": true,
+        "tex": "i (\\bar q_3^I T^A u_2)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im3233": {
+        "real": true,
+        "tex": "i (\\bar q_3^I T^A u_2)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im3311": {
+        "real": true,
+        "tex": "i (\\bar q_3^I T^A u_3)(\\bar q^J_1 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im3312": {
+        "real": true,
+        "tex": "i (\\bar q_3^I T^A u_3)(\\bar q^J_1 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im3313": {
+        "real": true,
+        "tex": "i (\\bar q_3^I T^A u_3)(\\bar q^J_1 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im3321": {
+        "real": true,
+        "tex": "i (\\bar q_3^I T^A u_3)(\\bar q^J_2 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im3322": {
+        "real": true,
+        "tex": "i (\\bar q_3^I T^A u_3)(\\bar q^J_2 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im3323": {
+        "real": true,
+        "tex": "i (\\bar q_3^I T^A u_3)(\\bar q^J_2 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im3331": {
+        "real": true,
+        "tex": "i (\\bar q_3^I T^A u_3)(\\bar q^J_3 T^A d_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im3332": {
+        "real": true,
+        "tex": "i (\\bar q_3^I T^A u_3)(\\bar q^J_3 T^A d_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cquqd8Im3333": {
+        "real": true,
+        "tex": "i (\\bar q_3^I T^A u_3)(\\bar q^J_3 T^A d_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1111": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_1)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1112": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_1)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1113": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_1)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1121": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_1)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1122": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_1)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1123": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_1)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1131": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_1)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1132": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_1)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1133": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_1)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1211": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1212": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1213": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1221": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1222": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1223": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1231": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1232": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1233": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1311": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1312": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1313": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1321": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1322": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1323": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1331": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1332": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1333": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2111": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2112": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2113": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2121": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2122": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2123": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2131": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2132": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2133": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2211": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_2)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2212": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_2)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2213": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_2)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2221": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_2)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2222": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_2)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2223": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_2)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2231": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_2)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2232": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_2)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2233": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_2)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2311": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2312": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2313": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2321": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2322": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2323": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2331": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2332": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2333": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3111": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3112": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3113": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3121": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3122": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3123": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3131": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3132": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3133": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3211": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3212": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3213": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3221": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3222": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3223": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3231": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3232": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3233": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3311": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_3)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3312": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_3)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3313": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_3)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3321": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_3)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3322": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_3)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3323": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_3)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3331": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_3)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3332": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_3)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3333": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_3)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1111": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_1)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1112": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_1)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1113": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_1)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1121": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_1)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1122": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_1)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1123": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_1)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1131": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_1)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1132": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_1)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1133": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_1)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1211": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1221": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1222": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1231": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1232": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1233": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2111": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2112": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2113": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2121": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2122": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2123": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2131": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2132": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2133": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2211": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_2)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_2)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_2)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2221": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_2)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2222": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_2)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_2)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2231": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_2)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2232": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_2)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2233": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_2)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3111": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3112": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3113": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3121": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3122": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3123": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3131": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3132": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3133": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3211": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3221": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3222": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3231": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3232": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3233": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_3)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_3)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_3)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_3)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_3)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_3)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_3)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_3)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_3)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1111": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1112": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1113": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1121": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1122": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1123": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1131": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1132": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1133": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1211": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1212": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1213": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1221": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1222": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1223": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1231": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1232": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1233": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1311": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1312": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1313": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1321": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1322": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1323": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1331": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1332": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1333": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2111": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2112": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2113": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2121": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2122": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2123": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2131": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2132": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2133": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2211": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2212": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2213": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2221": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2222": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2223": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2231": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2232": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2233": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2311": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2312": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2313": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2321": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2322": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2323": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2331": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2332": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2333": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3111": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3112": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3113": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3121": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3122": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3123": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3131": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3132": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3133": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3211": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3212": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3213": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3221": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3222": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3223": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3231": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3232": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3233": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3311": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3312": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3313": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3321": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3322": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3323": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3331": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3332": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3333": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im1111": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im1112": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im1113": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im1121": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im1122": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im1123": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im1131": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im1132": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im1133": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im1211": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im1212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im1213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im1221": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im1222": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im1223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im1231": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im1232": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im1233": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im1311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im1312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im1313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im1321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im1322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im1323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im1331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im1332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im1333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2111": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2112": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2113": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2121": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2122": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2123": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2131": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2132": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2133": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2211": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2221": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2222": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2231": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2232": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2233": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3111": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3112": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3113": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3121": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3122": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3123": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3131": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3132": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3133": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3211": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3221": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3222": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3231": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3232": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3233": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      }
+    }
   }
 }

--- a/smeft.smeftsim-general.basis.json
+++ b/smeft.smeftsim-general.basis.json
@@ -1196,39 +1196,39 @@
       },
       "cllRe1122": {
         "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2"
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2"
       },
       "cllRe1133": {
         "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2"
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2"
       },
       "cllRe2233": {
         "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2"
+        "tex": "2 (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2"
       },
       "cllRe1221": {
         "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_1) / \\text{TeV}^2"
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_1) / \\text{TeV}^2"
       },
       "cllRe1331": {
         "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_1) / \\text{TeV}^2"
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_1) / \\text{TeV}^2"
       },
       "cllRe2332": {
         "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2"
+        "tex": "2 (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2"
       },
       "cllRe1112": {
         "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_1 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_1 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllRe1113": {
         "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllRe1123": {
         "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllRe1212": {
         "real": true,
@@ -1236,19 +1236,19 @@
       },
       "cllRe1213": {
         "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllRe1222": {
         "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllRe1232": {
         "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllRe1233": {
         "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllRe1313": {
         "real": true,
@@ -1256,19 +1256,19 @@
       },
       "cllRe1322": {
         "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllRe1323": {
         "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllRe1333": {
         "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllRe2223": {
         "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllRe2323": {
         "real": true,
@@ -1276,31 +1276,31 @@
       },
       "cllRe3323": {
         "real": true,
-        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllRe1231": {
         "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_1) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_1) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllRe1223": {
         "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllRe1332": {
         "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllIm1112": {
         "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_1 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_1 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllIm1113": {
         "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllIm1123": {
         "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllIm1212": {
         "real": true,
@@ -1308,19 +1308,19 @@
       },
       "cllIm1213": {
         "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllIm1222": {
         "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllIm1232": {
         "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllIm1233": {
         "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllIm1313": {
         "real": true,
@@ -1328,19 +1328,19 @@
       },
       "cllIm1322": {
         "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllIm1323": {
         "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllIm1333": {
         "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllIm2223": {
         "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllIm2323": {
         "real": true,
@@ -1348,19 +1348,19 @@
       },
       "cllIm3323": {
         "real": true,
-        "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllIm1231": {
         "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_1) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_1) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllIm1223": {
         "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cllIm1332": {
         "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "clq1Re1111": {
         "real": true,
@@ -2024,39 +2024,39 @@
       },
       "cqq1Re1122": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu q_1)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2"
       },
       "cqq1Re1133": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu q_1)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2"
       },
       "cqq1Re2233": {
         "real": true,
-        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2"
+        "tex": "2 (\\bar q_2 \\gamma_\\mu q_2)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2"
       },
       "cqq1Re1221": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_1) / \\text{TeV}^2"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_1) / \\text{TeV}^2"
       },
       "cqq1Re1331": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu q_3)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2"
       },
       "cqq1Re2332": {
         "real": true,
-        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2"
+        "tex": "2 (\\bar q_2 \\gamma_\\mu q_3)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2"
       },
       "cqq1Re1112": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu q_1)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Re1113": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu q_1)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Re1123": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu q_1)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Re1212": {
         "real": true,
@@ -2064,19 +2064,19 @@
       },
       "cqq1Re1213": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Re1222": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Re1232": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Re1233": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Re1313": {
         "real": true,
@@ -2084,19 +2084,19 @@
       },
       "cqq1Re1322": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu q_3)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Re1323": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu q_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Re1333": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu q_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Re2223": {
         "real": true,
-        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_2 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Re2323": {
         "real": true,
@@ -2104,31 +2104,31 @@
       },
       "cqq1Re3323": {
         "real": true,
-        "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_3 \\gamma_\\mu q_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Re1231": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Re1223": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Re1332": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu q_3)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Im1112": {
         "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_1 \\gamma_\\mu q_1)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Im1113": {
         "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_1 \\gamma_\\mu q_1)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Im1123": {
         "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_1 \\gamma_\\mu q_1)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Im1212": {
         "real": true,
@@ -2136,19 +2136,19 @@
       },
       "cqq1Im1213": {
         "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Im1222": {
         "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Im1232": {
         "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Im1233": {
         "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Im1313": {
         "real": true,
@@ -2156,19 +2156,19 @@
       },
       "cqq1Im1322": {
         "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_1 \\gamma_\\mu q_3)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Im1323": {
         "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_1 \\gamma_\\mu q_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Im1333": {
         "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_1 \\gamma_\\mu q_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Im2223": {
         "real": true,
-        "tex": "i (\\bar q_2 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_2 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Im2323": {
         "real": true,
@@ -2176,19 +2176,19 @@
       },
       "cqq1Im3323": {
         "real": true,
-        "tex": "i (\\bar q_3 \\gamma_\\mu q_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_3 \\gamma_\\mu q_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Im1231": {
         "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Im1223": {
         "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_1 \\gamma_\\mu q_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq1Im1332": {
         "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_1 \\gamma_\\mu q_3)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Re1111": {
         "real": true,
@@ -2204,39 +2204,39 @@
       },
       "cqq3Re1122": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2"
       },
       "cqq3Re1133": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2"
       },
       "cqq3Re2233": {
         "real": true,
-        "tex": "(\\bar q_2 \\gamma_\\mu \\sigma^I q_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2"
+        "tex": "2 (\\bar q_2 \\gamma_\\mu \\sigma^I q_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2"
       },
       "cqq3Re1221": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2"
       },
       "cqq3Re1331": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2"
       },
       "cqq3Re2332": {
         "real": true,
-        "tex": "(\\bar q_2 \\gamma_\\mu \\sigma^I q_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2"
+        "tex": "2 (\\bar q_2 \\gamma_\\mu \\sigma^I q_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2"
       },
       "cqq3Re1112": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Re1113": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Re1123": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Re1212": {
         "real": true,
@@ -2244,19 +2244,19 @@
       },
       "cqq3Re1213": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Re1222": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Re1232": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Re1233": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Re1313": {
         "real": true,
@@ -2264,19 +2264,19 @@
       },
       "cqq3Re1322": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Re1323": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Re1333": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Re2223": {
         "real": true,
-        "tex": "(\\bar q_2 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_2 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Re2323": {
         "real": true,
@@ -2284,31 +2284,31 @@
       },
       "cqq3Re3323": {
         "real": true,
-        "tex": "(\\bar q_3 \\gamma_\\mu \\sigma^I q_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_3 \\gamma_\\mu \\sigma^I q_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Re1231": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Re1223": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Re1332": {
         "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Im1112": {
         "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Im1113": {
         "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Im1123": {
         "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_1 \\gamma_\\mu \\sigma^I q_1)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Im1212": {
         "real": true,
@@ -2316,19 +2316,19 @@
       },
       "cqq3Im1213": {
         "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Im1222": {
         "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Im1232": {
         "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Im1233": {
         "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Im1313": {
         "real": true,
@@ -2336,19 +2336,19 @@
       },
       "cqq3Im1322": {
         "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Im1323": {
         "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Im1333": {
         "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Im2223": {
         "real": true,
-        "tex": "i (\\bar q_2 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_2 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Im2323": {
         "real": true,
@@ -2356,19 +2356,19 @@
       },
       "cqq3Im3323": {
         "real": true,
-        "tex": "i (\\bar q_3 \\gamma_\\mu \\sigma^I q_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_3 \\gamma_\\mu \\sigma^I q_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Im1231": {
         "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Im1223": {
         "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_1 \\gamma_\\mu \\sigma^I q_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqq3Im1332": {
         "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar q_1 \\gamma_\\mu \\sigma^I q_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceeRe1111": {
         "real": true,
@@ -2384,27 +2384,27 @@
       },
       "ceeRe1122": {
         "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2"
+        "tex": "4 (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2"
       },
       "ceeRe1133": {
         "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2"
+        "tex": "4 (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2"
       },
       "ceeRe2233": {
         "real": true,
-        "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2"
+        "tex": "4 (\\bar e_2 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2"
       },
       "ceeRe1112": {
         "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceeRe1113": {
         "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceeRe1123": {
         "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "4 (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceeRe1212": {
         "real": true,
@@ -2412,19 +2412,19 @@
       },
       "ceeRe1213": {
         "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceeRe1222": {
         "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceeRe1232": {
         "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceeRe1233": {
         "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "4 (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceeRe1313": {
         "real": true,
@@ -2432,19 +2432,19 @@
       },
       "ceeRe1322": {
         "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "4 (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceeRe1323": {
         "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceeRe1333": {
         "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceeRe2223": {
         "real": true,
-        "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar e_2 \\gamma_\\mu e_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceeRe2323": {
         "real": true,
@@ -2452,19 +2452,19 @@
       },
       "ceeRe3323": {
         "real": true,
-        "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar e_3 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceeIm1112": {
         "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceeIm1113": {
         "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceeIm1123": {
         "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "4 i (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceeIm1212": {
         "real": true,
@@ -2472,19 +2472,19 @@
       },
       "ceeIm1213": {
         "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceeIm1222": {
         "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceeIm1232": {
         "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceeIm1233": {
         "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "4 i (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceeIm1313": {
         "real": true,
@@ -2492,19 +2492,19 @@
       },
       "ceeIm1322": {
         "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "4 i (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceeIm1323": {
         "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceeIm1333": {
         "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceeIm2223": {
         "real": true,
-        "tex": "i (\\bar e_2 \\gamma_\\mu e_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar e_2 \\gamma_\\mu e_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceeIm2323": {
         "real": true,
@@ -2512,7 +2512,7 @@
       },
       "ceeIm3323": {
         "real": true,
-        "tex": "i (\\bar e_3 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar e_3 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuRe1111": {
         "real": true,
@@ -2528,39 +2528,39 @@
       },
       "cuuRe1122": {
         "real": true,
-        "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2"
+        "tex": "2 (\\bar u_1 \\gamma_\\mu u_1)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2"
       },
       "cuuRe1133": {
         "real": true,
-        "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
+        "tex": "2 (\\bar u_1 \\gamma_\\mu u_1)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
       },
       "cuuRe2233": {
         "real": true,
-        "tex": "(\\bar u_2 \\gamma_\\mu u_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
+        "tex": "2 (\\bar u_2 \\gamma_\\mu u_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
       },
       "cuuRe1221": {
         "real": true,
-        "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2"
+        "tex": "2 (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2"
       },
       "cuuRe1331": {
         "real": true,
-        "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2"
+        "tex": "2 (\\bar u_1 \\gamma_\\mu u_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2"
       },
       "cuuRe2332": {
         "real": true,
-        "tex": "(\\bar u_2 \\gamma_\\mu u_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2"
+        "tex": "2 (\\bar u_2 \\gamma_\\mu u_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2"
       },
       "cuuRe1112": {
         "real": true,
-        "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar u_1 \\gamma_\\mu u_1)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuRe1113": {
         "real": true,
-        "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar u_1 \\gamma_\\mu u_1)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuRe1123": {
         "real": true,
-        "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar u_1 \\gamma_\\mu u_1)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuRe1212": {
         "real": true,
@@ -2568,19 +2568,19 @@
       },
       "cuuRe1213": {
         "real": true,
-        "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuRe1222": {
         "real": true,
-        "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuRe1232": {
         "real": true,
-        "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuRe1233": {
         "real": true,
-        "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuRe1313": {
         "real": true,
@@ -2588,19 +2588,19 @@
       },
       "cuuRe1322": {
         "real": true,
-        "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar u_1 \\gamma_\\mu u_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuRe1323": {
         "real": true,
-        "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar u_1 \\gamma_\\mu u_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuRe1333": {
         "real": true,
-        "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar u_1 \\gamma_\\mu u_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuRe2223": {
         "real": true,
-        "tex": "(\\bar u_2 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar u_2 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuRe2323": {
         "real": true,
@@ -2608,31 +2608,31 @@
       },
       "cuuRe3323": {
         "real": true,
-        "tex": "(\\bar u_3 \\gamma_\\mu u_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar u_3 \\gamma_\\mu u_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuRe1231": {
         "real": true,
-        "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuRe1223": {
         "real": true,
-        "tex": "(\\bar u_1 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuRe1332": {
         "real": true,
-        "tex": "(\\bar u_1 \\gamma_\\mu u_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar u_1 \\gamma_\\mu u_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuIm1112": {
         "real": true,
-        "tex": "i (\\bar u_1 \\gamma_\\mu u_1)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar u_1 \\gamma_\\mu u_1)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuIm1113": {
         "real": true,
-        "tex": "i (\\bar u_1 \\gamma_\\mu u_1)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar u_1 \\gamma_\\mu u_1)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuIm1123": {
         "real": true,
-        "tex": "i (\\bar u_1 \\gamma_\\mu u_1)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar u_1 \\gamma_\\mu u_1)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuIm1212": {
         "real": true,
@@ -2640,19 +2640,19 @@
       },
       "cuuIm1213": {
         "real": true,
-        "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuIm1222": {
         "real": true,
-        "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuIm1232": {
         "real": true,
-        "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuIm1233": {
         "real": true,
-        "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuIm1313": {
         "real": true,
@@ -2660,19 +2660,19 @@
       },
       "cuuIm1322": {
         "real": true,
-        "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar u_1 \\gamma_\\mu u_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuIm1323": {
         "real": true,
-        "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar u_1 \\gamma_\\mu u_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuIm1333": {
         "real": true,
-        "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar u_1 \\gamma_\\mu u_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuIm2223": {
         "real": true,
-        "tex": "i (\\bar u_2 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar u_2 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuIm2323": {
         "real": true,
@@ -2680,19 +2680,19 @@
       },
       "cuuIm3323": {
         "real": true,
-        "tex": "i (\\bar u_3 \\gamma_\\mu u_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar u_3 \\gamma_\\mu u_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuIm1231": {
         "real": true,
-        "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuIm1223": {
         "real": true,
-        "tex": "i (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar u_1 \\gamma_\\mu u_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuuIm1332": {
         "real": true,
-        "tex": "i (\\bar u_1 \\gamma_\\mu u_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar u_1 \\gamma_\\mu u_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddRe1111": {
         "real": true,
@@ -2708,39 +2708,39 @@
       },
       "cddRe1122": {
         "real": true,
-        "tex": "(\\bar d_1 \\gamma_\\mu d_1)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
+        "tex": "2 (\\bar d_1 \\gamma_\\mu d_1)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2"
       },
       "cddRe1133": {
         "real": true,
-        "tex": "(\\bar d_1 \\gamma_\\mu d_1)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
+        "tex": "2 (\\bar d_1 \\gamma_\\mu d_1)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
       },
       "cddRe2233": {
         "real": true,
-        "tex": "(\\bar d_2 \\gamma_\\mu d_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
+        "tex": "2 (\\bar d_2 \\gamma_\\mu d_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
       },
       "cddRe1221": {
         "real": true,
-        "tex": "(\\bar d_1 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2"
+        "tex": "2 (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2"
       },
       "cddRe1331": {
         "real": true,
-        "tex": "(\\bar d_1 \\gamma_\\mu d_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2"
+        "tex": "2 (\\bar d_1 \\gamma_\\mu d_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2"
       },
       "cddRe2332": {
         "real": true,
-        "tex": "(\\bar d_2 \\gamma_\\mu d_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2"
+        "tex": "2 (\\bar d_2 \\gamma_\\mu d_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2"
       },
       "cddRe1112": {
         "real": true,
-        "tex": "(\\bar d_1 \\gamma_\\mu d_1)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar d_1 \\gamma_\\mu d_1)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddRe1113": {
         "real": true,
-        "tex": "(\\bar d_1 \\gamma_\\mu d_1)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar d_1 \\gamma_\\mu d_1)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddRe1123": {
         "real": true,
-        "tex": "(\\bar d_1 \\gamma_\\mu d_1)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar d_1 \\gamma_\\mu d_1)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddRe1212": {
         "real": true,
@@ -2748,19 +2748,19 @@
       },
       "cddRe1213": {
         "real": true,
-        "tex": "(\\bar d_1 \\gamma_\\mu d_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddRe1222": {
         "real": true,
-        "tex": "(\\bar d_1 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddRe1232": {
         "real": true,
-        "tex": "(\\bar d_1 \\gamma_\\mu d_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddRe1233": {
         "real": true,
-        "tex": "(\\bar d_1 \\gamma_\\mu d_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddRe1313": {
         "real": true,
@@ -2768,19 +2768,19 @@
       },
       "cddRe1322": {
         "real": true,
-        "tex": "(\\bar d_1 \\gamma_\\mu d_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar d_1 \\gamma_\\mu d_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddRe1323": {
         "real": true,
-        "tex": "(\\bar d_1 \\gamma_\\mu d_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar d_1 \\gamma_\\mu d_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddRe1333": {
         "real": true,
-        "tex": "(\\bar d_1 \\gamma_\\mu d_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar d_1 \\gamma_\\mu d_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddRe2223": {
         "real": true,
-        "tex": "(\\bar d_2 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar d_2 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddRe2323": {
         "real": true,
@@ -2788,31 +2788,31 @@
       },
       "cddRe3323": {
         "real": true,
-        "tex": "(\\bar d_3 \\gamma_\\mu d_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar d_3 \\gamma_\\mu d_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddRe1231": {
         "real": true,
-        "tex": "(\\bar d_1 \\gamma_\\mu d_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddRe1223": {
         "real": true,
-        "tex": "(\\bar d_1 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddRe1332": {
         "real": true,
-        "tex": "(\\bar d_1 \\gamma_\\mu d_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar d_1 \\gamma_\\mu d_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddIm1112": {
         "real": true,
-        "tex": "i (\\bar d_1 \\gamma_\\mu d_1)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar d_1 \\gamma_\\mu d_1)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddIm1113": {
         "real": true,
-        "tex": "i (\\bar d_1 \\gamma_\\mu d_1)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar d_1 \\gamma_\\mu d_1)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddIm1123": {
         "real": true,
-        "tex": "i (\\bar d_1 \\gamma_\\mu d_1)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar d_1 \\gamma_\\mu d_1)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddIm1212": {
         "real": true,
@@ -2820,19 +2820,19 @@
       },
       "cddIm1213": {
         "real": true,
-        "tex": "i (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddIm1222": {
         "real": true,
-        "tex": "i (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddIm1232": {
         "real": true,
-        "tex": "i (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddIm1233": {
         "real": true,
-        "tex": "i (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddIm1313": {
         "real": true,
@@ -2840,19 +2840,19 @@
       },
       "cddIm1322": {
         "real": true,
-        "tex": "i (\\bar d_1 \\gamma_\\mu d_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar d_1 \\gamma_\\mu d_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddIm1323": {
         "real": true,
-        "tex": "i (\\bar d_1 \\gamma_\\mu d_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar d_1 \\gamma_\\mu d_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddIm1333": {
         "real": true,
-        "tex": "i (\\bar d_1 \\gamma_\\mu d_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar d_1 \\gamma_\\mu d_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddIm2223": {
         "real": true,
-        "tex": "i (\\bar d_2 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar d_2 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddIm2323": {
         "real": true,
@@ -2860,19 +2860,19 @@
       },
       "cddIm3323": {
         "real": true,
-        "tex": "i (\\bar d_3 \\gamma_\\mu d_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar d_3 \\gamma_\\mu d_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddIm1231": {
         "real": true,
-        "tex": "i (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddIm1223": {
         "real": true,
-        "tex": "i (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar d_1 \\gamma_\\mu d_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cddIm1332": {
         "real": true,
-        "tex": "i (\\bar d_1 \\gamma_\\mu d_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar d_1 \\gamma_\\mu d_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceuRe1111": {
         "real": true,

--- a/smeft.smeftsim-general.basis.yml
+++ b/smeft.smeftsim-general.basis.yml
@@ -1,8 +1,9 @@
 eft: SMEFT
 basis: SMEFTsim_general
 metadata:
-  description: >
-    Basis used in the `SMEFTsim_general` UFO models, version 3.0.0 or later. Implements Warsaw basis with generic flavor indices for all fermions. $q,u,d$ are the left- and right-handed quark fields. $\ell, e$ are left- and right-handed lepton fields. Quark fields are in the up-aligned basis. This basis definition corresponds to a fixed `LambdaSMEFT=1e+3` in the UFO models. Notation and conventions can vary compared to the Warsaw basis paper, see [arXiv:2012.11343](https://arxiv.org/abs/2012.11343) for all definitions.
+  description: 'Basis used in the `SMEFTsim_general` UFO models, version 3.0.0 or later. Implements Warsaw basis with generic flavor indices for all fermions. $q,u,d$ are the left- and right-handed quark fields. $\ell, e$ are left- and right-handed lepton fields. Quark fields are in the up-aligned basis. This basis definition corresponds to a fixed `LambdaSMEFT=1e+3` in the UFO models. Notation and conventions can vary compared to the Warsaw basis paper, see [arXiv:2012.11343](https://arxiv.org/abs/2012.11343) for all definitions.
+
+    '
 sectors:
   dB=dL=0:
     cG:

--- a/smeft.smeftsim-general.basis.yml
+++ b/smeft.smeftsim-general.basis.yml
@@ -899,130 +899,130 @@ sectors:
       tex: (\bar \ell_3 \gamma_\mu \ell_3)(\bar \ell_3 \gamma^\mu \ell_3) / \text{TeV}^2
     cllRe1122:
       real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_1)(\bar \ell_2 \gamma^\mu \ell_2) / \text{TeV}^2
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_1)(\bar \ell_2 \gamma^\mu \ell_2) / \text{TeV}^2
     cllRe1133:
       real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_1)(\bar \ell_3 \gamma^\mu \ell_3) / \text{TeV}^2
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_1)(\bar \ell_3 \gamma^\mu \ell_3) / \text{TeV}^2
     cllRe2233:
       real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_2)(\bar \ell_3 \gamma^\mu \ell_3) / \text{TeV}^2
+      tex: 2 (\bar \ell_2 \gamma_\mu \ell_2)(\bar \ell_3 \gamma^\mu \ell_3) / \text{TeV}^2
     cllRe1221:
       real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_2 \gamma^\mu \ell_1) / \text{TeV}^2
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_2 \gamma^\mu \ell_1) / \text{TeV}^2
     cllRe1331:
       real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_3 \gamma^\mu \ell_1) / \text{TeV}^2
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_3 \gamma^\mu \ell_1) / \text{TeV}^2
     cllRe2332:
       real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar \ell_3 \gamma^\mu \ell_2) / \text{TeV}^2
+      tex: 2 (\bar \ell_2 \gamma_\mu \ell_3)(\bar \ell_3 \gamma^\mu \ell_2) / \text{TeV}^2
     cllRe1112:
       real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_1)(\bar \ell_1 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_1)(\bar \ell_1 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
     cllRe1113:
       real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_1)(\bar \ell_1 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_1)(\bar \ell_1 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
     cllRe1123:
       real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_1)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_1)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
     cllRe1212:
       real: true
       tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_1 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
     cllRe1213:
       real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_1 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_1 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
     cllRe1222:
       real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_2 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_2 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
     cllRe1232:
       real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_3 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_3 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
     cllRe1233:
       real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_3 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_3 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
     cllRe1313:
       real: true
       tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_1 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
     cllRe1322:
       real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
     cllRe1323:
       real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
     cllRe1333:
       real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_3 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_3 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
     cllRe2223:
       real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_2)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar \ell_2 \gamma_\mu \ell_2)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
     cllRe2323:
       real: true
       tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
     cllRe3323:
       real: true
-      tex: (\bar \ell_3 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar \ell_3 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
     cllRe1231:
       real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_3 \gamma^\mu \ell_1) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_3 \gamma^\mu \ell_1) / \text{TeV}^2 + \text{h.c.}
     cllRe1223:
       real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
     cllRe1332:
       real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_3 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_3 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
     cllIm1112:
       real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_1)(\bar \ell_1 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_1)(\bar \ell_1 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
     cllIm1113:
       real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_1)(\bar \ell_1 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_1)(\bar \ell_1 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
     cllIm1123:
       real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_1)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_1)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
     cllIm1212:
       real: true
       tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_1 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
     cllIm1213:
       real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_1 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_1 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
     cllIm1222:
       real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_2 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_2 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
     cllIm1232:
       real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_3 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_3 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
     cllIm1233:
       real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_3 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_3 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
     cllIm1313:
       real: true
       tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_1 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
     cllIm1322:
       real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
     cllIm1323:
       real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
     cllIm1333:
       real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_3 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_3 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
     cllIm2223:
       real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_2)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar \ell_2 \gamma_\mu \ell_2)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
     cllIm2323:
       real: true
       tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
     cllIm3323:
       real: true
-      tex: i (\bar \ell_3 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar \ell_3 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
     cllIm1231:
       real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_3 \gamma^\mu \ell_1) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_3 \gamma^\mu \ell_1) / \text{TeV}^2 + \text{h.c.}
     cllIm1223:
       real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
     cllIm1332:
       real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_3 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_3 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
     clq1Re1111:
       real: true
       tex: (\bar \ell_1 \gamma_\mu \ell_1)(\bar q_1 \gamma^\mu q_1) / \text{TeV}^2
@@ -1520,130 +1520,130 @@ sectors:
       tex: (\bar q_3 \gamma_\mu q_3)(\bar q_3 \gamma^\mu q_3) / \text{TeV}^2
     cqq1Re1122:
       real: true
-      tex: (\bar q_1 \gamma_\mu q_1)(\bar q_2 \gamma^\mu q_2) / \text{TeV}^2
+      tex: 2 (\bar q_1 \gamma_\mu q_1)(\bar q_2 \gamma^\mu q_2) / \text{TeV}^2
     cqq1Re1133:
       real: true
-      tex: (\bar q_1 \gamma_\mu q_1)(\bar q_3 \gamma^\mu q_3) / \text{TeV}^2
+      tex: 2 (\bar q_1 \gamma_\mu q_1)(\bar q_3 \gamma^\mu q_3) / \text{TeV}^2
     cqq1Re2233:
       real: true
-      tex: (\bar q_2 \gamma_\mu q_2)(\bar q_3 \gamma^\mu q_3) / \text{TeV}^2
+      tex: 2 (\bar q_2 \gamma_\mu q_2)(\bar q_3 \gamma^\mu q_3) / \text{TeV}^2
     cqq1Re1221:
       real: true
-      tex: (\bar q_1 \gamma_\mu q_2)(\bar q_2 \gamma^\mu q_1) / \text{TeV}^2
+      tex: 2 (\bar q_1 \gamma_\mu q_2)(\bar q_2 \gamma^\mu q_1) / \text{TeV}^2
     cqq1Re1331:
       real: true
-      tex: (\bar q_1 \gamma_\mu q_3)(\bar q_3 \gamma^\mu q_1) / \text{TeV}^2
+      tex: 2 (\bar q_1 \gamma_\mu q_3)(\bar q_3 \gamma^\mu q_1) / \text{TeV}^2
     cqq1Re2332:
       real: true
-      tex: (\bar q_2 \gamma_\mu q_3)(\bar q_3 \gamma^\mu q_2) / \text{TeV}^2
+      tex: 2 (\bar q_2 \gamma_\mu q_3)(\bar q_3 \gamma^\mu q_2) / \text{TeV}^2
     cqq1Re1112:
       real: true
-      tex: (\bar q_1 \gamma_\mu q_1)(\bar q_1 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_1 \gamma_\mu q_1)(\bar q_1 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
     cqq1Re1113:
       real: true
-      tex: (\bar q_1 \gamma_\mu q_1)(\bar q_1 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_1 \gamma_\mu q_1)(\bar q_1 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
     cqq1Re1123:
       real: true
-      tex: (\bar q_1 \gamma_\mu q_1)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_1 \gamma_\mu q_1)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
     cqq1Re1212:
       real: true
       tex: (\bar q_1 \gamma_\mu q_2)(\bar q_1 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
     cqq1Re1213:
       real: true
-      tex: (\bar q_1 \gamma_\mu q_2)(\bar q_1 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_1 \gamma_\mu q_2)(\bar q_1 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
     cqq1Re1222:
       real: true
-      tex: (\bar q_1 \gamma_\mu q_2)(\bar q_2 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_1 \gamma_\mu q_2)(\bar q_2 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
     cqq1Re1232:
       real: true
-      tex: (\bar q_1 \gamma_\mu q_2)(\bar q_3 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_1 \gamma_\mu q_2)(\bar q_3 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
     cqq1Re1233:
       real: true
-      tex: (\bar q_1 \gamma_\mu q_2)(\bar q_3 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_1 \gamma_\mu q_2)(\bar q_3 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
     cqq1Re1313:
       real: true
       tex: (\bar q_1 \gamma_\mu q_3)(\bar q_1 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
     cqq1Re1322:
       real: true
-      tex: (\bar q_1 \gamma_\mu q_3)(\bar q_2 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_1 \gamma_\mu q_3)(\bar q_2 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
     cqq1Re1323:
       real: true
-      tex: (\bar q_1 \gamma_\mu q_3)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_1 \gamma_\mu q_3)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
     cqq1Re1333:
       real: true
-      tex: (\bar q_1 \gamma_\mu q_3)(\bar q_3 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_1 \gamma_\mu q_3)(\bar q_3 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
     cqq1Re2223:
       real: true
-      tex: (\bar q_2 \gamma_\mu q_2)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_2 \gamma_\mu q_2)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
     cqq1Re2323:
       real: true
       tex: (\bar q_2 \gamma_\mu q_3)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
     cqq1Re3323:
       real: true
-      tex: (\bar q_3 \gamma_\mu q_3)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_3 \gamma_\mu q_3)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
     cqq1Re1231:
       real: true
-      tex: (\bar q_1 \gamma_\mu q_2)(\bar q_3 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_1 \gamma_\mu q_2)(\bar q_3 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
     cqq1Re1223:
       real: true
-      tex: (\bar q_1 \gamma_\mu q_2)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_1 \gamma_\mu q_2)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
     cqq1Re1332:
       real: true
-      tex: (\bar q_1 \gamma_\mu q_3)(\bar q_3 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_1 \gamma_\mu q_3)(\bar q_3 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
     cqq1Im1112:
       real: true
-      tex: i (\bar q_1 \gamma_\mu q_1)(\bar q_1 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_1 \gamma_\mu q_1)(\bar q_1 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
     cqq1Im1113:
       real: true
-      tex: i (\bar q_1 \gamma_\mu q_1)(\bar q_1 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_1 \gamma_\mu q_1)(\bar q_1 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
     cqq1Im1123:
       real: true
-      tex: i (\bar q_1 \gamma_\mu q_1)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_1 \gamma_\mu q_1)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
     cqq1Im1212:
       real: true
       tex: i (\bar q_1 \gamma_\mu q_2)(\bar q_1 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
     cqq1Im1213:
       real: true
-      tex: i (\bar q_1 \gamma_\mu q_2)(\bar q_1 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_1 \gamma_\mu q_2)(\bar q_1 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
     cqq1Im1222:
       real: true
-      tex: i (\bar q_1 \gamma_\mu q_2)(\bar q_2 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_1 \gamma_\mu q_2)(\bar q_2 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
     cqq1Im1232:
       real: true
-      tex: i (\bar q_1 \gamma_\mu q_2)(\bar q_3 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_1 \gamma_\mu q_2)(\bar q_3 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
     cqq1Im1233:
       real: true
-      tex: i (\bar q_1 \gamma_\mu q_2)(\bar q_3 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_1 \gamma_\mu q_2)(\bar q_3 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
     cqq1Im1313:
       real: true
       tex: i (\bar q_1 \gamma_\mu q_3)(\bar q_1 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
     cqq1Im1322:
       real: true
-      tex: i (\bar q_1 \gamma_\mu q_3)(\bar q_2 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_1 \gamma_\mu q_3)(\bar q_2 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
     cqq1Im1323:
       real: true
-      tex: i (\bar q_1 \gamma_\mu q_3)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_1 \gamma_\mu q_3)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
     cqq1Im1333:
       real: true
-      tex: i (\bar q_1 \gamma_\mu q_3)(\bar q_3 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_1 \gamma_\mu q_3)(\bar q_3 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
     cqq1Im2223:
       real: true
-      tex: i (\bar q_2 \gamma_\mu q_2)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_2 \gamma_\mu q_2)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
     cqq1Im2323:
       real: true
       tex: i (\bar q_2 \gamma_\mu q_3)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
     cqq1Im3323:
       real: true
-      tex: i (\bar q_3 \gamma_\mu q_3)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_3 \gamma_\mu q_3)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
     cqq1Im1231:
       real: true
-      tex: i (\bar q_1 \gamma_\mu q_2)(\bar q_3 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_1 \gamma_\mu q_2)(\bar q_3 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
     cqq1Im1223:
       real: true
-      tex: i (\bar q_1 \gamma_\mu q_2)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_1 \gamma_\mu q_2)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
     cqq1Im1332:
       real: true
-      tex: i (\bar q_1 \gamma_\mu q_3)(\bar q_3 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_1 \gamma_\mu q_3)(\bar q_3 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
     cqq3Re1111:
       real: true
       tex: (\bar q_1 \gamma_\mu \sigma^I q_1)(\bar q_1 \gamma^\mu \sigma^I q_1) / \text{TeV}^2
@@ -1655,130 +1655,130 @@ sectors:
       tex: (\bar q_3 \gamma_\mu \sigma^I q_3)(\bar q_3 \gamma^\mu \sigma^I q_3) / \text{TeV}^2
     cqq3Re1122:
       real: true
-      tex: (\bar q_1 \gamma_\mu \sigma^I q_1)(\bar q_2 \gamma^\mu \sigma^I q_2) / \text{TeV}^2
+      tex: 2 (\bar q_1 \gamma_\mu \sigma^I q_1)(\bar q_2 \gamma^\mu \sigma^I q_2) / \text{TeV}^2
     cqq3Re1133:
       real: true
-      tex: (\bar q_1 \gamma_\mu \sigma^I q_1)(\bar q_3 \gamma^\mu \sigma^I q_3) / \text{TeV}^2
+      tex: 2 (\bar q_1 \gamma_\mu \sigma^I q_1)(\bar q_3 \gamma^\mu \sigma^I q_3) / \text{TeV}^2
     cqq3Re2233:
       real: true
-      tex: (\bar q_2 \gamma_\mu \sigma^I q_2)(\bar q_3 \gamma^\mu \sigma^I q_3) / \text{TeV}^2
+      tex: 2 (\bar q_2 \gamma_\mu \sigma^I q_2)(\bar q_3 \gamma^\mu \sigma^I q_3) / \text{TeV}^2
     cqq3Re1221:
       real: true
-      tex: (\bar q_1 \gamma_\mu \sigma^I q_2)(\bar q_2 \gamma^\mu \sigma^I q_1) / \text{TeV}^2
+      tex: 2 (\bar q_1 \gamma_\mu \sigma^I q_2)(\bar q_2 \gamma^\mu \sigma^I q_1) / \text{TeV}^2
     cqq3Re1331:
       real: true
-      tex: (\bar q_1 \gamma_\mu \sigma^I q_3)(\bar q_3 \gamma^\mu \sigma^I q_1) / \text{TeV}^2
+      tex: 2 (\bar q_1 \gamma_\mu \sigma^I q_3)(\bar q_3 \gamma^\mu \sigma^I q_1) / \text{TeV}^2
     cqq3Re2332:
       real: true
-      tex: (\bar q_2 \gamma_\mu \sigma^I q_3)(\bar q_3 \gamma^\mu \sigma^I q_2) / \text{TeV}^2
+      tex: 2 (\bar q_2 \gamma_\mu \sigma^I q_3)(\bar q_3 \gamma^\mu \sigma^I q_2) / \text{TeV}^2
     cqq3Re1112:
       real: true
-      tex: (\bar q_1 \gamma_\mu \sigma^I q_1)(\bar q_1 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_1 \gamma_\mu \sigma^I q_1)(\bar q_1 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
     cqq3Re1113:
       real: true
-      tex: (\bar q_1 \gamma_\mu \sigma^I q_1)(\bar q_1 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_1 \gamma_\mu \sigma^I q_1)(\bar q_1 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
     cqq3Re1123:
       real: true
-      tex: (\bar q_1 \gamma_\mu \sigma^I q_1)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_1 \gamma_\mu \sigma^I q_1)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
     cqq3Re1212:
       real: true
       tex: (\bar q_1 \gamma_\mu \sigma^I q_2)(\bar q_1 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
     cqq3Re1213:
       real: true
-      tex: (\bar q_1 \gamma_\mu \sigma^I q_2)(\bar q_1 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_1 \gamma_\mu \sigma^I q_2)(\bar q_1 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
     cqq3Re1222:
       real: true
-      tex: (\bar q_1 \gamma_\mu \sigma^I q_2)(\bar q_2 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_1 \gamma_\mu \sigma^I q_2)(\bar q_2 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
     cqq3Re1232:
       real: true
-      tex: (\bar q_1 \gamma_\mu \sigma^I q_2)(\bar q_3 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_1 \gamma_\mu \sigma^I q_2)(\bar q_3 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
     cqq3Re1233:
       real: true
-      tex: (\bar q_1 \gamma_\mu \sigma^I q_2)(\bar q_3 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_1 \gamma_\mu \sigma^I q_2)(\bar q_3 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
     cqq3Re1313:
       real: true
       tex: (\bar q_1 \gamma_\mu \sigma^I q_3)(\bar q_1 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
     cqq3Re1322:
       real: true
-      tex: (\bar q_1 \gamma_\mu \sigma^I q_3)(\bar q_2 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_1 \gamma_\mu \sigma^I q_3)(\bar q_2 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
     cqq3Re1323:
       real: true
-      tex: (\bar q_1 \gamma_\mu \sigma^I q_3)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_1 \gamma_\mu \sigma^I q_3)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
     cqq3Re1333:
       real: true
-      tex: (\bar q_1 \gamma_\mu \sigma^I q_3)(\bar q_3 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_1 \gamma_\mu \sigma^I q_3)(\bar q_3 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
     cqq3Re2223:
       real: true
-      tex: (\bar q_2 \gamma_\mu \sigma^I q_2)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_2 \gamma_\mu \sigma^I q_2)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
     cqq3Re2323:
       real: true
       tex: (\bar q_2 \gamma_\mu \sigma^I q_3)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
     cqq3Re3323:
       real: true
-      tex: (\bar q_3 \gamma_\mu \sigma^I q_3)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_3 \gamma_\mu \sigma^I q_3)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
     cqq3Re1231:
       real: true
-      tex: (\bar q_1 \gamma_\mu \sigma^I q_2)(\bar q_3 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_1 \gamma_\mu \sigma^I q_2)(\bar q_3 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
     cqq3Re1223:
       real: true
-      tex: (\bar q_1 \gamma_\mu \sigma^I q_2)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_1 \gamma_\mu \sigma^I q_2)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
     cqq3Re1332:
       real: true
-      tex: (\bar q_1 \gamma_\mu \sigma^I q_3)(\bar q_3 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar q_1 \gamma_\mu \sigma^I q_3)(\bar q_3 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
     cqq3Im1112:
       real: true
-      tex: i (\bar q_1 \gamma_\mu \sigma^I q_1)(\bar q_1 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_1 \gamma_\mu \sigma^I q_1)(\bar q_1 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
     cqq3Im1113:
       real: true
-      tex: i (\bar q_1 \gamma_\mu \sigma^I q_1)(\bar q_1 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_1 \gamma_\mu \sigma^I q_1)(\bar q_1 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
     cqq3Im1123:
       real: true
-      tex: i (\bar q_1 \gamma_\mu \sigma^I q_1)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_1 \gamma_\mu \sigma^I q_1)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
     cqq3Im1212:
       real: true
       tex: i (\bar q_1 \gamma_\mu \sigma^I q_2)(\bar q_1 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
     cqq3Im1213:
       real: true
-      tex: i (\bar q_1 \gamma_\mu \sigma^I q_2)(\bar q_1 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_1 \gamma_\mu \sigma^I q_2)(\bar q_1 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
     cqq3Im1222:
       real: true
-      tex: i (\bar q_1 \gamma_\mu \sigma^I q_2)(\bar q_2 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_1 \gamma_\mu \sigma^I q_2)(\bar q_2 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
     cqq3Im1232:
       real: true
-      tex: i (\bar q_1 \gamma_\mu \sigma^I q_2)(\bar q_3 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_1 \gamma_\mu \sigma^I q_2)(\bar q_3 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
     cqq3Im1233:
       real: true
-      tex: i (\bar q_1 \gamma_\mu \sigma^I q_2)(\bar q_3 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_1 \gamma_\mu \sigma^I q_2)(\bar q_3 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
     cqq3Im1313:
       real: true
       tex: i (\bar q_1 \gamma_\mu \sigma^I q_3)(\bar q_1 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
     cqq3Im1322:
       real: true
-      tex: i (\bar q_1 \gamma_\mu \sigma^I q_3)(\bar q_2 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_1 \gamma_\mu \sigma^I q_3)(\bar q_2 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
     cqq3Im1323:
       real: true
-      tex: i (\bar q_1 \gamma_\mu \sigma^I q_3)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_1 \gamma_\mu \sigma^I q_3)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
     cqq3Im1333:
       real: true
-      tex: i (\bar q_1 \gamma_\mu \sigma^I q_3)(\bar q_3 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_1 \gamma_\mu \sigma^I q_3)(\bar q_3 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
     cqq3Im2223:
       real: true
-      tex: i (\bar q_2 \gamma_\mu \sigma^I q_2)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_2 \gamma_\mu \sigma^I q_2)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
     cqq3Im2323:
       real: true
       tex: i (\bar q_2 \gamma_\mu \sigma^I q_3)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
     cqq3Im3323:
       real: true
-      tex: i (\bar q_3 \gamma_\mu \sigma^I q_3)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_3 \gamma_\mu \sigma^I q_3)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
     cqq3Im1231:
       real: true
-      tex: i (\bar q_1 \gamma_\mu \sigma^I q_2)(\bar q_3 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_1 \gamma_\mu \sigma^I q_2)(\bar q_3 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
     cqq3Im1223:
       real: true
-      tex: i (\bar q_1 \gamma_\mu \sigma^I q_2)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_1 \gamma_\mu \sigma^I q_2)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
     cqq3Im1332:
       real: true
-      tex: i (\bar q_1 \gamma_\mu \sigma^I q_3)(\bar q_3 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar q_1 \gamma_\mu \sigma^I q_3)(\bar q_3 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
     ceeRe1111:
       real: true
       tex: (\bar e_1 \gamma_\mu e_1)(\bar e_1 \gamma^\mu e_1) / \text{TeV}^2
@@ -1790,103 +1790,103 @@ sectors:
       tex: (\bar e_3 \gamma_\mu e_3)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2
     ceeRe1122:
       real: true
-      tex: (\bar e_1 \gamma_\mu e_1)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2
+      tex: 4 (\bar e_1 \gamma_\mu e_1)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2
     ceeRe1133:
       real: true
-      tex: (\bar e_1 \gamma_\mu e_1)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2
+      tex: 4 (\bar e_1 \gamma_\mu e_1)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2
     ceeRe2233:
       real: true
-      tex: (\bar e_2 \gamma_\mu e_2)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2
+      tex: 4 (\bar e_2 \gamma_\mu e_2)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2
     ceeRe1112:
       real: true
-      tex: (\bar e_1 \gamma_\mu e_1)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar e_1 \gamma_\mu e_1)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
     ceeRe1113:
       real: true
-      tex: (\bar e_1 \gamma_\mu e_1)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar e_1 \gamma_\mu e_1)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     ceeRe1123:
       real: true
-      tex: (\bar e_1 \gamma_\mu e_1)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 4 (\bar e_1 \gamma_\mu e_1)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     ceeRe1212:
       real: true
       tex: (\bar e_1 \gamma_\mu e_2)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
     ceeRe1213:
       real: true
-      tex: (\bar e_1 \gamma_\mu e_2)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar e_1 \gamma_\mu e_2)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     ceeRe1222:
       real: true
-      tex: (\bar e_1 \gamma_\mu e_2)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar e_1 \gamma_\mu e_2)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
     ceeRe1232:
       real: true
-      tex: (\bar e_1 \gamma_\mu e_2)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar e_1 \gamma_\mu e_2)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
     ceeRe1233:
       real: true
-      tex: (\bar e_1 \gamma_\mu e_2)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 4 (\bar e_1 \gamma_\mu e_2)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     ceeRe1313:
       real: true
       tex: (\bar e_1 \gamma_\mu e_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     ceeRe1322:
       real: true
-      tex: (\bar e_1 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 4 (\bar e_1 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
     ceeRe1323:
       real: true
-      tex: (\bar e_1 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar e_1 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     ceeRe1333:
       real: true
-      tex: (\bar e_1 \gamma_\mu e_3)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar e_1 \gamma_\mu e_3)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     ceeRe2223:
       real: true
-      tex: (\bar e_2 \gamma_\mu e_2)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar e_2 \gamma_\mu e_2)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     ceeRe2323:
       real: true
       tex: (\bar e_2 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     ceeRe3323:
       real: true
-      tex: (\bar e_3 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar e_3 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     ceeIm1112:
       real: true
-      tex: i (\bar e_1 \gamma_\mu e_1)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar e_1 \gamma_\mu e_1)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
     ceeIm1113:
       real: true
-      tex: i (\bar e_1 \gamma_\mu e_1)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar e_1 \gamma_\mu e_1)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     ceeIm1123:
       real: true
-      tex: i (\bar e_1 \gamma_\mu e_1)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 4 i (\bar e_1 \gamma_\mu e_1)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     ceeIm1212:
       real: true
       tex: i (\bar e_1 \gamma_\mu e_2)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
     ceeIm1213:
       real: true
-      tex: i (\bar e_1 \gamma_\mu e_2)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar e_1 \gamma_\mu e_2)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     ceeIm1222:
       real: true
-      tex: i (\bar e_1 \gamma_\mu e_2)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar e_1 \gamma_\mu e_2)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
     ceeIm1232:
       real: true
-      tex: i (\bar e_1 \gamma_\mu e_2)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar e_1 \gamma_\mu e_2)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
     ceeIm1233:
       real: true
-      tex: i (\bar e_1 \gamma_\mu e_2)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 4 i (\bar e_1 \gamma_\mu e_2)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     ceeIm1313:
       real: true
       tex: i (\bar e_1 \gamma_\mu e_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     ceeIm1322:
       real: true
-      tex: i (\bar e_1 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 4 i (\bar e_1 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
     ceeIm1323:
       real: true
-      tex: i (\bar e_1 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar e_1 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     ceeIm1333:
       real: true
-      tex: i (\bar e_1 \gamma_\mu e_3)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar e_1 \gamma_\mu e_3)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     ceeIm2223:
       real: true
-      tex: i (\bar e_2 \gamma_\mu e_2)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar e_2 \gamma_\mu e_2)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     ceeIm2323:
       real: true
       tex: i (\bar e_2 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     ceeIm3323:
       real: true
-      tex: i (\bar e_3 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar e_3 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     cuuRe1111:
       real: true
       tex: (\bar u_1 \gamma_\mu u_1)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2
@@ -1898,130 +1898,130 @@ sectors:
       tex: (\bar u_3 \gamma_\mu u_3)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2
     cuuRe1122:
       real: true
-      tex: (\bar u_1 \gamma_\mu u_1)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2
+      tex: 2 (\bar u_1 \gamma_\mu u_1)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2
     cuuRe1133:
       real: true
-      tex: (\bar u_1 \gamma_\mu u_1)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2
+      tex: 2 (\bar u_1 \gamma_\mu u_1)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2
     cuuRe2233:
       real: true
-      tex: (\bar u_2 \gamma_\mu u_2)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2
+      tex: 2 (\bar u_2 \gamma_\mu u_2)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2
     cuuRe1221:
       real: true
-      tex: (\bar u_1 \gamma_\mu u_2)(\bar u_2 \gamma^\mu u_1) / \text{TeV}^2
+      tex: 2 (\bar u_1 \gamma_\mu u_2)(\bar u_2 \gamma^\mu u_1) / \text{TeV}^2
     cuuRe1331:
       real: true
-      tex: (\bar u_1 \gamma_\mu u_3)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2
+      tex: 2 (\bar u_1 \gamma_\mu u_3)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2
     cuuRe2332:
       real: true
-      tex: (\bar u_2 \gamma_\mu u_3)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2
+      tex: 2 (\bar u_2 \gamma_\mu u_3)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2
     cuuRe1112:
       real: true
-      tex: (\bar u_1 \gamma_\mu u_1)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar u_1 \gamma_\mu u_1)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
     cuuRe1113:
       real: true
-      tex: (\bar u_1 \gamma_\mu u_1)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar u_1 \gamma_\mu u_1)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     cuuRe1123:
       real: true
-      tex: (\bar u_1 \gamma_\mu u_1)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar u_1 \gamma_\mu u_1)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     cuuRe1212:
       real: true
       tex: (\bar u_1 \gamma_\mu u_2)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
     cuuRe1213:
       real: true
-      tex: (\bar u_1 \gamma_\mu u_2)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar u_1 \gamma_\mu u_2)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     cuuRe1222:
       real: true
-      tex: (\bar u_1 \gamma_\mu u_2)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar u_1 \gamma_\mu u_2)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
     cuuRe1232:
       real: true
-      tex: (\bar u_1 \gamma_\mu u_2)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar u_1 \gamma_\mu u_2)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
     cuuRe1233:
       real: true
-      tex: (\bar u_1 \gamma_\mu u_2)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar u_1 \gamma_\mu u_2)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     cuuRe1313:
       real: true
       tex: (\bar u_1 \gamma_\mu u_3)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     cuuRe1322:
       real: true
-      tex: (\bar u_1 \gamma_\mu u_3)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar u_1 \gamma_\mu u_3)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
     cuuRe1323:
       real: true
-      tex: (\bar u_1 \gamma_\mu u_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar u_1 \gamma_\mu u_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     cuuRe1333:
       real: true
-      tex: (\bar u_1 \gamma_\mu u_3)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar u_1 \gamma_\mu u_3)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     cuuRe2223:
       real: true
-      tex: (\bar u_2 \gamma_\mu u_2)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar u_2 \gamma_\mu u_2)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     cuuRe2323:
       real: true
       tex: (\bar u_2 \gamma_\mu u_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     cuuRe3323:
       real: true
-      tex: (\bar u_3 \gamma_\mu u_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar u_3 \gamma_\mu u_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     cuuRe1231:
       real: true
-      tex: (\bar u_1 \gamma_\mu u_2)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar u_1 \gamma_\mu u_2)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
     cuuRe1223:
       real: true
-      tex: (\bar u_1 \gamma_\mu u_2)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar u_1 \gamma_\mu u_2)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     cuuRe1332:
       real: true
-      tex: (\bar u_1 \gamma_\mu u_3)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar u_1 \gamma_\mu u_3)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
     cuuIm1112:
       real: true
-      tex: i (\bar u_1 \gamma_\mu u_1)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar u_1 \gamma_\mu u_1)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
     cuuIm1113:
       real: true
-      tex: i (\bar u_1 \gamma_\mu u_1)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar u_1 \gamma_\mu u_1)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     cuuIm1123:
       real: true
-      tex: i (\bar u_1 \gamma_\mu u_1)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar u_1 \gamma_\mu u_1)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     cuuIm1212:
       real: true
       tex: i (\bar u_1 \gamma_\mu u_2)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
     cuuIm1213:
       real: true
-      tex: i (\bar u_1 \gamma_\mu u_2)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar u_1 \gamma_\mu u_2)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     cuuIm1222:
       real: true
-      tex: i (\bar u_1 \gamma_\mu u_2)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar u_1 \gamma_\mu u_2)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
     cuuIm1232:
       real: true
-      tex: i (\bar u_1 \gamma_\mu u_2)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar u_1 \gamma_\mu u_2)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
     cuuIm1233:
       real: true
-      tex: i (\bar u_1 \gamma_\mu u_2)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar u_1 \gamma_\mu u_2)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     cuuIm1313:
       real: true
       tex: i (\bar u_1 \gamma_\mu u_3)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     cuuIm1322:
       real: true
-      tex: i (\bar u_1 \gamma_\mu u_3)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar u_1 \gamma_\mu u_3)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
     cuuIm1323:
       real: true
-      tex: i (\bar u_1 \gamma_\mu u_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar u_1 \gamma_\mu u_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     cuuIm1333:
       real: true
-      tex: i (\bar u_1 \gamma_\mu u_3)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar u_1 \gamma_\mu u_3)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     cuuIm2223:
       real: true
-      tex: i (\bar u_2 \gamma_\mu u_2)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar u_2 \gamma_\mu u_2)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     cuuIm2323:
       real: true
       tex: i (\bar u_2 \gamma_\mu u_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     cuuIm3323:
       real: true
-      tex: i (\bar u_3 \gamma_\mu u_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar u_3 \gamma_\mu u_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     cuuIm1231:
       real: true
-      tex: i (\bar u_1 \gamma_\mu u_2)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar u_1 \gamma_\mu u_2)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
     cuuIm1223:
       real: true
-      tex: i (\bar u_1 \gamma_\mu u_2)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar u_1 \gamma_\mu u_2)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     cuuIm1332:
       real: true
-      tex: i (\bar u_1 \gamma_\mu u_3)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar u_1 \gamma_\mu u_3)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
     cddRe1111:
       real: true
       tex: (\bar d_1 \gamma_\mu d_1)(\bar d_1 \gamma^\mu d_1) / \text{TeV}^2
@@ -2033,130 +2033,130 @@ sectors:
       tex: (\bar d_3 \gamma_\mu d_3)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2
     cddRe1122:
       real: true
-      tex: (\bar d_1 \gamma_\mu d_1)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2
+      tex: 2 (\bar d_1 \gamma_\mu d_1)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2
     cddRe1133:
       real: true
-      tex: (\bar d_1 \gamma_\mu d_1)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2
+      tex: 2 (\bar d_1 \gamma_\mu d_1)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2
     cddRe2233:
       real: true
-      tex: (\bar d_2 \gamma_\mu d_2)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2
+      tex: 2 (\bar d_2 \gamma_\mu d_2)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2
     cddRe1221:
       real: true
-      tex: (\bar d_1 \gamma_\mu d_2)(\bar d_2 \gamma^\mu d_1) / \text{TeV}^2
+      tex: 2 (\bar d_1 \gamma_\mu d_2)(\bar d_2 \gamma^\mu d_1) / \text{TeV}^2
     cddRe1331:
       real: true
-      tex: (\bar d_1 \gamma_\mu d_3)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2
+      tex: 2 (\bar d_1 \gamma_\mu d_3)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2
     cddRe2332:
       real: true
-      tex: (\bar d_2 \gamma_\mu d_3)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2
+      tex: 2 (\bar d_2 \gamma_\mu d_3)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2
     cddRe1112:
       real: true
-      tex: (\bar d_1 \gamma_\mu d_1)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar d_1 \gamma_\mu d_1)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
     cddRe1113:
       real: true
-      tex: (\bar d_1 \gamma_\mu d_1)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar d_1 \gamma_\mu d_1)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cddRe1123:
       real: true
-      tex: (\bar d_1 \gamma_\mu d_1)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar d_1 \gamma_\mu d_1)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cddRe1212:
       real: true
       tex: (\bar d_1 \gamma_\mu d_2)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
     cddRe1213:
       real: true
-      tex: (\bar d_1 \gamma_\mu d_2)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar d_1 \gamma_\mu d_2)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cddRe1222:
       real: true
-      tex: (\bar d_1 \gamma_\mu d_2)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar d_1 \gamma_\mu d_2)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
     cddRe1232:
       real: true
-      tex: (\bar d_1 \gamma_\mu d_2)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar d_1 \gamma_\mu d_2)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
     cddRe1233:
       real: true
-      tex: (\bar d_1 \gamma_\mu d_2)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar d_1 \gamma_\mu d_2)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cddRe1313:
       real: true
       tex: (\bar d_1 \gamma_\mu d_3)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cddRe1322:
       real: true
-      tex: (\bar d_1 \gamma_\mu d_3)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar d_1 \gamma_\mu d_3)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
     cddRe1323:
       real: true
-      tex: (\bar d_1 \gamma_\mu d_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar d_1 \gamma_\mu d_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cddRe1333:
       real: true
-      tex: (\bar d_1 \gamma_\mu d_3)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar d_1 \gamma_\mu d_3)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cddRe2223:
       real: true
-      tex: (\bar d_2 \gamma_\mu d_2)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar d_2 \gamma_\mu d_2)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cddRe2323:
       real: true
       tex: (\bar d_2 \gamma_\mu d_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cddRe3323:
       real: true
-      tex: (\bar d_3 \gamma_\mu d_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar d_3 \gamma_\mu d_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cddRe1231:
       real: true
-      tex: (\bar d_1 \gamma_\mu d_2)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar d_1 \gamma_\mu d_2)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
     cddRe1223:
       real: true
-      tex: (\bar d_1 \gamma_\mu d_2)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar d_1 \gamma_\mu d_2)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cddRe1332:
       real: true
-      tex: (\bar d_1 \gamma_\mu d_3)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 (\bar d_1 \gamma_\mu d_3)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
     cddIm1112:
       real: true
-      tex: i (\bar d_1 \gamma_\mu d_1)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar d_1 \gamma_\mu d_1)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
     cddIm1113:
       real: true
-      tex: i (\bar d_1 \gamma_\mu d_1)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar d_1 \gamma_\mu d_1)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cddIm1123:
       real: true
-      tex: i (\bar d_1 \gamma_\mu d_1)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar d_1 \gamma_\mu d_1)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cddIm1212:
       real: true
       tex: i (\bar d_1 \gamma_\mu d_2)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
     cddIm1213:
       real: true
-      tex: i (\bar d_1 \gamma_\mu d_2)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar d_1 \gamma_\mu d_2)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cddIm1222:
       real: true
-      tex: i (\bar d_1 \gamma_\mu d_2)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar d_1 \gamma_\mu d_2)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
     cddIm1232:
       real: true
-      tex: i (\bar d_1 \gamma_\mu d_2)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar d_1 \gamma_\mu d_2)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
     cddIm1233:
       real: true
-      tex: i (\bar d_1 \gamma_\mu d_2)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar d_1 \gamma_\mu d_2)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cddIm1313:
       real: true
       tex: i (\bar d_1 \gamma_\mu d_3)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cddIm1322:
       real: true
-      tex: i (\bar d_1 \gamma_\mu d_3)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar d_1 \gamma_\mu d_3)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
     cddIm1323:
       real: true
-      tex: i (\bar d_1 \gamma_\mu d_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar d_1 \gamma_\mu d_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cddIm1333:
       real: true
-      tex: i (\bar d_1 \gamma_\mu d_3)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar d_1 \gamma_\mu d_3)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cddIm2223:
       real: true
-      tex: i (\bar d_2 \gamma_\mu d_2)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar d_2 \gamma_\mu d_2)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cddIm2323:
       real: true
       tex: i (\bar d_2 \gamma_\mu d_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cddIm3323:
       real: true
-      tex: i (\bar d_3 \gamma_\mu d_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar d_3 \gamma_\mu d_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cddIm1231:
       real: true
-      tex: i (\bar d_1 \gamma_\mu d_2)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar d_1 \gamma_\mu d_2)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
     cddIm1223:
       real: true
-      tex: i (\bar d_1 \gamma_\mu d_2)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar d_1 \gamma_\mu d_2)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cddIm1332:
       real: true
-      tex: i (\bar d_1 \gamma_\mu d_3)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+      tex: 2 i (\bar d_1 \gamma_\mu d_3)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
     ceuRe1111:
       real: true
       tex: (\bar e_1 \gamma_\mu e_1)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2


### PR DESCRIPTION
This PR adds multiplicity factors to the SMEFTsim operators such that the definitions of the Wilson coefficients agrees with the one in SMEFTsim.
SMEFTsim which uses a "redundant" basis of flavor indices, while the wcxf basis definition uses the "non-redundant" basis. By explicitly including multiplicity factors in the definitions of the operators, we make sure that the Wilson coefficients are the same in SMEFTsim and in the wcxf SMEFTsim basis.