### PR TITLE
Split SMEFT sectors `dB=dL=0` and `dB=dL=1` into smallest sectors closed under RG evolution

### DIFF
--- a/smeft.eft.json
+++ b/smeft.eft.json
@@ -4,9 +4,45 @@
     "description": "Standard Model Effective Field Theory with linearly realized electroweak symmetry breaking.\n"
   },
   "sectors": {
-    "dB=dL=0": {
-      "tex": "\\Delta B=\\Delta L=0",
-      "description": "Baryon and lepton number conserving operators"
+    "dB=de=dmu=dtau=0": {
+      "tex": "\\Delta B=\\Delta e=\\Delta \\mu=\\Delta \\tau=0",
+      "description": "Baryon and individual lepton number conserving operators"
+    },
+    "mue": {
+      "tex": "\\mu e",
+      "description": "Operators violating muon and electron number by one unit and conserve overall lepton number"
+    },
+    "taue": {
+      "tex": "\\tau e",
+      "description": "Operators violating tau and electron number by one unit and conserve overall lepton number"
+    },
+    "mutau": {
+      "tex": "\\mu \\tau",
+      "description": "Operators violating muon and tau number by one unit and conserve overall lepton number"
+    },
+    "muemue": {
+      "tex": "\\mu e \\mu e",
+      "description": "Operators violating muon and electron number by two units and conserve overall lepton number"
+    },
+    "etauemu": {
+      "tex": "e \\tau e \\mu",
+      "description": "Operators violating electron number by two units, muon and tau number by one unit, and conserve overall lepton number"
+    },
+    "muemutau": {
+      "tex": "\\mu e \\mu \\tau",
+      "description": "Operators violating muon number by two units, electron and tau number by one unit, and conserve overall lepton number"
+    },
+    "tauetaue": {
+      "tex": "\\tau e \\tau e",
+      "description": "Operators violating tau and electron number by two units and conserve overall lepton number"
+    },
+    "tauetaumu": {
+      "tex": "\\tau e \\tau \\mu",
+      "description": "Operators violating tau number by two units, electron and muon number by one unit, and conserve overall lepton number"
+    },
+    "taumutaumu": {
+      "tex": "\\tau \\mu \\tau \\mu",
+      "description": "Operators violating tau and muon number by two units and conserve overall lepton number"
     },
     "dB=dL=1": {
       "tex": "\\Delta B=\\Delta L=1",

--- a/smeft.eft.json
+++ b/smeft.eft.json
@@ -10,39 +10,39 @@
     },
     "mue": {
       "tex": "\\mu e",
-      "description": "Operators violating muon and electron number by one unit and conserve overall lepton number"
+      "description": "Operators violating muon and electron number by one unit and conserving overall lepton number"
     },
     "taue": {
       "tex": "\\tau e",
-      "description": "Operators violating tau and electron number by one unit and conserve overall lepton number"
+      "description": "Operators violating tau and electron number by one unit and conserving overall lepton number"
     },
     "mutau": {
       "tex": "\\mu \\tau",
-      "description": "Operators violating muon and tau number by one unit and conserve overall lepton number"
+      "description": "Operators violating muon and tau number by one unit and conserving overall lepton number"
     },
     "muemue": {
       "tex": "\\mu e \\mu e",
-      "description": "Operators violating muon and electron number by two units and conserve overall lepton number"
+      "description": "Operators violating muon and electron number by two units and conserving overall lepton number"
     },
     "etauemu": {
       "tex": "e \\tau e \\mu",
-      "description": "Operators violating electron number by two units, muon and tau number by one unit, and conserve overall lepton number"
+      "description": "Operators violating electron number by two units, muon and tau number by one unit, and conserving overall lepton number"
     },
     "muemutau": {
       "tex": "\\mu e \\mu \\tau",
-      "description": "Operators violating muon number by two units, electron and tau number by one unit, and conserve overall lepton number"
+      "description": "Operators violating muon number by two units, electron and tau number by one unit, and conserving overall lepton number"
     },
     "tauetaue": {
       "tex": "\\tau e \\tau e",
-      "description": "Operators violating tau and electron number by two units and conserve overall lepton number"
+      "description": "Operators violating tau and electron number by two units and conserving overall lepton number"
     },
     "tauetaumu": {
       "tex": "\\tau e \\tau \\mu",
-      "description": "Operators violating tau number by two units, electron and muon number by one unit, and conserve overall lepton number"
+      "description": "Operators violating tau number by two units, electron and muon number by one unit, and conserving overall lepton number"
     },
     "taumutaumu": {
       "tex": "\\tau \\mu \\tau \\mu",
-      "description": "Operators violating tau and muon number by two units and conserve overall lepton number"
+      "description": "Operators violating tau and muon number by two units and conserving overall lepton number"
     },
     "dB=dL=1": {
       "tex": "\\Delta B=\\Delta L=1",

--- a/smeft.eft.json
+++ b/smeft.eft.json
@@ -44,9 +44,17 @@
       "tex": "\\tau \\mu \\tau \\mu",
       "description": "Operators violating tau and muon number by two units and conserving overall lepton number"
     },
-    "dB=dL=1": {
-      "tex": "\\Delta B=\\Delta L=1",
-      "description": "Baryon number violating operators that conserve $B-L$"
+    "dB=de=1": {
+      "tex": "\\Delta B=\\Delta e=1",
+      "description": "Baryon and electron number violating operators that conserve $B-L$"
+    },
+    "dB=dmu=1": {
+      "tex": "\\Delta B=\\Delta \\mu=1",
+      "description": "Baryon and muon number violating operators that conserve $B-L$"
+    },
+    "dB=dtau=1": {
+      "tex": "\\Delta B=\\Delta \\tau=1",
+      "description": "Baryon and tau number violating operators that conserve $B-L$"
     },
     "dL=2": {
       "tex": "\\Delta L=2",

--- a/smeft.eft.yml
+++ b/smeft.eft.yml
@@ -34,9 +34,15 @@ sectors:
   taumutaumu:
     tex: \tau \mu \tau \mu
     description: Operators violating tau and muon number by two units and conserving overall lepton number
-  dB=dL=1:
-    tex: \Delta B=\Delta L=1
-    description: Baryon number violating operators that conserve $B-L$
+  dB=de=1:
+    tex: \Delta B=\Delta e=1
+    description: Baryon and electron number violating operators that conserve $B-L$
+  dB=dmu=1:
+    tex: \Delta B=\Delta \mu=1
+    description: Baryon and muon number violating operators that conserve $B-L$
+  dB=dtau=1:
+    tex: \Delta B=\Delta \tau=1
+    description: Baryon and tau number violating operators that conserve $B-L$
   dL=2:
     tex: \Delta L=2
     description: Operators violating lepton number by two units

--- a/smeft.eft.yml
+++ b/smeft.eft.yml
@@ -1,12 +1,39 @@
 eft: SMEFT
 metadata:
-  description: >
-    Standard Model Effective Field Theory with linearly realized
-    electroweak symmetry breaking.
+  description: 'Standard Model Effective Field Theory with linearly realized electroweak symmetry breaking.
+
+    '
 sectors:
-  dB=dL=0:
-    tex: \Delta B=\Delta L=0
-    description: Baryon and lepton number conserving operators
+  dB=de=dmu=dtau=0:
+    tex: \Delta B=\Delta e=\Delta \mu=\Delta \tau=0
+    description: Baryon and individual lepton number conserving operators
+  mue:
+    tex: \mu e
+    description: Operators violating muon and electron number by one unit and conserve overall lepton number
+  taue:
+    tex: \tau e
+    description: Operators violating tau and electron number by one unit and conserve overall lepton number
+  mutau:
+    tex: \mu \tau
+    description: Operators violating muon and tau number by one unit and conserve overall lepton number
+  muemue:
+    tex: \mu e \mu e
+    description: Operators violating muon and electron number by two units and conserve overall lepton number
+  etauemu:
+    tex: e \tau e \mu
+    description: Operators violating electron number by two units, muon and tau number by one unit, and conserve overall lepton number
+  muemutau:
+    tex: \mu e \mu \tau
+    description: Operators violating muon number by two units, electron and tau number by one unit, and conserve overall lepton number
+  tauetaue:
+    tex: \tau e \tau e
+    description: Operators violating tau and electron number by two units and conserve overall lepton number
+  tauetaumu:
+    tex: \tau e \tau \mu
+    description: Operators violating tau number by two units, electron and muon number by one unit, and conserve overall lepton number
+  taumutaumu:
+    tex: \tau \mu \tau \mu
+    description: Operators violating tau and muon number by two units and conserve overall lepton number
   dB=dL=1:
     tex: \Delta B=\Delta L=1
     description: Baryon number violating operators that conserve $B-L$

--- a/smeft.eft.yml
+++ b/smeft.eft.yml
@@ -9,31 +9,31 @@ sectors:
     description: Baryon and individual lepton number conserving operators
   mue:
     tex: \mu e
-    description: Operators violating muon and electron number by one unit and conserve overall lepton number
+    description: Operators violating muon and electron number by one unit and conserving overall lepton number
   taue:
     tex: \tau e
-    description: Operators violating tau and electron number by one unit and conserve overall lepton number
+    description: Operators violating tau and electron number by one unit and conserving overall lepton number
   mutau:
     tex: \mu \tau
-    description: Operators violating muon and tau number by one unit and conserve overall lepton number
+    description: Operators violating muon and tau number by one unit and conserving overall lepton number
   muemue:
     tex: \mu e \mu e
-    description: Operators violating muon and electron number by two units and conserve overall lepton number
+    description: Operators violating muon and electron number by two units and conserving overall lepton number
   etauemu:
     tex: e \tau e \mu
-    description: Operators violating electron number by two units, muon and tau number by one unit, and conserve overall lepton number
+    description: Operators violating electron number by two units, muon and tau number by one unit, and conserving overall lepton number
   muemutau:
     tex: \mu e \mu \tau
-    description: Operators violating muon number by two units, electron and tau number by one unit, and conserve overall lepton number
+    description: Operators violating muon number by two units, electron and tau number by one unit, and conserving overall lepton number
   tauetaue:
     tex: \tau e \tau e
-    description: Operators violating tau and electron number by two units and conserve overall lepton number
+    description: Operators violating tau and electron number by two units and conserving overall lepton number
   tauetaumu:
     tex: \tau e \tau \mu
-    description: Operators violating tau number by two units, electron and muon number by one unit, and conserve overall lepton number
+    description: Operators violating tau number by two units, electron and muon number by one unit, and conserving overall lepton number
   taumutaumu:
     tex: \tau \mu \tau \mu
-    description: Operators violating tau and muon number by two units and conserve overall lepton number
+    description: Operators violating tau and muon number by two units and conserving overall lepton number
   dB=dL=1:
     tex: \Delta B=\Delta L=1
     description: Baryon number violating operators that conserve $B-L$

--- a/smeft.higgs.basis.json
+++ b/smeft.higgs.basis.json
@@ -4216,822 +4216,826 @@
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
       }
     },
-    "dB=dL=1": {
+    "dB=de=1": {
       "duql_1111": {
         "tex": "\\left( d_1 C u_1 \\right) \\left( q_1 C \\ell_1 \\right)"
-      },
-      "duql_1112": {
-        "tex": "\\left( d_1 C u_1 \\right) \\left( q_1 C \\ell_2 \\right)"
-      },
-      "duql_1113": {
-        "tex": "\\left( d_1 C u_1 \\right) \\left( q_1 C \\ell_3 \\right)"
       },
       "duql_1121": {
         "tex": "\\left( d_1 C u_1 \\right) \\left( q_2 C \\ell_1 \\right)"
       },
-      "duql_1122": {
-        "tex": "\\left( d_1 C u_1 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "duql_1123": {
-        "tex": "\\left( d_1 C u_1 \\right) \\left( q_2 C \\ell_3 \\right)"
-      },
       "duql_1131": {
         "tex": "\\left( d_1 C u_1 \\right) \\left( q_3 C \\ell_1 \\right)"
-      },
-      "duql_1132": {
-        "tex": "\\left( d_1 C u_1 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "duql_1133": {
-        "tex": "\\left( d_1 C u_1 \\right) \\left( q_3 C \\ell_3 \\right)"
       },
       "duql_1211": {
         "tex": "\\left( d_1 C u_2 \\right) \\left( q_1 C \\ell_1 \\right)"
       },
-      "duql_1212": {
-        "tex": "\\left( d_1 C u_2 \\right) \\left( q_1 C \\ell_2 \\right)"
-      },
-      "duql_1213": {
-        "tex": "\\left( d_1 C u_2 \\right) \\left( q_1 C \\ell_3 \\right)"
-      },
       "duql_1221": {
         "tex": "\\left( d_1 C u_2 \\right) \\left( q_2 C \\ell_1 \\right)"
-      },
-      "duql_1222": {
-        "tex": "\\left( d_1 C u_2 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "duql_1223": {
-        "tex": "\\left( d_1 C u_2 \\right) \\left( q_2 C \\ell_3 \\right)"
       },
       "duql_1231": {
         "tex": "\\left( d_1 C u_2 \\right) \\left( q_3 C \\ell_1 \\right)"
       },
-      "duql_1232": {
-        "tex": "\\left( d_1 C u_2 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "duql_1233": {
-        "tex": "\\left( d_1 C u_2 \\right) \\left( q_3 C \\ell_3 \\right)"
-      },
       "duql_1311": {
         "tex": "\\left( d_1 C u_3 \\right) \\left( q_1 C \\ell_1 \\right)"
-      },
-      "duql_1312": {
-        "tex": "\\left( d_1 C u_3 \\right) \\left( q_1 C \\ell_2 \\right)"
-      },
-      "duql_1313": {
-        "tex": "\\left( d_1 C u_3 \\right) \\left( q_1 C \\ell_3 \\right)"
       },
       "duql_1321": {
         "tex": "\\left( d_1 C u_3 \\right) \\left( q_2 C \\ell_1 \\right)"
       },
-      "duql_1322": {
-        "tex": "\\left( d_1 C u_3 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "duql_1323": {
-        "tex": "\\left( d_1 C u_3 \\right) \\left( q_2 C \\ell_3 \\right)"
-      },
       "duql_1331": {
         "tex": "\\left( d_1 C u_3 \\right) \\left( q_3 C \\ell_1 \\right)"
-      },
-      "duql_1332": {
-        "tex": "\\left( d_1 C u_3 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "duql_1333": {
-        "tex": "\\left( d_1 C u_3 \\right) \\left( q_3 C \\ell_3 \\right)"
       },
       "duql_2111": {
         "tex": "\\left( d_2 C u_1 \\right) \\left( q_1 C \\ell_1 \\right)"
       },
-      "duql_2112": {
-        "tex": "\\left( d_2 C u_1 \\right) \\left( q_1 C \\ell_2 \\right)"
-      },
-      "duql_2113": {
-        "tex": "\\left( d_2 C u_1 \\right) \\left( q_1 C \\ell_3 \\right)"
-      },
       "duql_2121": {
         "tex": "\\left( d_2 C u_1 \\right) \\left( q_2 C \\ell_1 \\right)"
-      },
-      "duql_2122": {
-        "tex": "\\left( d_2 C u_1 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "duql_2123": {
-        "tex": "\\left( d_2 C u_1 \\right) \\left( q_2 C \\ell_3 \\right)"
       },
       "duql_2131": {
         "tex": "\\left( d_2 C u_1 \\right) \\left( q_3 C \\ell_1 \\right)"
       },
-      "duql_2132": {
-        "tex": "\\left( d_2 C u_1 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "duql_2133": {
-        "tex": "\\left( d_2 C u_1 \\right) \\left( q_3 C \\ell_3 \\right)"
-      },
       "duql_2211": {
         "tex": "\\left( d_2 C u_2 \\right) \\left( q_1 C \\ell_1 \\right)"
-      },
-      "duql_2212": {
-        "tex": "\\left( d_2 C u_2 \\right) \\left( q_1 C \\ell_2 \\right)"
-      },
-      "duql_2213": {
-        "tex": "\\left( d_2 C u_2 \\right) \\left( q_1 C \\ell_3 \\right)"
       },
       "duql_2221": {
         "tex": "\\left( d_2 C u_2 \\right) \\left( q_2 C \\ell_1 \\right)"
       },
-      "duql_2222": {
-        "tex": "\\left( d_2 C u_2 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "duql_2223": {
-        "tex": "\\left( d_2 C u_2 \\right) \\left( q_2 C \\ell_3 \\right)"
-      },
       "duql_2231": {
         "tex": "\\left( d_2 C u_2 \\right) \\left( q_3 C \\ell_1 \\right)"
-      },
-      "duql_2232": {
-        "tex": "\\left( d_2 C u_2 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "duql_2233": {
-        "tex": "\\left( d_2 C u_2 \\right) \\left( q_3 C \\ell_3 \\right)"
       },
       "duql_2311": {
         "tex": "\\left( d_2 C u_3 \\right) \\left( q_1 C \\ell_1 \\right)"
       },
-      "duql_2312": {
-        "tex": "\\left( d_2 C u_3 \\right) \\left( q_1 C \\ell_2 \\right)"
-      },
-      "duql_2313": {
-        "tex": "\\left( d_2 C u_3 \\right) \\left( q_1 C \\ell_3 \\right)"
-      },
       "duql_2321": {
         "tex": "\\left( d_2 C u_3 \\right) \\left( q_2 C \\ell_1 \\right)"
-      },
-      "duql_2322": {
-        "tex": "\\left( d_2 C u_3 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "duql_2323": {
-        "tex": "\\left( d_2 C u_3 \\right) \\left( q_2 C \\ell_3 \\right)"
       },
       "duql_2331": {
         "tex": "\\left( d_2 C u_3 \\right) \\left( q_3 C \\ell_1 \\right)"
       },
-      "duql_2332": {
-        "tex": "\\left( d_2 C u_3 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "duql_2333": {
-        "tex": "\\left( d_2 C u_3 \\right) \\left( q_3 C \\ell_3 \\right)"
-      },
       "duql_3111": {
         "tex": "\\left( d_3 C u_1 \\right) \\left( q_1 C \\ell_1 \\right)"
-      },
-      "duql_3112": {
-        "tex": "\\left( d_3 C u_1 \\right) \\left( q_1 C \\ell_2 \\right)"
-      },
-      "duql_3113": {
-        "tex": "\\left( d_3 C u_1 \\right) \\left( q_1 C \\ell_3 \\right)"
       },
       "duql_3121": {
         "tex": "\\left( d_3 C u_1 \\right) \\left( q_2 C \\ell_1 \\right)"
       },
-      "duql_3122": {
-        "tex": "\\left( d_3 C u_1 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "duql_3123": {
-        "tex": "\\left( d_3 C u_1 \\right) \\left( q_2 C \\ell_3 \\right)"
-      },
       "duql_3131": {
         "tex": "\\left( d_3 C u_1 \\right) \\left( q_3 C \\ell_1 \\right)"
-      },
-      "duql_3132": {
-        "tex": "\\left( d_3 C u_1 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "duql_3133": {
-        "tex": "\\left( d_3 C u_1 \\right) \\left( q_3 C \\ell_3 \\right)"
       },
       "duql_3211": {
         "tex": "\\left( d_3 C u_2 \\right) \\left( q_1 C \\ell_1 \\right)"
       },
-      "duql_3212": {
-        "tex": "\\left( d_3 C u_2 \\right) \\left( q_1 C \\ell_2 \\right)"
-      },
-      "duql_3213": {
-        "tex": "\\left( d_3 C u_2 \\right) \\left( q_1 C \\ell_3 \\right)"
-      },
       "duql_3221": {
         "tex": "\\left( d_3 C u_2 \\right) \\left( q_2 C \\ell_1 \\right)"
-      },
-      "duql_3222": {
-        "tex": "\\left( d_3 C u_2 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "duql_3223": {
-        "tex": "\\left( d_3 C u_2 \\right) \\left( q_2 C \\ell_3 \\right)"
       },
       "duql_3231": {
         "tex": "\\left( d_3 C u_2 \\right) \\left( q_3 C \\ell_1 \\right)"
       },
-      "duql_3232": {
-        "tex": "\\left( d_3 C u_2 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "duql_3233": {
-        "tex": "\\left( d_3 C u_2 \\right) \\left( q_3 C \\ell_3 \\right)"
-      },
       "duql_3311": {
         "tex": "\\left( d_3 C u_3 \\right) \\left( q_1 C \\ell_1 \\right)"
-      },
-      "duql_3312": {
-        "tex": "\\left( d_3 C u_3 \\right) \\left( q_1 C \\ell_2 \\right)"
-      },
-      "duql_3313": {
-        "tex": "\\left( d_3 C u_3 \\right) \\left( q_1 C \\ell_3 \\right)"
       },
       "duql_3321": {
         "tex": "\\left( d_3 C u_3 \\right) \\left( q_2 C \\ell_1 \\right)"
       },
-      "duql_3322": {
-        "tex": "\\left( d_3 C u_3 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "duql_3323": {
-        "tex": "\\left( d_3 C u_3 \\right) \\left( q_2 C \\ell_3 \\right)"
-      },
       "duql_3331": {
         "tex": "\\left( d_3 C u_3 \\right) \\left( q_3 C \\ell_1 \\right)"
-      },
-      "duql_3332": {
-        "tex": "\\left( d_3 C u_3 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "duql_3333": {
-        "tex": "\\left( d_3 C u_3 \\right) \\left( q_3 C \\ell_3 \\right)"
       },
       "qque_1111": {
         "tex": "\\left( q_1 C q_1 \\right) \\left( u_1 C e_1 \\right)"
       },
-      "qque_1112": {
-        "tex": "\\left( q_1 C q_1 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "qque_1113": {
-        "tex": "\\left( q_1 C q_1 \\right) \\left( u_1 C e_3 \\right)"
-      },
       "qque_1121": {
         "tex": "\\left( q_1 C q_1 \\right) \\left( u_2 C e_1 \\right)"
-      },
-      "qque_1122": {
-        "tex": "\\left( q_1 C q_1 \\right) \\left( u_2 C e_2 \\right)"
-      },
-      "qque_1123": {
-        "tex": "\\left( q_1 C q_1 \\right) \\left( u_2 C e_3 \\right)"
       },
       "qque_1131": {
         "tex": "\\left( q_1 C q_1 \\right) \\left( u_3 C e_1 \\right)"
       },
-      "qque_1132": {
-        "tex": "\\left( q_1 C q_1 \\right) \\left( u_3 C e_2 \\right)"
-      },
-      "qque_1133": {
-        "tex": "\\left( q_1 C q_1 \\right) \\left( u_3 C e_3 \\right)"
-      },
       "qque_1211": {
         "tex": "\\left( q_1 C q_2 \\right) \\left( u_1 C e_1 \\right)"
-      },
-      "qque_1212": {
-        "tex": "\\left( q_1 C q_2 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "qque_1213": {
-        "tex": "\\left( q_1 C q_2 \\right) \\left( u_1 C e_3 \\right)"
       },
       "qque_1221": {
         "tex": "\\left( q_1 C q_2 \\right) \\left( u_2 C e_1 \\right)"
       },
-      "qque_1222": {
-        "tex": "\\left( q_1 C q_2 \\right) \\left( u_2 C e_2 \\right)"
-      },
-      "qque_1223": {
-        "tex": "\\left( q_1 C q_2 \\right) \\left( u_2 C e_3 \\right)"
-      },
       "qque_1231": {
         "tex": "\\left( q_1 C q_2 \\right) \\left( u_3 C e_1 \\right)"
-      },
-      "qque_1232": {
-        "tex": "\\left( q_1 C q_2 \\right) \\left( u_3 C e_2 \\right)"
-      },
-      "qque_1233": {
-        "tex": "\\left( q_1 C q_2 \\right) \\left( u_3 C e_3 \\right)"
       },
       "qque_1311": {
         "tex": "\\left( q_1 C q_3 \\right) \\left( u_1 C e_1 \\right)"
       },
-      "qque_1312": {
-        "tex": "\\left( q_1 C q_3 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "qque_1313": {
-        "tex": "\\left( q_1 C q_3 \\right) \\left( u_1 C e_3 \\right)"
-      },
       "qque_1321": {
         "tex": "\\left( q_1 C q_3 \\right) \\left( u_2 C e_1 \\right)"
-      },
-      "qque_1322": {
-        "tex": "\\left( q_1 C q_3 \\right) \\left( u_2 C e_2 \\right)"
-      },
-      "qque_1323": {
-        "tex": "\\left( q_1 C q_3 \\right) \\left( u_2 C e_3 \\right)"
       },
       "qque_1331": {
         "tex": "\\left( q_1 C q_3 \\right) \\left( u_3 C e_1 \\right)"
       },
-      "qque_1332": {
-        "tex": "\\left( q_1 C q_3 \\right) \\left( u_3 C e_2 \\right)"
-      },
-      "qque_1333": {
-        "tex": "\\left( q_1 C q_3 \\right) \\left( u_3 C e_3 \\right)"
-      },
       "qque_2211": {
         "tex": "\\left( q_2 C q_2 \\right) \\left( u_1 C e_1 \\right)"
-      },
-      "qque_2212": {
-        "tex": "\\left( q_2 C q_2 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "qque_2213": {
-        "tex": "\\left( q_2 C q_2 \\right) \\left( u_1 C e_3 \\right)"
       },
       "qque_2221": {
         "tex": "\\left( q_2 C q_2 \\right) \\left( u_2 C e_1 \\right)"
       },
-      "qque_2222": {
-        "tex": "\\left( q_2 C q_2 \\right) \\left( u_2 C e_2 \\right)"
-      },
-      "qque_2223": {
-        "tex": "\\left( q_2 C q_2 \\right) \\left( u_2 C e_3 \\right)"
-      },
       "qque_2231": {
         "tex": "\\left( q_2 C q_2 \\right) \\left( u_3 C e_1 \\right)"
-      },
-      "qque_2232": {
-        "tex": "\\left( q_2 C q_2 \\right) \\left( u_3 C e_2 \\right)"
-      },
-      "qque_2233": {
-        "tex": "\\left( q_2 C q_2 \\right) \\left( u_3 C e_3 \\right)"
       },
       "qque_2311": {
         "tex": "\\left( q_2 C q_3 \\right) \\left( u_1 C e_1 \\right)"
       },
-      "qque_2312": {
-        "tex": "\\left( q_2 C q_3 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "qque_2313": {
-        "tex": "\\left( q_2 C q_3 \\right) \\left( u_1 C e_3 \\right)"
-      },
       "qque_2321": {
         "tex": "\\left( q_2 C q_3 \\right) \\left( u_2 C e_1 \\right)"
-      },
-      "qque_2322": {
-        "tex": "\\left( q_2 C q_3 \\right) \\left( u_2 C e_2 \\right)"
-      },
-      "qque_2323": {
-        "tex": "\\left( q_2 C q_3 \\right) \\left( u_2 C e_3 \\right)"
       },
       "qque_2331": {
         "tex": "\\left( q_2 C q_3 \\right) \\left( u_3 C e_1 \\right)"
       },
-      "qque_2332": {
-        "tex": "\\left( q_2 C q_3 \\right) \\left( u_3 C e_2 \\right)"
-      },
-      "qque_2333": {
-        "tex": "\\left( q_2 C q_3 \\right) \\left( u_3 C e_3 \\right)"
-      },
       "qque_3311": {
         "tex": "\\left( q_3 C q_3 \\right) \\left( u_1 C e_1 \\right)"
-      },
-      "qque_3312": {
-        "tex": "\\left( q_3 C q_3 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "qque_3313": {
-        "tex": "\\left( q_3 C q_3 \\right) \\left( u_1 C e_3 \\right)"
       },
       "qque_3321": {
         "tex": "\\left( q_3 C q_3 \\right) \\left( u_2 C e_1 \\right)"
       },
-      "qque_3322": {
-        "tex": "\\left( q_3 C q_3 \\right) \\left( u_2 C e_2 \\right)"
-      },
-      "qque_3323": {
-        "tex": "\\left( q_3 C q_3 \\right) \\left( u_2 C e_3 \\right)"
-      },
       "qque_3331": {
         "tex": "\\left( q_3 C q_3 \\right) \\left( u_3 C e_1 \\right)"
-      },
-      "qque_3332": {
-        "tex": "\\left( q_3 C q_3 \\right) \\left( u_3 C e_2 \\right)"
-      },
-      "qque_3333": {
-        "tex": "\\left( q_3 C q_3 \\right) \\left( u_3 C e_3 \\right)"
       },
       "qqql_1111": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_1 C \\ell_1 \\right)"
       },
-      "qqql_1112": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_1 C \\ell_2 \\right)"
-      },
-      "qqql_1113": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_1 C \\ell_3 \\right)"
-      },
       "qqql_1121": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_2 C \\ell_1 \\right)"
-      },
-      "qqql_1122": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "qqql_1123": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_2 C \\ell_3 \\right)"
       },
       "qqql_1131": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_3 C \\ell_1 \\right)"
       },
-      "qqql_1132": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "qqql_1133": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_3 C \\ell_3 \\right)"
-      },
       "qqql_1211": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_1 C \\ell_1 \\right)"
-      },
-      "qqql_1212": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_1 C \\ell_2 \\right)"
-      },
-      "qqql_1213": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_1 C \\ell_3 \\right)"
       },
       "qqql_1221": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_2 C \\ell_1 \\right)"
       },
-      "qqql_1222": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "qqql_1223": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_2 C \\ell_3 \\right)"
-      },
       "qqql_1231": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_3 C \\ell_1 \\right)"
-      },
-      "qqql_1232": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "qqql_1233": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_3 C \\ell_3 \\right)"
       },
       "qqql_1311": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_1 C \\ell_1 \\right)"
       },
-      "qqql_1312": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_1 C \\ell_2 \\right)"
-      },
-      "qqql_1313": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_1 C \\ell_3 \\right)"
-      },
       "qqql_1321": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_2 C \\ell_1 \\right)"
-      },
-      "qqql_1322": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "qqql_1323": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_2 C \\ell_3 \\right)"
       },
       "qqql_1331": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_3 C \\ell_1 \\right)"
       },
-      "qqql_1332": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "qqql_1333": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_3 C \\ell_3 \\right)"
-      },
       "qqql_2121": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_1 \\right) \\left( q_2 C \\ell_1 \\right)"
-      },
-      "qqql_2122": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_1 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "qqql_2123": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_1 \\right) \\left( q_2 C \\ell_3 \\right)"
       },
       "qqql_2131": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_1 \\right) \\left( q_3 C \\ell_1 \\right)"
       },
-      "qqql_2132": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_1 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "qqql_2133": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_1 \\right) \\left( q_3 C \\ell_3 \\right)"
-      },
       "qqql_2221": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_2 \\right) \\left( q_2 C \\ell_1 \\right)"
-      },
-      "qqql_2222": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_2 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "qqql_2223": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_2 \\right) \\left( q_2 C \\ell_3 \\right)"
       },
       "qqql_2231": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_2 \\right) \\left( q_3 C \\ell_1 \\right)"
       },
-      "qqql_2232": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_2 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "qqql_2233": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_2 \\right) \\left( q_3 C \\ell_3 \\right)"
-      },
       "qqql_2311": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_1 C \\ell_1 \\right)"
-      },
-      "qqql_2312": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_1 C \\ell_2 \\right)"
-      },
-      "qqql_2313": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_1 C \\ell_3 \\right)"
       },
       "qqql_2321": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_2 C \\ell_1 \\right)"
       },
-      "qqql_2322": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "qqql_2323": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_2 C \\ell_3 \\right)"
-      },
       "qqql_2331": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_3 C \\ell_1 \\right)"
-      },
-      "qqql_2332": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "qqql_2333": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_3 C \\ell_3 \\right)"
       },
       "qqql_3131": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_1 \\right) \\left( q_3 C \\ell_1 \\right)"
       },
-      "qqql_3132": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_1 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "qqql_3133": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_1 \\right) \\left( q_3 C \\ell_3 \\right)"
-      },
       "qqql_3231": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_2 \\right) \\left( q_3 C \\ell_1 \\right)"
-      },
-      "qqql_3232": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_2 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "qqql_3233": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_2 \\right) \\left( q_3 C \\ell_3 \\right)"
       },
       "qqql_3331": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_3 \\right) \\left( q_3 C \\ell_1 \\right)"
       },
-      "qqql_3332": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_3 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "qqql_3333": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_3 \\right) \\left( q_3 C \\ell_3 \\right)"
-      },
       "duue_1111": {
         "tex": "\\left( d_1 C u_1 \\right) \\left( u_1 C e_1 \\right)"
-      },
-      "duue_1112": {
-        "tex": "\\left( d_1 C u_1 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "duue_1113": {
-        "tex": "\\left( d_1 C u_1 \\right) \\left( u_1 C e_3 \\right)"
       },
       "duue_1121": {
         "tex": "\\left( d_1 C u_1 \\right) \\left( u_2 C e_1 \\right)"
       },
-      "duue_1122": {
-        "tex": "\\left( d_1 C u_1 \\right) \\left( u_2 C e_2 \\right)"
-      },
-      "duue_1123": {
-        "tex": "\\left( d_1 C u_1 \\right) \\left( u_2 C e_3 \\right)"
-      },
       "duue_1131": {
         "tex": "\\left( d_1 C u_1 \\right) \\left( u_3 C e_1 \\right)"
-      },
-      "duue_1132": {
-        "tex": "\\left( d_1 C u_1 \\right) \\left( u_3 C e_2 \\right)"
-      },
-      "duue_1133": {
-        "tex": "\\left( d_1 C u_1 \\right) \\left( u_3 C e_3 \\right)"
       },
       "duue_1211": {
         "tex": "\\left( d_1 C u_2 \\right) \\left( u_1 C e_1 \\right)"
       },
-      "duue_1212": {
-        "tex": "\\left( d_1 C u_2 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "duue_1213": {
-        "tex": "\\left( d_1 C u_2 \\right) \\left( u_1 C e_3 \\right)"
-      },
       "duue_1221": {
         "tex": "\\left( d_1 C u_2 \\right) \\left( u_2 C e_1 \\right)"
-      },
-      "duue_1222": {
-        "tex": "\\left( d_1 C u_2 \\right) \\left( u_2 C e_2 \\right)"
-      },
-      "duue_1223": {
-        "tex": "\\left( d_1 C u_2 \\right) \\left( u_2 C e_3 \\right)"
       },
       "duue_1231": {
         "tex": "\\left( d_1 C u_2 \\right) \\left( u_3 C e_1 \\right)"
       },
-      "duue_1232": {
-        "tex": "\\left( d_1 C u_2 \\right) \\left( u_3 C e_2 \\right)"
-      },
-      "duue_1233": {
-        "tex": "\\left( d_1 C u_2 \\right) \\left( u_3 C e_3 \\right)"
-      },
       "duue_1311": {
         "tex": "\\left( d_1 C u_3 \\right) \\left( u_1 C e_1 \\right)"
-      },
-      "duue_1312": {
-        "tex": "\\left( d_1 C u_3 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "duue_1313": {
-        "tex": "\\left( d_1 C u_3 \\right) \\left( u_1 C e_3 \\right)"
       },
       "duue_1321": {
         "tex": "\\left( d_1 C u_3 \\right) \\left( u_2 C e_1 \\right)"
       },
-      "duue_1322": {
-        "tex": "\\left( d_1 C u_3 \\right) \\left( u_2 C e_2 \\right)"
-      },
-      "duue_1323": {
-        "tex": "\\left( d_1 C u_3 \\right) \\left( u_2 C e_3 \\right)"
-      },
       "duue_1331": {
         "tex": "\\left( d_1 C u_3 \\right) \\left( u_3 C e_1 \\right)"
-      },
-      "duue_1332": {
-        "tex": "\\left( d_1 C u_3 \\right) \\left( u_3 C e_2 \\right)"
-      },
-      "duue_1333": {
-        "tex": "\\left( d_1 C u_3 \\right) \\left( u_3 C e_3 \\right)"
       },
       "duue_2111": {
         "tex": "\\left( d_2 C u_1 \\right) \\left( u_1 C e_1 \\right)"
       },
-      "duue_2112": {
-        "tex": "\\left( d_2 C u_1 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "duue_2113": {
-        "tex": "\\left( d_2 C u_1 \\right) \\left( u_1 C e_3 \\right)"
-      },
       "duue_2121": {
         "tex": "\\left( d_2 C u_1 \\right) \\left( u_2 C e_1 \\right)"
-      },
-      "duue_2122": {
-        "tex": "\\left( d_2 C u_1 \\right) \\left( u_2 C e_2 \\right)"
-      },
-      "duue_2123": {
-        "tex": "\\left( d_2 C u_1 \\right) \\left( u_2 C e_3 \\right)"
       },
       "duue_2131": {
         "tex": "\\left( d_2 C u_1 \\right) \\left( u_3 C e_1 \\right)"
       },
-      "duue_2132": {
-        "tex": "\\left( d_2 C u_1 \\right) \\left( u_3 C e_2 \\right)"
-      },
-      "duue_2133": {
-        "tex": "\\left( d_2 C u_1 \\right) \\left( u_3 C e_3 \\right)"
-      },
       "duue_2211": {
         "tex": "\\left( d_2 C u_2 \\right) \\left( u_1 C e_1 \\right)"
-      },
-      "duue_2212": {
-        "tex": "\\left( d_2 C u_2 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "duue_2213": {
-        "tex": "\\left( d_2 C u_2 \\right) \\left( u_1 C e_3 \\right)"
       },
       "duue_2221": {
         "tex": "\\left( d_2 C u_2 \\right) \\left( u_2 C e_1 \\right)"
       },
-      "duue_2222": {
-        "tex": "\\left( d_2 C u_2 \\right) \\left( u_2 C e_2 \\right)"
-      },
-      "duue_2223": {
-        "tex": "\\left( d_2 C u_2 \\right) \\left( u_2 C e_3 \\right)"
-      },
       "duue_2231": {
         "tex": "\\left( d_2 C u_2 \\right) \\left( u_3 C e_1 \\right)"
-      },
-      "duue_2232": {
-        "tex": "\\left( d_2 C u_2 \\right) \\left( u_3 C e_2 \\right)"
-      },
-      "duue_2233": {
-        "tex": "\\left( d_2 C u_2 \\right) \\left( u_3 C e_3 \\right)"
       },
       "duue_2311": {
         "tex": "\\left( d_2 C u_3 \\right) \\left( u_1 C e_1 \\right)"
       },
-      "duue_2312": {
-        "tex": "\\left( d_2 C u_3 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "duue_2313": {
-        "tex": "\\left( d_2 C u_3 \\right) \\left( u_1 C e_3 \\right)"
-      },
       "duue_2321": {
         "tex": "\\left( d_2 C u_3 \\right) \\left( u_2 C e_1 \\right)"
-      },
-      "duue_2322": {
-        "tex": "\\left( d_2 C u_3 \\right) \\left( u_2 C e_2 \\right)"
-      },
-      "duue_2323": {
-        "tex": "\\left( d_2 C u_3 \\right) \\left( u_2 C e_3 \\right)"
       },
       "duue_2331": {
         "tex": "\\left( d_2 C u_3 \\right) \\left( u_3 C e_1 \\right)"
       },
-      "duue_2332": {
-        "tex": "\\left( d_2 C u_3 \\right) \\left( u_3 C e_2 \\right)"
-      },
-      "duue_2333": {
-        "tex": "\\left( d_2 C u_3 \\right) \\left( u_3 C e_3 \\right)"
-      },
       "duue_3111": {
         "tex": "\\left( d_3 C u_1 \\right) \\left( u_1 C e_1 \\right)"
-      },
-      "duue_3112": {
-        "tex": "\\left( d_3 C u_1 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "duue_3113": {
-        "tex": "\\left( d_3 C u_1 \\right) \\left( u_1 C e_3 \\right)"
       },
       "duue_3121": {
         "tex": "\\left( d_3 C u_1 \\right) \\left( u_2 C e_1 \\right)"
       },
-      "duue_3122": {
-        "tex": "\\left( d_3 C u_1 \\right) \\left( u_2 C e_2 \\right)"
-      },
-      "duue_3123": {
-        "tex": "\\left( d_3 C u_1 \\right) \\left( u_2 C e_3 \\right)"
-      },
       "duue_3131": {
         "tex": "\\left( d_3 C u_1 \\right) \\left( u_3 C e_1 \\right)"
-      },
-      "duue_3132": {
-        "tex": "\\left( d_3 C u_1 \\right) \\left( u_3 C e_2 \\right)"
-      },
-      "duue_3133": {
-        "tex": "\\left( d_3 C u_1 \\right) \\left( u_3 C e_3 \\right)"
       },
       "duue_3211": {
         "tex": "\\left( d_3 C u_2 \\right) \\left( u_1 C e_1 \\right)"
       },
-      "duue_3212": {
-        "tex": "\\left( d_3 C u_2 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "duue_3213": {
-        "tex": "\\left( d_3 C u_2 \\right) \\left( u_1 C e_3 \\right)"
-      },
       "duue_3221": {
         "tex": "\\left( d_3 C u_2 \\right) \\left( u_2 C e_1 \\right)"
-      },
-      "duue_3222": {
-        "tex": "\\left( d_3 C u_2 \\right) \\left( u_2 C e_2 \\right)"
-      },
-      "duue_3223": {
-        "tex": "\\left( d_3 C u_2 \\right) \\left( u_2 C e_3 \\right)"
       },
       "duue_3231": {
         "tex": "\\left( d_3 C u_2 \\right) \\left( u_3 C e_1 \\right)"
       },
-      "duue_3232": {
-        "tex": "\\left( d_3 C u_2 \\right) \\left( u_3 C e_2 \\right)"
-      },
-      "duue_3233": {
-        "tex": "\\left( d_3 C u_2 \\right) \\left( u_3 C e_3 \\right)"
-      },
       "duue_3311": {
         "tex": "\\left( d_3 C u_3 \\right) \\left( u_1 C e_1 \\right)"
-      },
-      "duue_3312": {
-        "tex": "\\left( d_3 C u_3 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "duue_3313": {
-        "tex": "\\left( d_3 C u_3 \\right) \\left( u_1 C e_3 \\right)"
       },
       "duue_3321": {
         "tex": "\\left( d_3 C u_3 \\right) \\left( u_2 C e_1 \\right)"
       },
+      "duue_3331": {
+        "tex": "\\left( d_3 C u_3 \\right) \\left( u_3 C e_1 \\right)"
+      }
+    },
+    "dB=dmu=1": {
+      "duql_1112": {
+        "tex": "\\left( d_1 C u_1 \\right) \\left( q_1 C \\ell_2 \\right)"
+      },
+      "duql_1122": {
+        "tex": "\\left( d_1 C u_1 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "duql_1132": {
+        "tex": "\\left( d_1 C u_1 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "duql_1212": {
+        "tex": "\\left( d_1 C u_2 \\right) \\left( q_1 C \\ell_2 \\right)"
+      },
+      "duql_1222": {
+        "tex": "\\left( d_1 C u_2 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "duql_1232": {
+        "tex": "\\left( d_1 C u_2 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "duql_1312": {
+        "tex": "\\left( d_1 C u_3 \\right) \\left( q_1 C \\ell_2 \\right)"
+      },
+      "duql_1322": {
+        "tex": "\\left( d_1 C u_3 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "duql_1332": {
+        "tex": "\\left( d_1 C u_3 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "duql_2112": {
+        "tex": "\\left( d_2 C u_1 \\right) \\left( q_1 C \\ell_2 \\right)"
+      },
+      "duql_2122": {
+        "tex": "\\left( d_2 C u_1 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "duql_2132": {
+        "tex": "\\left( d_2 C u_1 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "duql_2212": {
+        "tex": "\\left( d_2 C u_2 \\right) \\left( q_1 C \\ell_2 \\right)"
+      },
+      "duql_2222": {
+        "tex": "\\left( d_2 C u_2 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "duql_2232": {
+        "tex": "\\left( d_2 C u_2 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "duql_2312": {
+        "tex": "\\left( d_2 C u_3 \\right) \\left( q_1 C \\ell_2 \\right)"
+      },
+      "duql_2322": {
+        "tex": "\\left( d_2 C u_3 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "duql_2332": {
+        "tex": "\\left( d_2 C u_3 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "duql_3112": {
+        "tex": "\\left( d_3 C u_1 \\right) \\left( q_1 C \\ell_2 \\right)"
+      },
+      "duql_3122": {
+        "tex": "\\left( d_3 C u_1 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "duql_3132": {
+        "tex": "\\left( d_3 C u_1 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "duql_3212": {
+        "tex": "\\left( d_3 C u_2 \\right) \\left( q_1 C \\ell_2 \\right)"
+      },
+      "duql_3222": {
+        "tex": "\\left( d_3 C u_2 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "duql_3232": {
+        "tex": "\\left( d_3 C u_2 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "duql_3312": {
+        "tex": "\\left( d_3 C u_3 \\right) \\left( q_1 C \\ell_2 \\right)"
+      },
+      "duql_3322": {
+        "tex": "\\left( d_3 C u_3 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "duql_3332": {
+        "tex": "\\left( d_3 C u_3 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "qque_1112": {
+        "tex": "\\left( q_1 C q_1 \\right) \\left( u_1 C e_2 \\right)"
+      },
+      "qque_1122": {
+        "tex": "\\left( q_1 C q_1 \\right) \\left( u_2 C e_2 \\right)"
+      },
+      "qque_1132": {
+        "tex": "\\left( q_1 C q_1 \\right) \\left( u_3 C e_2 \\right)"
+      },
+      "qque_1212": {
+        "tex": "\\left( q_1 C q_2 \\right) \\left( u_1 C e_2 \\right)"
+      },
+      "qque_1222": {
+        "tex": "\\left( q_1 C q_2 \\right) \\left( u_2 C e_2 \\right)"
+      },
+      "qque_1232": {
+        "tex": "\\left( q_1 C q_2 \\right) \\left( u_3 C e_2 \\right)"
+      },
+      "qque_1312": {
+        "tex": "\\left( q_1 C q_3 \\right) \\left( u_1 C e_2 \\right)"
+      },
+      "qque_1322": {
+        "tex": "\\left( q_1 C q_3 \\right) \\left( u_2 C e_2 \\right)"
+      },
+      "qque_1332": {
+        "tex": "\\left( q_1 C q_3 \\right) \\left( u_3 C e_2 \\right)"
+      },
+      "qque_2212": {
+        "tex": "\\left( q_2 C q_2 \\right) \\left( u_1 C e_2 \\right)"
+      },
+      "qque_2222": {
+        "tex": "\\left( q_2 C q_2 \\right) \\left( u_2 C e_2 \\right)"
+      },
+      "qque_2232": {
+        "tex": "\\left( q_2 C q_2 \\right) \\left( u_3 C e_2 \\right)"
+      },
+      "qque_2312": {
+        "tex": "\\left( q_2 C q_3 \\right) \\left( u_1 C e_2 \\right)"
+      },
+      "qque_2322": {
+        "tex": "\\left( q_2 C q_3 \\right) \\left( u_2 C e_2 \\right)"
+      },
+      "qque_2332": {
+        "tex": "\\left( q_2 C q_3 \\right) \\left( u_3 C e_2 \\right)"
+      },
+      "qque_3312": {
+        "tex": "\\left( q_3 C q_3 \\right) \\left( u_1 C e_2 \\right)"
+      },
+      "qque_3322": {
+        "tex": "\\left( q_3 C q_3 \\right) \\left( u_2 C e_2 \\right)"
+      },
+      "qque_3332": {
+        "tex": "\\left( q_3 C q_3 \\right) \\left( u_3 C e_2 \\right)"
+      },
+      "qqql_1112": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_1 C \\ell_2 \\right)"
+      },
+      "qqql_1122": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "qqql_1132": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "qqql_1212": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_1 C \\ell_2 \\right)"
+      },
+      "qqql_1222": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "qqql_1232": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "qqql_1312": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_1 C \\ell_2 \\right)"
+      },
+      "qqql_1322": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "qqql_1332": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "qqql_2122": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_1 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "qqql_2132": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_1 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "qqql_2222": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_2 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "qqql_2232": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_2 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "qqql_2312": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_1 C \\ell_2 \\right)"
+      },
+      "qqql_2322": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "qqql_2332": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "qqql_3132": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_1 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "qqql_3232": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_2 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "qqql_3332": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_3 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "duue_1112": {
+        "tex": "\\left( d_1 C u_1 \\right) \\left( u_1 C e_2 \\right)"
+      },
+      "duue_1122": {
+        "tex": "\\left( d_1 C u_1 \\right) \\left( u_2 C e_2 \\right)"
+      },
+      "duue_1132": {
+        "tex": "\\left( d_1 C u_1 \\right) \\left( u_3 C e_2 \\right)"
+      },
+      "duue_1212": {
+        "tex": "\\left( d_1 C u_2 \\right) \\left( u_1 C e_2 \\right)"
+      },
+      "duue_1222": {
+        "tex": "\\left( d_1 C u_2 \\right) \\left( u_2 C e_2 \\right)"
+      },
+      "duue_1232": {
+        "tex": "\\left( d_1 C u_2 \\right) \\left( u_3 C e_2 \\right)"
+      },
+      "duue_1312": {
+        "tex": "\\left( d_1 C u_3 \\right) \\left( u_1 C e_2 \\right)"
+      },
+      "duue_1322": {
+        "tex": "\\left( d_1 C u_3 \\right) \\left( u_2 C e_2 \\right)"
+      },
+      "duue_1332": {
+        "tex": "\\left( d_1 C u_3 \\right) \\left( u_3 C e_2 \\right)"
+      },
+      "duue_2112": {
+        "tex": "\\left( d_2 C u_1 \\right) \\left( u_1 C e_2 \\right)"
+      },
+      "duue_2122": {
+        "tex": "\\left( d_2 C u_1 \\right) \\left( u_2 C e_2 \\right)"
+      },
+      "duue_2132": {
+        "tex": "\\left( d_2 C u_1 \\right) \\left( u_3 C e_2 \\right)"
+      },
+      "duue_2212": {
+        "tex": "\\left( d_2 C u_2 \\right) \\left( u_1 C e_2 \\right)"
+      },
+      "duue_2222": {
+        "tex": "\\left( d_2 C u_2 \\right) \\left( u_2 C e_2 \\right)"
+      },
+      "duue_2232": {
+        "tex": "\\left( d_2 C u_2 \\right) \\left( u_3 C e_2 \\right)"
+      },
+      "duue_2312": {
+        "tex": "\\left( d_2 C u_3 \\right) \\left( u_1 C e_2 \\right)"
+      },
+      "duue_2322": {
+        "tex": "\\left( d_2 C u_3 \\right) \\left( u_2 C e_2 \\right)"
+      },
+      "duue_2332": {
+        "tex": "\\left( d_2 C u_3 \\right) \\left( u_3 C e_2 \\right)"
+      },
+      "duue_3112": {
+        "tex": "\\left( d_3 C u_1 \\right) \\left( u_1 C e_2 \\right)"
+      },
+      "duue_3122": {
+        "tex": "\\left( d_3 C u_1 \\right) \\left( u_2 C e_2 \\right)"
+      },
+      "duue_3132": {
+        "tex": "\\left( d_3 C u_1 \\right) \\left( u_3 C e_2 \\right)"
+      },
+      "duue_3212": {
+        "tex": "\\left( d_3 C u_2 \\right) \\left( u_1 C e_2 \\right)"
+      },
+      "duue_3222": {
+        "tex": "\\left( d_3 C u_2 \\right) \\left( u_2 C e_2 \\right)"
+      },
+      "duue_3232": {
+        "tex": "\\left( d_3 C u_2 \\right) \\left( u_3 C e_2 \\right)"
+      },
+      "duue_3312": {
+        "tex": "\\left( d_3 C u_3 \\right) \\left( u_1 C e_2 \\right)"
+      },
       "duue_3322": {
         "tex": "\\left( d_3 C u_3 \\right) \\left( u_2 C e_2 \\right)"
       },
-      "duue_3323": {
-        "tex": "\\left( d_3 C u_3 \\right) \\left( u_2 C e_3 \\right)"
-      },
-      "duue_3331": {
-        "tex": "\\left( d_3 C u_3 \\right) \\left( u_3 C e_1 \\right)"
-      },
       "duue_3332": {
         "tex": "\\left( d_3 C u_3 \\right) \\left( u_3 C e_2 \\right)"
+      }
+    },
+    "dB=dtau=1": {
+      "duql_1113": {
+        "tex": "\\left( d_1 C u_1 \\right) \\left( q_1 C \\ell_3 \\right)"
+      },
+      "duql_1123": {
+        "tex": "\\left( d_1 C u_1 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "duql_1133": {
+        "tex": "\\left( d_1 C u_1 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "duql_1213": {
+        "tex": "\\left( d_1 C u_2 \\right) \\left( q_1 C \\ell_3 \\right)"
+      },
+      "duql_1223": {
+        "tex": "\\left( d_1 C u_2 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "duql_1233": {
+        "tex": "\\left( d_1 C u_2 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "duql_1313": {
+        "tex": "\\left( d_1 C u_3 \\right) \\left( q_1 C \\ell_3 \\right)"
+      },
+      "duql_1323": {
+        "tex": "\\left( d_1 C u_3 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "duql_1333": {
+        "tex": "\\left( d_1 C u_3 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "duql_2113": {
+        "tex": "\\left( d_2 C u_1 \\right) \\left( q_1 C \\ell_3 \\right)"
+      },
+      "duql_2123": {
+        "tex": "\\left( d_2 C u_1 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "duql_2133": {
+        "tex": "\\left( d_2 C u_1 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "duql_2213": {
+        "tex": "\\left( d_2 C u_2 \\right) \\left( q_1 C \\ell_3 \\right)"
+      },
+      "duql_2223": {
+        "tex": "\\left( d_2 C u_2 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "duql_2233": {
+        "tex": "\\left( d_2 C u_2 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "duql_2313": {
+        "tex": "\\left( d_2 C u_3 \\right) \\left( q_1 C \\ell_3 \\right)"
+      },
+      "duql_2323": {
+        "tex": "\\left( d_2 C u_3 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "duql_2333": {
+        "tex": "\\left( d_2 C u_3 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "duql_3113": {
+        "tex": "\\left( d_3 C u_1 \\right) \\left( q_1 C \\ell_3 \\right)"
+      },
+      "duql_3123": {
+        "tex": "\\left( d_3 C u_1 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "duql_3133": {
+        "tex": "\\left( d_3 C u_1 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "duql_3213": {
+        "tex": "\\left( d_3 C u_2 \\right) \\left( q_1 C \\ell_3 \\right)"
+      },
+      "duql_3223": {
+        "tex": "\\left( d_3 C u_2 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "duql_3233": {
+        "tex": "\\left( d_3 C u_2 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "duql_3313": {
+        "tex": "\\left( d_3 C u_3 \\right) \\left( q_1 C \\ell_3 \\right)"
+      },
+      "duql_3323": {
+        "tex": "\\left( d_3 C u_3 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "duql_3333": {
+        "tex": "\\left( d_3 C u_3 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "qque_1113": {
+        "tex": "\\left( q_1 C q_1 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "qque_1123": {
+        "tex": "\\left( q_1 C q_1 \\right) \\left( u_2 C e_3 \\right)"
+      },
+      "qque_1133": {
+        "tex": "\\left( q_1 C q_1 \\right) \\left( u_3 C e_3 \\right)"
+      },
+      "qque_1213": {
+        "tex": "\\left( q_1 C q_2 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "qque_1223": {
+        "tex": "\\left( q_1 C q_2 \\right) \\left( u_2 C e_3 \\right)"
+      },
+      "qque_1233": {
+        "tex": "\\left( q_1 C q_2 \\right) \\left( u_3 C e_3 \\right)"
+      },
+      "qque_1313": {
+        "tex": "\\left( q_1 C q_3 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "qque_1323": {
+        "tex": "\\left( q_1 C q_3 \\right) \\left( u_2 C e_3 \\right)"
+      },
+      "qque_1333": {
+        "tex": "\\left( q_1 C q_3 \\right) \\left( u_3 C e_3 \\right)"
+      },
+      "qque_2213": {
+        "tex": "\\left( q_2 C q_2 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "qque_2223": {
+        "tex": "\\left( q_2 C q_2 \\right) \\left( u_2 C e_3 \\right)"
+      },
+      "qque_2233": {
+        "tex": "\\left( q_2 C q_2 \\right) \\left( u_3 C e_3 \\right)"
+      },
+      "qque_2313": {
+        "tex": "\\left( q_2 C q_3 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "qque_2323": {
+        "tex": "\\left( q_2 C q_3 \\right) \\left( u_2 C e_3 \\right)"
+      },
+      "qque_2333": {
+        "tex": "\\left( q_2 C q_3 \\right) \\left( u_3 C e_3 \\right)"
+      },
+      "qque_3313": {
+        "tex": "\\left( q_3 C q_3 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "qque_3323": {
+        "tex": "\\left( q_3 C q_3 \\right) \\left( u_2 C e_3 \\right)"
+      },
+      "qque_3333": {
+        "tex": "\\left( q_3 C q_3 \\right) \\left( u_3 C e_3 \\right)"
+      },
+      "qqql_1113": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_1 C \\ell_3 \\right)"
+      },
+      "qqql_1123": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "qqql_1133": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "qqql_1213": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_1 C \\ell_3 \\right)"
+      },
+      "qqql_1223": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "qqql_1233": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "qqql_1313": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_1 C \\ell_3 \\right)"
+      },
+      "qqql_1323": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "qqql_1333": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "qqql_2123": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_1 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "qqql_2133": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_1 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "qqql_2223": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_2 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "qqql_2233": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_2 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "qqql_2313": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_1 C \\ell_3 \\right)"
+      },
+      "qqql_2323": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "qqql_2333": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "qqql_3133": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_1 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "qqql_3233": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_2 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "qqql_3333": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_3 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "duue_1113": {
+        "tex": "\\left( d_1 C u_1 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "duue_1123": {
+        "tex": "\\left( d_1 C u_1 \\right) \\left( u_2 C e_3 \\right)"
+      },
+      "duue_1133": {
+        "tex": "\\left( d_1 C u_1 \\right) \\left( u_3 C e_3 \\right)"
+      },
+      "duue_1213": {
+        "tex": "\\left( d_1 C u_2 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "duue_1223": {
+        "tex": "\\left( d_1 C u_2 \\right) \\left( u_2 C e_3 \\right)"
+      },
+      "duue_1233": {
+        "tex": "\\left( d_1 C u_2 \\right) \\left( u_3 C e_3 \\right)"
+      },
+      "duue_1313": {
+        "tex": "\\left( d_1 C u_3 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "duue_1323": {
+        "tex": "\\left( d_1 C u_3 \\right) \\left( u_2 C e_3 \\right)"
+      },
+      "duue_1333": {
+        "tex": "\\left( d_1 C u_3 \\right) \\left( u_3 C e_3 \\right)"
+      },
+      "duue_2113": {
+        "tex": "\\left( d_2 C u_1 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "duue_2123": {
+        "tex": "\\left( d_2 C u_1 \\right) \\left( u_2 C e_3 \\right)"
+      },
+      "duue_2133": {
+        "tex": "\\left( d_2 C u_1 \\right) \\left( u_3 C e_3 \\right)"
+      },
+      "duue_2213": {
+        "tex": "\\left( d_2 C u_2 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "duue_2223": {
+        "tex": "\\left( d_2 C u_2 \\right) \\left( u_2 C e_3 \\right)"
+      },
+      "duue_2233": {
+        "tex": "\\left( d_2 C u_2 \\right) \\left( u_3 C e_3 \\right)"
+      },
+      "duue_2313": {
+        "tex": "\\left( d_2 C u_3 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "duue_2323": {
+        "tex": "\\left( d_2 C u_3 \\right) \\left( u_2 C e_3 \\right)"
+      },
+      "duue_2333": {
+        "tex": "\\left( d_2 C u_3 \\right) \\left( u_3 C e_3 \\right)"
+      },
+      "duue_3113": {
+        "tex": "\\left( d_3 C u_1 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "duue_3123": {
+        "tex": "\\left( d_3 C u_1 \\right) \\left( u_2 C e_3 \\right)"
+      },
+      "duue_3133": {
+        "tex": "\\left( d_3 C u_1 \\right) \\left( u_3 C e_3 \\right)"
+      },
+      "duue_3213": {
+        "tex": "\\left( d_3 C u_2 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "duue_3223": {
+        "tex": "\\left( d_3 C u_2 \\right) \\left( u_2 C e_3 \\right)"
+      },
+      "duue_3233": {
+        "tex": "\\left( d_3 C u_2 \\right) \\left( u_3 C e_3 \\right)"
+      },
+      "duue_3313": {
+        "tex": "\\left( d_3 C u_3 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "duue_3323": {
+        "tex": "\\left( d_3 C u_3 \\right) \\left( u_2 C e_3 \\right)"
       },
       "duue_3333": {
         "tex": "\\left( d_3 C u_3 \\right) \\left( u_3 C e_3 \\right)"

--- a/smeft.higgs.basis.json
+++ b/smeft.higgs.basis.json
@@ -5,7 +5,7 @@
     "description": "This is a mixture between the Higgs basis as defined e.g. in arXiv:1610.07922 and the Warsaw up basis. All bosonic operators involving at least one Higgs field as well as the operators of type $\\psi^2 \\phi^2 D$ are taken from the Higgs basis (with dimensionful Wilson coefficients rather than normalizing by $1/v^2$), while all other operators (in particular $\\psi^2\\phi^3$ and four-fermion operators) are defined as in the Warsaw up basis.\n"
   },
   "sectors": {
-    "dB=dL=0": {
+    "dB=de=dmu=dtau=0": {
       "G": {
         "real": true,
         "tex": "f^{ABC} G_\\mu^{A \\nu} G_\\nu^{B \\rho} G_\\rho^{C \\mu}"
@@ -114,26 +114,8 @@
       "ephi_11": {
         "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_1 e_1 \\varphi \\right)"
       },
-      "ephi_12": {
-        "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_1 e_2 \\varphi \\right)"
-      },
-      "ephi_13": {
-        "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_1 e_3 \\varphi \\right)"
-      },
-      "ephi_21": {
-        "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_2 e_1 \\varphi \\right)"
-      },
       "ephi_22": {
         "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_2 e_2 \\varphi \\right)"
-      },
-      "ephi_23": {
-        "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_2 e_3 \\varphi \\right)"
-      },
-      "ephi_31": {
-        "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_3 e_1 \\varphi \\right)"
-      },
-      "ephi_32": {
-        "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_3 e_2 \\varphi \\right)"
       },
       "ephi_33": {
         "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_3 e_3 \\varphi \\right)"
@@ -141,26 +123,8 @@
       "eW_11": {
         "tex": "\\left( \\bar \\ell_1 \\sigma^{\\mu \\nu} e_1 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
       },
-      "eW_12": {
-        "tex": "\\left( \\bar \\ell_1 \\sigma^{\\mu \\nu} e_2 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
-      },
-      "eW_13": {
-        "tex": "\\left( \\bar \\ell_1 \\sigma^{\\mu \\nu} e_3 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
-      },
-      "eW_21": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma^{\\mu \\nu} e_1 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
-      },
       "eW_22": {
         "tex": "\\left( \\bar \\ell_2 \\sigma^{\\mu \\nu} e_2 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
-      },
-      "eW_23": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma^{\\mu \\nu} e_3 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
-      },
-      "eW_31": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma^{\\mu \\nu} e_1 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
-      },
-      "eW_32": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma^{\\mu \\nu} e_2 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
       },
       "eW_33": {
         "tex": "\\left( \\bar \\ell_3 \\sigma^{\\mu \\nu} e_3 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
@@ -168,26 +132,8 @@
       "eB_11": {
         "tex": "\\left( \\bar \\ell_1 \\sigma^{\\mu \\nu} e_1 \\right) \\varphi B_{\\mu \\nu}"
       },
-      "eB_12": {
-        "tex": "\\left( \\bar \\ell_1 \\sigma^{\\mu \\nu} e_2 \\right) \\varphi B_{\\mu \\nu}"
-      },
-      "eB_13": {
-        "tex": "\\left( \\bar \\ell_1 \\sigma^{\\mu \\nu} e_3 \\right) \\varphi B_{\\mu \\nu}"
-      },
-      "eB_21": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma^{\\mu \\nu} e_1 \\right) \\varphi B_{\\mu \\nu}"
-      },
       "eB_22": {
         "tex": "\\left( \\bar \\ell_2 \\sigma^{\\mu \\nu} e_2 \\right) \\varphi B_{\\mu \\nu}"
-      },
-      "eB_23": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma^{\\mu \\nu} e_3 \\right) \\varphi B_{\\mu \\nu}"
-      },
-      "eB_31": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma^{\\mu \\nu} e_1 \\right) \\varphi B_{\\mu \\nu}"
-      },
-      "eB_32": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma^{\\mu \\nu} e_2 \\right) \\varphi B_{\\mu \\nu}"
       },
       "eB_33": {
         "tex": "\\left( \\bar \\ell_3 \\sigma^{\\mu \\nu} e_3 \\right) \\varphi B_{\\mu \\nu}"
@@ -357,36 +303,27 @@
       "deltagZeL_11": {
         "real": true
       },
-      "deltagZeL_12": null,
-      "deltagZeL_13": null,
       "deltagZeL_22": {
         "real": true
       },
-      "deltagZeL_23": null,
       "deltagZeL_33": {
         "real": true
       },
       "deltagWlL_11": {
         "real": true
       },
-      "deltagWlL_12": null,
-      "deltagWlL_13": null,
       "deltagWlL_22": {
         "real": true
       },
-      "deltagWlL_23": null,
       "deltagWlL_33": {
         "real": true
       },
       "deltagZeR_11": {
         "real": true
       },
-      "deltagZeR_12": null,
-      "deltagZeR_13": null,
       "deltagZeR_22": {
         "real": true
       },
-      "deltagZeR_23": null,
       "deltagZeR_33": {
         "real": true
       },
@@ -451,87 +388,33 @@
         "real": true,
         "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar \\ell_1 \\gamma^\\mu \\ell_1 \\right)"
       },
-      "ll_1112": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar \\ell_1 \\gamma^\\mu \\ell_2 \\right)"
-      },
-      "ll_1113": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar \\ell_1 \\gamma^\\mu \\ell_3 \\right)"
-      },
       "ll_1122": {
         "real": true,
         "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_2 \\right)"
-      },
-      "ll_1123": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_3 \\right)"
       },
       "ll_1133": {
         "real": true,
         "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_3 \\right)"
       },
-      "ll_1212": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_1 \\gamma^\\mu \\ell_2 \\right)"
-      },
-      "ll_1213": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_1 \\gamma^\\mu \\ell_3 \\right)"
-      },
       "ll_1221": {
         "real": true,
         "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_1 \\right)"
-      },
-      "ll_1222": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_2 \\right)"
-      },
-      "ll_1223": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_3 \\right)"
-      },
-      "ll_1231": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_1 \\right)"
-      },
-      "ll_1232": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_2 \\right)"
-      },
-      "ll_1233": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_3 \\right)"
-      },
-      "ll_1313": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_1 \\gamma^\\mu \\ell_3 \\right)"
-      },
-      "ll_1322": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_2 \\right)"
-      },
-      "ll_1323": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_3 \\right)"
       },
       "ll_1331": {
         "real": true,
         "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_1 \\right)"
       },
-      "ll_1332": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_2 \\right)"
-      },
-      "ll_1333": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_3 \\right)"
-      },
       "ll_2222": {
         "real": true,
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_2 \\right)"
-      },
-      "ll_2223": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_3 \\right)"
       },
       "ll_2233": {
         "real": true,
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_3 \\right)"
       },
-      "ll_2323": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_3 \\right)"
-      },
       "ll_2332": {
         "real": true,
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_2 \\right)"
-      },
-      "ll_2333": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_3 \\right)"
       },
       "ll_3333": {
         "real": true,
@@ -738,60 +621,6 @@
         "real": true,
         "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar q_3 \\gamma^\\mu q_3 \\right)"
       },
-      "lq1_1211": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_1 \\gamma^\\mu q_1 \\right)"
-      },
-      "lq1_1212": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_1 \\gamma^\\mu q_2 \\right)"
-      },
-      "lq1_1213": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_1 \\gamma^\\mu q_3 \\right)"
-      },
-      "lq1_1221": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_2 \\gamma^\\mu q_1 \\right)"
-      },
-      "lq1_1222": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_2 \\gamma^\\mu q_2 \\right)"
-      },
-      "lq1_1223": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_2 \\gamma^\\mu q_3 \\right)"
-      },
-      "lq1_1231": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_3 \\gamma^\\mu q_1 \\right)"
-      },
-      "lq1_1232": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_3 \\gamma^\\mu q_2 \\right)"
-      },
-      "lq1_1233": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_3 \\gamma^\\mu q_3 \\right)"
-      },
-      "lq1_1311": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu q_1 \\right)"
-      },
-      "lq1_1312": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu q_2 \\right)"
-      },
-      "lq1_1313": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu q_3 \\right)"
-      },
-      "lq1_1321": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu q_1 \\right)"
-      },
-      "lq1_1322": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu q_2 \\right)"
-      },
-      "lq1_1323": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu q_3 \\right)"
-      },
-      "lq1_1331": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu q_1 \\right)"
-      },
-      "lq1_1332": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu q_2 \\right)"
-      },
-      "lq1_1333": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu q_3 \\right)"
-      },
       "lq1_2211": {
         "real": true,
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_1 \\gamma^\\mu q_1 \\right)"
@@ -812,33 +641,6 @@
       "lq1_2233": {
         "real": true,
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_3 \\gamma^\\mu q_3 \\right)"
-      },
-      "lq1_2311": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu q_1 \\right)"
-      },
-      "lq1_2312": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu q_2 \\right)"
-      },
-      "lq1_2313": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu q_3 \\right)"
-      },
-      "lq1_2321": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu q_1 \\right)"
-      },
-      "lq1_2322": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu q_2 \\right)"
-      },
-      "lq1_2323": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu q_3 \\right)"
-      },
-      "lq1_2331": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu q_1 \\right)"
-      },
-      "lq1_2332": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu q_2 \\right)"
-      },
-      "lq1_2333": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu q_3 \\right)"
       },
       "lq1_3311": {
         "real": true,
@@ -882,60 +684,6 @@
         "real": true,
         "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_1 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_3 \\right)"
       },
-      "lq3_1211": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_1 \\right)"
-      },
-      "lq3_1212": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_2 \\right)"
-      },
-      "lq3_1213": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_3 \\right)"
-      },
-      "lq3_1221": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_1 \\right)"
-      },
-      "lq3_1222": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_2 \\right)"
-      },
-      "lq3_1223": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_3 \\right)"
-      },
-      "lq3_1231": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_1 \\right)"
-      },
-      "lq3_1232": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_2 \\right)"
-      },
-      "lq3_1233": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_3 \\right)"
-      },
-      "lq3_1311": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_1 \\right)"
-      },
-      "lq3_1312": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_2 \\right)"
-      },
-      "lq3_1313": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_3 \\right)"
-      },
-      "lq3_1321": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_1 \\right)"
-      },
-      "lq3_1322": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_2 \\right)"
-      },
-      "lq3_1323": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_3 \\right)"
-      },
-      "lq3_1331": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_1 \\right)"
-      },
-      "lq3_1332": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_2 \\right)"
-      },
-      "lq3_1333": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_3 \\right)"
-      },
       "lq3_2211": {
         "real": true,
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_1 \\right)"
@@ -956,33 +704,6 @@
       "lq3_2233": {
         "real": true,
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_3 \\right)"
-      },
-      "lq3_2311": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_1 \\right)"
-      },
-      "lq3_2312": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_2 \\right)"
-      },
-      "lq3_2313": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_3 \\right)"
-      },
-      "lq3_2321": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_1 \\right)"
-      },
-      "lq3_2322": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_2 \\right)"
-      },
-      "lq3_2323": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_3 \\right)"
-      },
-      "lq3_2331": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_1 \\right)"
-      },
-      "lq3_2332": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_2 \\right)"
-      },
-      "lq3_2333": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_3 \\right)"
       },
       "lq3_3311": {
         "real": true,
@@ -1009,66 +730,21 @@
         "real": true,
         "tex": "\\left( \\bar e_1 \\gamma_\\mu e_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
       },
-      "ee_1112": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "ee_1113": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
       "ee_1122": {
         "real": true,
         "tex": "\\left( \\bar e_1 \\gamma_\\mu e_1 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "ee_1123": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_1 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
       },
       "ee_1133": {
         "real": true,
         "tex": "\\left( \\bar e_1 \\gamma_\\mu e_1 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
       },
-      "ee_1212": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "ee_1213": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
-      "ee_1222": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "ee_1223": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
-      },
-      "ee_1232": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_2 \\right)"
-      },
-      "ee_1233": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
-      },
-      "ee_1313": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
-      "ee_1323": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
-      },
-      "ee_1333": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
-      },
       "ee_2222": {
         "real": true,
         "tex": "\\left( \\bar e_2 \\gamma_\\mu e_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
       },
-      "ee_2223": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
-      },
       "ee_2233": {
         "real": true,
         "tex": "\\left( \\bar e_2 \\gamma_\\mu e_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
-      },
-      "ee_2323": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
-      },
-      "ee_2333": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
       },
       "ee_3333": {
         "real": true,
@@ -1275,60 +951,6 @@
         "real": true,
         "tex": "\\left( \\bar e_1 \\gamma_\\mu e_1 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
       },
-      "eu_1211": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_1 \\gamma^\\mu u_1 \\right)"
-      },
-      "eu_1212": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_1 \\gamma^\\mu u_2 \\right)"
-      },
-      "eu_1213": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_1 \\gamma^\\mu u_3 \\right)"
-      },
-      "eu_1221": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_2 \\gamma^\\mu u_1 \\right)"
-      },
-      "eu_1222": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_2 \\gamma^\\mu u_2 \\right)"
-      },
-      "eu_1223": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_2 \\gamma^\\mu u_3 \\right)"
-      },
-      "eu_1231": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_3 \\gamma^\\mu u_1 \\right)"
-      },
-      "eu_1232": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_3 \\gamma^\\mu u_2 \\right)"
-      },
-      "eu_1233": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
-      },
-      "eu_1311": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_1 \\right)"
-      },
-      "eu_1312": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_2 \\right)"
-      },
-      "eu_1313": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_3 \\right)"
-      },
-      "eu_1321": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_1 \\right)"
-      },
-      "eu_1322": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_2 \\right)"
-      },
-      "eu_1323": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_3 \\right)"
-      },
-      "eu_1331": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_1 \\right)"
-      },
-      "eu_1332": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_2 \\right)"
-      },
-      "eu_1333": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
-      },
       "eu_2211": {
         "real": true,
         "tex": "\\left( \\bar e_2 \\gamma_\\mu e_2 \\right) \\left( \\bar u_1 \\gamma^\\mu u_1 \\right)"
@@ -1349,33 +971,6 @@
       "eu_2233": {
         "real": true,
         "tex": "\\left( \\bar e_2 \\gamma_\\mu e_2 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
-      },
-      "eu_2311": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_1 \\right)"
-      },
-      "eu_2312": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_2 \\right)"
-      },
-      "eu_2313": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_3 \\right)"
-      },
-      "eu_2321": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_1 \\right)"
-      },
-      "eu_2322": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_2 \\right)"
-      },
-      "eu_2323": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_3 \\right)"
-      },
-      "eu_2331": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_1 \\right)"
-      },
-      "eu_2332": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_2 \\right)"
-      },
-      "eu_2333": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
       },
       "eu_3311": {
         "real": true,
@@ -1419,60 +1014,6 @@
         "real": true,
         "tex": "\\left( \\bar e_1 \\gamma_\\mu e_1 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
       },
-      "ed_1211": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_1 \\gamma^\\mu d_1 \\right)"
-      },
-      "ed_1212": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_1 \\gamma^\\mu d_2 \\right)"
-      },
-      "ed_1213": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_1 \\gamma^\\mu d_3 \\right)"
-      },
-      "ed_1221": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_2 \\gamma^\\mu d_1 \\right)"
-      },
-      "ed_1222": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_2 \\gamma^\\mu d_2 \\right)"
-      },
-      "ed_1223": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_2 \\gamma^\\mu d_3 \\right)"
-      },
-      "ed_1231": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_3 \\gamma^\\mu d_1 \\right)"
-      },
-      "ed_1232": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_3 \\gamma^\\mu d_2 \\right)"
-      },
-      "ed_1233": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
-      },
-      "ed_1311": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_1 \\right)"
-      },
-      "ed_1312": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_2 \\right)"
-      },
-      "ed_1313": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_3 \\right)"
-      },
-      "ed_1321": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_1 \\right)"
-      },
-      "ed_1322": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_2 \\right)"
-      },
-      "ed_1323": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_3 \\right)"
-      },
-      "ed_1331": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_1 \\right)"
-      },
-      "ed_1332": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_2 \\right)"
-      },
-      "ed_1333": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
-      },
       "ed_2211": {
         "real": true,
         "tex": "\\left( \\bar e_2 \\gamma_\\mu e_2 \\right) \\left( \\bar d_1 \\gamma^\\mu d_1 \\right)"
@@ -1493,33 +1034,6 @@
       "ed_2233": {
         "real": true,
         "tex": "\\left( \\bar e_2 \\gamma_\\mu e_2 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
-      },
-      "ed_2311": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_1 \\right)"
-      },
-      "ed_2312": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_2 \\right)"
-      },
-      "ed_2313": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_3 \\right)"
-      },
-      "ed_2321": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_1 \\right)"
-      },
-      "ed_2322": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_2 \\right)"
-      },
-      "ed_2323": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_3 \\right)"
-      },
-      "ed_2331": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_1 \\right)"
-      },
-      "ed_2332": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_2 \\right)"
-      },
-      "ed_2333": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
       },
       "ed_3311": {
         "real": true,
@@ -1834,141 +1348,42 @@
         "real": true,
         "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
       },
-      "le_1112": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_1113": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
       "le_1122": {
         "real": true,
         "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_1123": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
       },
       "le_1133": {
         "real": true,
         "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
       },
-      "le_1211": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
-      },
-      "le_1212": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_1213": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
       "le_1221": {
         "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_1 \\right)"
       },
-      "le_1222": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_1223": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
-      },
-      "le_1231": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_1 \\right)"
-      },
-      "le_1232": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_1233": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
-      },
-      "le_1311": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
-      },
-      "le_1312": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_1313": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
-      "le_1321": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_1 \\right)"
-      },
-      "le_1322": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_1323": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
-      },
       "le_1331": {
         "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_1 \\right)"
-      },
-      "le_1332": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_1333": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
       },
       "le_2211": {
         "real": true,
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
       },
-      "le_2212": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_2213": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
       "le_2222": {
         "real": true,
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_2223": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
       },
       "le_2233": {
         "real": true,
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
       },
-      "le_2311": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
-      },
-      "le_2312": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_2313": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
-      "le_2321": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_1 \\right)"
-      },
-      "le_2322": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_2323": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
-      },
-      "le_2331": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_1 \\right)"
-      },
       "le_2332": {
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_2333": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
       },
       "le_3311": {
         "real": true,
         "tex": "\\left( \\bar \\ell_3 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
       },
-      "le_3312": {
-        "tex": "\\left( \\bar \\ell_3 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_3313": {
-        "tex": "\\left( \\bar \\ell_3 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
       "le_3322": {
         "real": true,
         "tex": "\\left( \\bar \\ell_3 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_3323": {
-        "tex": "\\left( \\bar \\ell_3 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
       },
       "le_3333": {
         "real": true,
@@ -1995,60 +1410,6 @@
         "real": true,
         "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
       },
-      "lu_1211": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_1 \\gamma^\\mu u_1 \\right)"
-      },
-      "lu_1212": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_1 \\gamma^\\mu u_2 \\right)"
-      },
-      "lu_1213": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_1 \\gamma^\\mu u_3 \\right)"
-      },
-      "lu_1221": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_2 \\gamma^\\mu u_1 \\right)"
-      },
-      "lu_1222": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_2 \\gamma^\\mu u_2 \\right)"
-      },
-      "lu_1223": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_2 \\gamma^\\mu u_3 \\right)"
-      },
-      "lu_1231": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_3 \\gamma^\\mu u_1 \\right)"
-      },
-      "lu_1232": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_3 \\gamma^\\mu u_2 \\right)"
-      },
-      "lu_1233": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
-      },
-      "lu_1311": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_1 \\right)"
-      },
-      "lu_1312": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_2 \\right)"
-      },
-      "lu_1313": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_3 \\right)"
-      },
-      "lu_1321": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_1 \\right)"
-      },
-      "lu_1322": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_2 \\right)"
-      },
-      "lu_1323": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_3 \\right)"
-      },
-      "lu_1331": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_1 \\right)"
-      },
-      "lu_1332": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_2 \\right)"
-      },
-      "lu_1333": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
-      },
       "lu_2211": {
         "real": true,
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_1 \\gamma^\\mu u_1 \\right)"
@@ -2069,33 +1430,6 @@
       "lu_2233": {
         "real": true,
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
-      },
-      "lu_2311": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_1 \\right)"
-      },
-      "lu_2312": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_2 \\right)"
-      },
-      "lu_2313": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_3 \\right)"
-      },
-      "lu_2321": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_1 \\right)"
-      },
-      "lu_2322": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_2 \\right)"
-      },
-      "lu_2323": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_3 \\right)"
-      },
-      "lu_2331": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_1 \\right)"
-      },
-      "lu_2332": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_2 \\right)"
-      },
-      "lu_2333": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
       },
       "lu_3311": {
         "real": true,
@@ -2139,60 +1473,6 @@
         "real": true,
         "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
       },
-      "ld_1211": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_1 \\gamma^\\mu d_1 \\right)"
-      },
-      "ld_1212": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_1 \\gamma^\\mu d_2 \\right)"
-      },
-      "ld_1213": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_1 \\gamma^\\mu d_3 \\right)"
-      },
-      "ld_1221": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_2 \\gamma^\\mu d_1 \\right)"
-      },
-      "ld_1222": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_2 \\gamma^\\mu d_2 \\right)"
-      },
-      "ld_1223": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_2 \\gamma^\\mu d_3 \\right)"
-      },
-      "ld_1231": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_3 \\gamma^\\mu d_1 \\right)"
-      },
-      "ld_1232": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_3 \\gamma^\\mu d_2 \\right)"
-      },
-      "ld_1233": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
-      },
-      "ld_1311": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_1 \\right)"
-      },
-      "ld_1312": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_2 \\right)"
-      },
-      "ld_1313": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_3 \\right)"
-      },
-      "ld_1321": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_1 \\right)"
-      },
-      "ld_1322": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_2 \\right)"
-      },
-      "ld_1323": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_3 \\right)"
-      },
-      "ld_1331": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_1 \\right)"
-      },
-      "ld_1332": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_2 \\right)"
-      },
-      "ld_1333": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
-      },
       "ld_2211": {
         "real": true,
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_1 \\gamma^\\mu d_1 \\right)"
@@ -2213,33 +1493,6 @@
       "ld_2233": {
         "real": true,
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
-      },
-      "ld_2311": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_1 \\right)"
-      },
-      "ld_2312": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_2 \\right)"
-      },
-      "ld_2313": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_3 \\right)"
-      },
-      "ld_2321": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_1 \\right)"
-      },
-      "ld_2322": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_2 \\right)"
-      },
-      "ld_2323": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_3 \\right)"
-      },
-      "ld_2331": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_1 \\right)"
-      },
-      "ld_2332": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_2 \\right)"
-      },
-      "ld_2333": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
       },
       "ld_3311": {
         "real": true,
@@ -2266,18 +1519,9 @@
         "real": true,
         "tex": "\\left( \\bar q_1 \\gamma_\\mu q_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
       },
-      "qe_1112": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "qe_1113": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
       "qe_1122": {
         "real": true,
         "tex": "\\left( \\bar q_1 \\gamma_\\mu q_1 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "qe_1123": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_1 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
       },
       "qe_1133": {
         "real": true,
@@ -2286,26 +1530,8 @@
       "qe_1211": {
         "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
       },
-      "qe_1212": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "qe_1213": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
-      "qe_1221": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_1 \\right)"
-      },
       "qe_1222": {
         "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "qe_1223": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
-      },
-      "qe_1231": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_1 \\right)"
-      },
-      "qe_1232": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_2 \\right)"
       },
       "qe_1233": {
         "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
@@ -2313,26 +1539,8 @@
       "qe_1311": {
         "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
       },
-      "qe_1312": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "qe_1313": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
-      "qe_1321": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_1 \\right)"
-      },
       "qe_1322": {
         "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "qe_1323": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
-      },
-      "qe_1331": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_1 \\right)"
-      },
-      "qe_1332": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_2 \\right)"
       },
       "qe_1333": {
         "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
@@ -2341,18 +1549,9 @@
         "real": true,
         "tex": "\\left( \\bar q_2 \\gamma_\\mu q_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
       },
-      "qe_2212": {
-        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "qe_2213": {
-        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
       "qe_2222": {
         "real": true,
         "tex": "\\left( \\bar q_2 \\gamma_\\mu q_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "qe_2223": {
-        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
       },
       "qe_2233": {
         "real": true,
@@ -2361,26 +1560,8 @@
       "qe_2311": {
         "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
       },
-      "qe_2312": {
-        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "qe_2313": {
-        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
-      "qe_2321": {
-        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_1 \\right)"
-      },
       "qe_2322": {
         "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "qe_2323": {
-        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
-      },
-      "qe_2331": {
-        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_1 \\right)"
-      },
-      "qe_2332": {
-        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_2 \\right)"
       },
       "qe_2333": {
         "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
@@ -2389,18 +1570,9 @@
         "real": true,
         "tex": "\\left( \\bar q_3 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
       },
-      "qe_3312": {
-        "tex": "\\left( \\bar q_3 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "qe_3313": {
-        "tex": "\\left( \\bar q_3 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
       "qe_3322": {
         "real": true,
         "tex": "\\left( \\bar q_3 \\gamma_\\mu q_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "qe_3323": {
-        "tex": "\\left( \\bar q_3 \\gamma_\\mu q_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
       },
       "qe_3333": {
         "real": true,
@@ -3009,87 +2181,6 @@
       "ledq_1133": {
         "tex": "\\left( \\bar \\ell_1 e_1 \\right) \\left( \\bar d_3 q_3 \\right)"
       },
-      "ledq_1211": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_1 q_1 \\right)"
-      },
-      "ledq_1212": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_1 q_2 \\right)"
-      },
-      "ledq_1213": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_1 q_3 \\right)"
-      },
-      "ledq_1221": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_2 q_1 \\right)"
-      },
-      "ledq_1222": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_2 q_2 \\right)"
-      },
-      "ledq_1223": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_2 q_3 \\right)"
-      },
-      "ledq_1231": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_3 q_1 \\right)"
-      },
-      "ledq_1232": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_3 q_2 \\right)"
-      },
-      "ledq_1233": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_3 q_3 \\right)"
-      },
-      "ledq_1311": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_1 q_1 \\right)"
-      },
-      "ledq_1312": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_1 q_2 \\right)"
-      },
-      "ledq_1313": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_1 q_3 \\right)"
-      },
-      "ledq_1321": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_2 q_1 \\right)"
-      },
-      "ledq_1322": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_2 q_2 \\right)"
-      },
-      "ledq_1323": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_2 q_3 \\right)"
-      },
-      "ledq_1331": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_3 q_1 \\right)"
-      },
-      "ledq_1332": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_3 q_2 \\right)"
-      },
-      "ledq_1333": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_3 q_3 \\right)"
-      },
-      "ledq_2111": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_1 q_1 \\right)"
-      },
-      "ledq_2112": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_1 q_2 \\right)"
-      },
-      "ledq_2113": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_1 q_3 \\right)"
-      },
-      "ledq_2121": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_2 q_1 \\right)"
-      },
-      "ledq_2122": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_2 q_2 \\right)"
-      },
-      "ledq_2123": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_2 q_3 \\right)"
-      },
-      "ledq_2131": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_3 q_1 \\right)"
-      },
-      "ledq_2132": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_3 q_2 \\right)"
-      },
-      "ledq_2133": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_3 q_3 \\right)"
-      },
       "ledq_2211": {
         "tex": "\\left( \\bar \\ell_2 e_2 \\right) \\left( \\bar d_1 q_1 \\right)"
       },
@@ -3116,87 +2207,6 @@
       },
       "ledq_2233": {
         "tex": "\\left( \\bar \\ell_2 e_2 \\right) \\left( \\bar d_3 q_3 \\right)"
-      },
-      "ledq_2311": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_1 q_1 \\right)"
-      },
-      "ledq_2312": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_1 q_2 \\right)"
-      },
-      "ledq_2313": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_1 q_3 \\right)"
-      },
-      "ledq_2321": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_2 q_1 \\right)"
-      },
-      "ledq_2322": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_2 q_2 \\right)"
-      },
-      "ledq_2323": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_2 q_3 \\right)"
-      },
-      "ledq_2331": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_3 q_1 \\right)"
-      },
-      "ledq_2332": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_3 q_2 \\right)"
-      },
-      "ledq_2333": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_3 q_3 \\right)"
-      },
-      "ledq_3111": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_1 q_1 \\right)"
-      },
-      "ledq_3112": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_1 q_2 \\right)"
-      },
-      "ledq_3113": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_1 q_3 \\right)"
-      },
-      "ledq_3121": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_2 q_1 \\right)"
-      },
-      "ledq_3122": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_2 q_2 \\right)"
-      },
-      "ledq_3123": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_2 q_3 \\right)"
-      },
-      "ledq_3131": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_3 q_1 \\right)"
-      },
-      "ledq_3132": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_3 q_2 \\right)"
-      },
-      "ledq_3133": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_3 q_3 \\right)"
-      },
-      "ledq_3211": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_1 q_1 \\right)"
-      },
-      "ledq_3212": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_1 q_2 \\right)"
-      },
-      "ledq_3213": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_1 q_3 \\right)"
-      },
-      "ledq_3221": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_2 q_1 \\right)"
-      },
-      "ledq_3222": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_2 q_2 \\right)"
-      },
-      "ledq_3223": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_2 q_3 \\right)"
-      },
-      "ledq_3231": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_3 q_1 \\right)"
-      },
-      "ledq_3232": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_3 q_2 \\right)"
-      },
-      "ledq_3233": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_3 q_3 \\right)"
       },
       "ledq_3311": {
         "tex": "\\left( \\bar \\ell_3 e_3 \\right) \\left( \\bar d_1 q_1 \\right)"
@@ -3738,87 +2748,6 @@
       "lequ1_1133": {
         "tex": "\\left( \\bar \\ell_1 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_3 \\right)"
       },
-      "lequ1_1211": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_1 \\right)"
-      },
-      "lequ1_1212": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_2 \\right)"
-      },
-      "lequ1_1213": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_3 \\right)"
-      },
-      "lequ1_1221": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_1 \\right)"
-      },
-      "lequ1_1222": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_2 \\right)"
-      },
-      "lequ1_1223": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_3 \\right)"
-      },
-      "lequ1_1231": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_1 \\right)"
-      },
-      "lequ1_1232": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_2 \\right)"
-      },
-      "lequ1_1233": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_3 \\right)"
-      },
-      "lequ1_1311": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_1 \\right)"
-      },
-      "lequ1_1312": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_2 \\right)"
-      },
-      "lequ1_1313": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_3 \\right)"
-      },
-      "lequ1_1321": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_1 \\right)"
-      },
-      "lequ1_1322": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_2 \\right)"
-      },
-      "lequ1_1323": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_3 \\right)"
-      },
-      "lequ1_1331": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_1 \\right)"
-      },
-      "lequ1_1332": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_2 \\right)"
-      },
-      "lequ1_1333": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_3 \\right)"
-      },
-      "lequ1_2111": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_1 \\right)"
-      },
-      "lequ1_2112": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_2 \\right)"
-      },
-      "lequ1_2113": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_3 \\right)"
-      },
-      "lequ1_2121": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_1 \\right)"
-      },
-      "lequ1_2122": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_2 \\right)"
-      },
-      "lequ1_2123": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_3 \\right)"
-      },
-      "lequ1_2131": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_1 \\right)"
-      },
-      "lequ1_2132": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_2 \\right)"
-      },
-      "lequ1_2133": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_3 \\right)"
-      },
       "lequ1_2211": {
         "tex": "\\left( \\bar \\ell_2 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_1 \\right)"
       },
@@ -3845,87 +2774,6 @@
       },
       "lequ1_2233": {
         "tex": "\\left( \\bar \\ell_2 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_3 \\right)"
-      },
-      "lequ1_2311": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_1 \\right)"
-      },
-      "lequ1_2312": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_2 \\right)"
-      },
-      "lequ1_2313": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_3 \\right)"
-      },
-      "lequ1_2321": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_1 \\right)"
-      },
-      "lequ1_2322": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_2 \\right)"
-      },
-      "lequ1_2323": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_3 \\right)"
-      },
-      "lequ1_2331": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_1 \\right)"
-      },
-      "lequ1_2332": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_2 \\right)"
-      },
-      "lequ1_2333": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_3 \\right)"
-      },
-      "lequ1_3111": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_1 \\right)"
-      },
-      "lequ1_3112": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_2 \\right)"
-      },
-      "lequ1_3113": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_3 \\right)"
-      },
-      "lequ1_3121": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_1 \\right)"
-      },
-      "lequ1_3122": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_2 \\right)"
-      },
-      "lequ1_3123": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_3 \\right)"
-      },
-      "lequ1_3131": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_1 \\right)"
-      },
-      "lequ1_3132": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_2 \\right)"
-      },
-      "lequ1_3133": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_3 \\right)"
-      },
-      "lequ1_3211": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_1 \\right)"
-      },
-      "lequ1_3212": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_2 \\right)"
-      },
-      "lequ1_3213": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_3 \\right)"
-      },
-      "lequ1_3221": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_1 \\right)"
-      },
-      "lequ1_3222": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_2 \\right)"
-      },
-      "lequ1_3223": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_3 \\right)"
-      },
-      "lequ1_3231": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_1 \\right)"
-      },
-      "lequ1_3232": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_2 \\right)"
-      },
-      "lequ1_3233": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_3 \\right)"
       },
       "lequ1_3311": {
         "tex": "\\left( \\bar \\ell_3 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_1 \\right)"
@@ -3981,6 +2829,425 @@
       "lequ3_1133": {
         "tex": "\\left( \\bar \\ell_1 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_3 \\right)"
       },
+      "lequ3_2211": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_1 \\right)"
+      },
+      "lequ3_2212": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_2 \\right)"
+      },
+      "lequ3_2213": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_3 \\right)"
+      },
+      "lequ3_2221": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_1 \\right)"
+      },
+      "lequ3_2222": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_2 \\right)"
+      },
+      "lequ3_2223": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_3 \\right)"
+      },
+      "lequ3_2231": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_1 \\right)"
+      },
+      "lequ3_2232": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_2 \\right)"
+      },
+      "lequ3_2233": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_3 \\right)"
+      },
+      "lequ3_3311": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_1 \\right)"
+      },
+      "lequ3_3312": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_2 \\right)"
+      },
+      "lequ3_3313": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_3 \\right)"
+      },
+      "lequ3_3321": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_1 \\right)"
+      },
+      "lequ3_3322": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_2 \\right)"
+      },
+      "lequ3_3323": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_3 \\right)"
+      },
+      "lequ3_3331": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_1 \\right)"
+      },
+      "lequ3_3332": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_2 \\right)"
+      },
+      "lequ3_3333": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_3 \\right)"
+      }
+    },
+    "mue": {
+      "ephi_12": {
+        "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_1 e_2 \\varphi \\right)"
+      },
+      "ephi_21": {
+        "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_2 e_1 \\varphi \\right)"
+      },
+      "eW_12": {
+        "tex": "\\left( \\bar \\ell_1 \\sigma^{\\mu \\nu} e_2 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
+      },
+      "eW_21": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma^{\\mu \\nu} e_1 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
+      },
+      "eB_12": {
+        "tex": "\\left( \\bar \\ell_1 \\sigma^{\\mu \\nu} e_2 \\right) \\varphi B_{\\mu \\nu}"
+      },
+      "eB_21": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma^{\\mu \\nu} e_1 \\right) \\varphi B_{\\mu \\nu}"
+      },
+      "deltagZeL_12": null,
+      "deltagWlL_12": null,
+      "deltagZeR_12": null,
+      "ll_1112": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar \\ell_1 \\gamma^\\mu \\ell_2 \\right)"
+      },
+      "ll_1222": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_2 \\right)"
+      },
+      "ll_1233": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_3 \\right)"
+      },
+      "ll_1332": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_2 \\right)"
+      },
+      "lq1_1211": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_1 \\gamma^\\mu q_1 \\right)"
+      },
+      "lq1_1212": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_1 \\gamma^\\mu q_2 \\right)"
+      },
+      "lq1_1213": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_1 \\gamma^\\mu q_3 \\right)"
+      },
+      "lq1_1221": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_2 \\gamma^\\mu q_1 \\right)"
+      },
+      "lq1_1222": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_2 \\gamma^\\mu q_2 \\right)"
+      },
+      "lq1_1223": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_2 \\gamma^\\mu q_3 \\right)"
+      },
+      "lq1_1231": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_3 \\gamma^\\mu q_1 \\right)"
+      },
+      "lq1_1232": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_3 \\gamma^\\mu q_2 \\right)"
+      },
+      "lq1_1233": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_3 \\gamma^\\mu q_3 \\right)"
+      },
+      "lq3_1211": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_1 \\right)"
+      },
+      "lq3_1212": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_2 \\right)"
+      },
+      "lq3_1213": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_3 \\right)"
+      },
+      "lq3_1221": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_1 \\right)"
+      },
+      "lq3_1222": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_2 \\right)"
+      },
+      "lq3_1223": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_3 \\right)"
+      },
+      "lq3_1231": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_1 \\right)"
+      },
+      "lq3_1232": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_2 \\right)"
+      },
+      "lq3_1233": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_3 \\right)"
+      },
+      "ee_1112": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
+      },
+      "ee_1222": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
+      },
+      "ee_1233": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
+      },
+      "eu_1211": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_1 \\gamma^\\mu u_1 \\right)"
+      },
+      "eu_1212": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_1 \\gamma^\\mu u_2 \\right)"
+      },
+      "eu_1213": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_1 \\gamma^\\mu u_3 \\right)"
+      },
+      "eu_1221": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_2 \\gamma^\\mu u_1 \\right)"
+      },
+      "eu_1222": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_2 \\gamma^\\mu u_2 \\right)"
+      },
+      "eu_1223": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_2 \\gamma^\\mu u_3 \\right)"
+      },
+      "eu_1231": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_3 \\gamma^\\mu u_1 \\right)"
+      },
+      "eu_1232": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_3 \\gamma^\\mu u_2 \\right)"
+      },
+      "eu_1233": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
+      },
+      "ed_1211": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_1 \\gamma^\\mu d_1 \\right)"
+      },
+      "ed_1212": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_1 \\gamma^\\mu d_2 \\right)"
+      },
+      "ed_1213": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_1 \\gamma^\\mu d_3 \\right)"
+      },
+      "ed_1221": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_2 \\gamma^\\mu d_1 \\right)"
+      },
+      "ed_1222": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_2 \\gamma^\\mu d_2 \\right)"
+      },
+      "ed_1223": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_2 \\gamma^\\mu d_3 \\right)"
+      },
+      "ed_1231": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_3 \\gamma^\\mu d_1 \\right)"
+      },
+      "ed_1232": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_3 \\gamma^\\mu d_2 \\right)"
+      },
+      "ed_1233": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
+      },
+      "le_1112": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
+      },
+      "le_1211": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
+      },
+      "le_1222": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
+      },
+      "le_1233": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
+      },
+      "le_1332": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_2 \\right)"
+      },
+      "le_2212": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
+      },
+      "le_2331": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_1 \\right)"
+      },
+      "le_3312": {
+        "tex": "\\left( \\bar \\ell_3 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
+      },
+      "lu_1211": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_1 \\gamma^\\mu u_1 \\right)"
+      },
+      "lu_1212": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_1 \\gamma^\\mu u_2 \\right)"
+      },
+      "lu_1213": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_1 \\gamma^\\mu u_3 \\right)"
+      },
+      "lu_1221": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_2 \\gamma^\\mu u_1 \\right)"
+      },
+      "lu_1222": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_2 \\gamma^\\mu u_2 \\right)"
+      },
+      "lu_1223": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_2 \\gamma^\\mu u_3 \\right)"
+      },
+      "lu_1231": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_3 \\gamma^\\mu u_1 \\right)"
+      },
+      "lu_1232": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_3 \\gamma^\\mu u_2 \\right)"
+      },
+      "lu_1233": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
+      },
+      "ld_1211": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_1 \\gamma^\\mu d_1 \\right)"
+      },
+      "ld_1212": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_1 \\gamma^\\mu d_2 \\right)"
+      },
+      "ld_1213": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_1 \\gamma^\\mu d_3 \\right)"
+      },
+      "ld_1221": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_2 \\gamma^\\mu d_1 \\right)"
+      },
+      "ld_1222": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_2 \\gamma^\\mu d_2 \\right)"
+      },
+      "ld_1223": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_2 \\gamma^\\mu d_3 \\right)"
+      },
+      "ld_1231": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_3 \\gamma^\\mu d_1 \\right)"
+      },
+      "ld_1232": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_3 \\gamma^\\mu d_2 \\right)"
+      },
+      "ld_1233": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
+      },
+      "qe_1112": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
+      },
+      "qe_1212": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
+      },
+      "qe_1221": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_1 \\right)"
+      },
+      "qe_1312": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
+      },
+      "qe_1321": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_1 \\right)"
+      },
+      "qe_2212": {
+        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
+      },
+      "qe_2312": {
+        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
+      },
+      "qe_2321": {
+        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_1 \\right)"
+      },
+      "qe_3312": {
+        "tex": "\\left( \\bar q_3 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
+      },
+      "ledq_1211": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_1 q_1 \\right)"
+      },
+      "ledq_1212": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_1 q_2 \\right)"
+      },
+      "ledq_1213": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_1 q_3 \\right)"
+      },
+      "ledq_1221": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_2 q_1 \\right)"
+      },
+      "ledq_1222": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_2 q_2 \\right)"
+      },
+      "ledq_1223": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_2 q_3 \\right)"
+      },
+      "ledq_1231": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_3 q_1 \\right)"
+      },
+      "ledq_1232": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_3 q_2 \\right)"
+      },
+      "ledq_1233": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_3 q_3 \\right)"
+      },
+      "ledq_2111": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_1 q_1 \\right)"
+      },
+      "ledq_2112": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_1 q_2 \\right)"
+      },
+      "ledq_2113": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_1 q_3 \\right)"
+      },
+      "ledq_2121": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_2 q_1 \\right)"
+      },
+      "ledq_2122": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_2 q_2 \\right)"
+      },
+      "ledq_2123": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_2 q_3 \\right)"
+      },
+      "ledq_2131": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_3 q_1 \\right)"
+      },
+      "ledq_2132": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_3 q_2 \\right)"
+      },
+      "ledq_2133": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_3 q_3 \\right)"
+      },
+      "lequ1_1211": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_1 \\right)"
+      },
+      "lequ1_1212": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_2 \\right)"
+      },
+      "lequ1_1213": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_3 \\right)"
+      },
+      "lequ1_1221": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_1 \\right)"
+      },
+      "lequ1_1222": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_2 \\right)"
+      },
+      "lequ1_1223": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_3 \\right)"
+      },
+      "lequ1_1231": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_1 \\right)"
+      },
+      "lequ1_1232": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_2 \\right)"
+      },
+      "lequ1_1233": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_3 \\right)"
+      },
+      "lequ1_2111": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_1 \\right)"
+      },
+      "lequ1_2112": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_2 \\right)"
+      },
+      "lequ1_2113": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_3 \\right)"
+      },
+      "lequ1_2121": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_1 \\right)"
+      },
+      "lequ1_2122": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_2 \\right)"
+      },
+      "lequ1_2123": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_3 \\right)"
+      },
+      "lequ1_2131": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_1 \\right)"
+      },
+      "lequ1_2132": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_2 \\right)"
+      },
+      "lequ1_2133": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_3 \\right)"
+      },
       "lequ3_1211": {
         "tex": "\\left( \\bar \\ell_1 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_1 \\right)"
       },
@@ -4007,6 +3274,398 @@
       },
       "lequ3_1233": {
         "tex": "\\left( \\bar \\ell_1 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_3 \\right)"
+      },
+      "lequ3_2111": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_1 \\right)"
+      },
+      "lequ3_2112": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_2 \\right)"
+      },
+      "lequ3_2113": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_3 \\right)"
+      },
+      "lequ3_2121": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_1 \\right)"
+      },
+      "lequ3_2122": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_2 \\right)"
+      },
+      "lequ3_2123": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_3 \\right)"
+      },
+      "lequ3_2131": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_1 \\right)"
+      },
+      "lequ3_2132": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_2 \\right)"
+      },
+      "lequ3_2133": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_3 \\right)"
+      }
+    },
+    "taue": {
+      "ephi_13": {
+        "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_1 e_3 \\varphi \\right)"
+      },
+      "ephi_31": {
+        "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_3 e_1 \\varphi \\right)"
+      },
+      "eW_13": {
+        "tex": "\\left( \\bar \\ell_1 \\sigma^{\\mu \\nu} e_3 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
+      },
+      "eW_31": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma^{\\mu \\nu} e_1 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
+      },
+      "eB_13": {
+        "tex": "\\left( \\bar \\ell_1 \\sigma^{\\mu \\nu} e_3 \\right) \\varphi B_{\\mu \\nu}"
+      },
+      "eB_31": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma^{\\mu \\nu} e_1 \\right) \\varphi B_{\\mu \\nu}"
+      },
+      "deltagZeL_13": null,
+      "deltagWlL_13": null,
+      "deltagZeR_13": null,
+      "ll_1113": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar \\ell_1 \\gamma^\\mu \\ell_3 \\right)"
+      },
+      "ll_1223": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_3 \\right)"
+      },
+      "ll_1322": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_2 \\right)"
+      },
+      "ll_1333": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_3 \\right)"
+      },
+      "lq1_1311": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu q_1 \\right)"
+      },
+      "lq1_1312": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu q_2 \\right)"
+      },
+      "lq1_1313": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu q_3 \\right)"
+      },
+      "lq1_1321": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu q_1 \\right)"
+      },
+      "lq1_1322": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu q_2 \\right)"
+      },
+      "lq1_1323": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu q_3 \\right)"
+      },
+      "lq1_1331": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu q_1 \\right)"
+      },
+      "lq1_1332": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu q_2 \\right)"
+      },
+      "lq1_1333": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu q_3 \\right)"
+      },
+      "lq3_1311": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_1 \\right)"
+      },
+      "lq3_1312": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_2 \\right)"
+      },
+      "lq3_1313": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_3 \\right)"
+      },
+      "lq3_1321": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_1 \\right)"
+      },
+      "lq3_1322": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_2 \\right)"
+      },
+      "lq3_1323": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_3 \\right)"
+      },
+      "lq3_1331": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_1 \\right)"
+      },
+      "lq3_1332": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_2 \\right)"
+      },
+      "lq3_1333": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_3 \\right)"
+      },
+      "ee_1113": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
+      },
+      "ee_1223": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "ee_1333": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
+      },
+      "eu_1311": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_1 \\right)"
+      },
+      "eu_1312": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_2 \\right)"
+      },
+      "eu_1313": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_3 \\right)"
+      },
+      "eu_1321": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_1 \\right)"
+      },
+      "eu_1322": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_2 \\right)"
+      },
+      "eu_1323": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_3 \\right)"
+      },
+      "eu_1331": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_1 \\right)"
+      },
+      "eu_1332": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_2 \\right)"
+      },
+      "eu_1333": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
+      },
+      "ed_1311": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_1 \\right)"
+      },
+      "ed_1312": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_2 \\right)"
+      },
+      "ed_1313": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_3 \\right)"
+      },
+      "ed_1321": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_1 \\right)"
+      },
+      "ed_1322": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_2 \\right)"
+      },
+      "ed_1323": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_3 \\right)"
+      },
+      "ed_1331": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_1 \\right)"
+      },
+      "ed_1332": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_2 \\right)"
+      },
+      "ed_1333": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
+      },
+      "le_1113": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
+      },
+      "le_1223": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "le_1311": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
+      },
+      "le_1322": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
+      },
+      "le_1333": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
+      },
+      "le_2213": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
+      },
+      "le_2312": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
+      },
+      "le_3313": {
+        "tex": "\\left( \\bar \\ell_3 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
+      },
+      "lu_1311": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_1 \\right)"
+      },
+      "lu_1312": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_2 \\right)"
+      },
+      "lu_1313": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_3 \\right)"
+      },
+      "lu_1321": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_1 \\right)"
+      },
+      "lu_1322": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_2 \\right)"
+      },
+      "lu_1323": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_3 \\right)"
+      },
+      "lu_1331": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_1 \\right)"
+      },
+      "lu_1332": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_2 \\right)"
+      },
+      "lu_1333": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
+      },
+      "ld_1311": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_1 \\right)"
+      },
+      "ld_1312": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_2 \\right)"
+      },
+      "ld_1313": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_3 \\right)"
+      },
+      "ld_1321": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_1 \\right)"
+      },
+      "ld_1322": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_2 \\right)"
+      },
+      "ld_1323": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_3 \\right)"
+      },
+      "ld_1331": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_1 \\right)"
+      },
+      "ld_1332": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_2 \\right)"
+      },
+      "ld_1333": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
+      },
+      "qe_1113": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
+      },
+      "qe_1213": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
+      },
+      "qe_1231": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_1 \\right)"
+      },
+      "qe_1313": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
+      },
+      "qe_1331": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_1 \\right)"
+      },
+      "qe_2213": {
+        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
+      },
+      "qe_2313": {
+        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
+      },
+      "qe_2331": {
+        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_1 \\right)"
+      },
+      "qe_3313": {
+        "tex": "\\left( \\bar q_3 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
+      },
+      "ledq_1311": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_1 q_1 \\right)"
+      },
+      "ledq_1312": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_1 q_2 \\right)"
+      },
+      "ledq_1313": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_1 q_3 \\right)"
+      },
+      "ledq_1321": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_2 q_1 \\right)"
+      },
+      "ledq_1322": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_2 q_2 \\right)"
+      },
+      "ledq_1323": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_2 q_3 \\right)"
+      },
+      "ledq_1331": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_3 q_1 \\right)"
+      },
+      "ledq_1332": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_3 q_2 \\right)"
+      },
+      "ledq_1333": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_3 q_3 \\right)"
+      },
+      "ledq_3111": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_1 q_1 \\right)"
+      },
+      "ledq_3112": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_1 q_2 \\right)"
+      },
+      "ledq_3113": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_1 q_3 \\right)"
+      },
+      "ledq_3121": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_2 q_1 \\right)"
+      },
+      "ledq_3122": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_2 q_2 \\right)"
+      },
+      "ledq_3123": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_2 q_3 \\right)"
+      },
+      "ledq_3131": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_3 q_1 \\right)"
+      },
+      "ledq_3132": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_3 q_2 \\right)"
+      },
+      "ledq_3133": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_3 q_3 \\right)"
+      },
+      "lequ1_1311": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_1 \\right)"
+      },
+      "lequ1_1312": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_2 \\right)"
+      },
+      "lequ1_1313": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_3 \\right)"
+      },
+      "lequ1_1321": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_1 \\right)"
+      },
+      "lequ1_1322": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_2 \\right)"
+      },
+      "lequ1_1323": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_3 \\right)"
+      },
+      "lequ1_1331": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_1 \\right)"
+      },
+      "lequ1_1332": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_2 \\right)"
+      },
+      "lequ1_1333": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_3 \\right)"
+      },
+      "lequ1_3111": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_1 \\right)"
+      },
+      "lequ1_3112": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_2 \\right)"
+      },
+      "lequ1_3113": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_3 \\right)"
+      },
+      "lequ1_3121": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_1 \\right)"
+      },
+      "lequ1_3122": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_2 \\right)"
+      },
+      "lequ1_3123": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_3 \\right)"
+      },
+      "lequ1_3131": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_1 \\right)"
+      },
+      "lequ1_3132": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_2 \\right)"
+      },
+      "lequ1_3133": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_3 \\right)"
       },
       "lequ3_1311": {
         "tex": "\\left( \\bar \\ell_1 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_1 \\right)"
@@ -4035,59 +3694,397 @@
       "lequ3_1333": {
         "tex": "\\left( \\bar \\ell_1 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_3 \\right)"
       },
-      "lequ3_2111": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_1 \\right)"
+      "lequ3_3111": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_1 \\right)"
       },
-      "lequ3_2112": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_2 \\right)"
+      "lequ3_3112": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_2 \\right)"
       },
-      "lequ3_2113": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_3 \\right)"
+      "lequ3_3113": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_3 \\right)"
       },
-      "lequ3_2121": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_1 \\right)"
+      "lequ3_3121": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_1 \\right)"
       },
-      "lequ3_2122": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_2 \\right)"
+      "lequ3_3122": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_2 \\right)"
       },
-      "lequ3_2123": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_3 \\right)"
+      "lequ3_3123": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_3 \\right)"
       },
-      "lequ3_2131": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_1 \\right)"
+      "lequ3_3131": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_1 \\right)"
       },
-      "lequ3_2132": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_2 \\right)"
+      "lequ3_3132": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_2 \\right)"
       },
-      "lequ3_2133": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_3 \\right)"
+      "lequ3_3133": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_3 \\right)"
+      }
+    },
+    "mutau": {
+      "ephi_23": {
+        "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_2 e_3 \\varphi \\right)"
       },
-      "lequ3_2211": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_1 \\right)"
+      "ephi_32": {
+        "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_3 e_2 \\varphi \\right)"
       },
-      "lequ3_2212": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_2 \\right)"
+      "eW_23": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma^{\\mu \\nu} e_3 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
       },
-      "lequ3_2213": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_3 \\right)"
+      "eW_32": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma^{\\mu \\nu} e_2 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
       },
-      "lequ3_2221": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_1 \\right)"
+      "eB_23": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma^{\\mu \\nu} e_3 \\right) \\varphi B_{\\mu \\nu}"
       },
-      "lequ3_2222": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_2 \\right)"
+      "eB_32": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma^{\\mu \\nu} e_2 \\right) \\varphi B_{\\mu \\nu}"
       },
-      "lequ3_2223": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_3 \\right)"
+      "deltagZeL_23": null,
+      "deltagWlL_23": null,
+      "deltagZeR_23": null,
+      "ll_1123": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_3 \\right)"
       },
-      "lequ3_2231": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_1 \\right)"
+      "ll_1231": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_1 \\right)"
       },
-      "lequ3_2232": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_2 \\right)"
+      "ll_2223": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_3 \\right)"
       },
-      "lequ3_2233": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_3 \\right)"
+      "ll_2333": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_3 \\right)"
+      },
+      "lq1_2311": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu q_1 \\right)"
+      },
+      "lq1_2312": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu q_2 \\right)"
+      },
+      "lq1_2313": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu q_3 \\right)"
+      },
+      "lq1_2321": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu q_1 \\right)"
+      },
+      "lq1_2322": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu q_2 \\right)"
+      },
+      "lq1_2323": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu q_3 \\right)"
+      },
+      "lq1_2331": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu q_1 \\right)"
+      },
+      "lq1_2332": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu q_2 \\right)"
+      },
+      "lq1_2333": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu q_3 \\right)"
+      },
+      "lq3_2311": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_1 \\right)"
+      },
+      "lq3_2312": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_2 \\right)"
+      },
+      "lq3_2313": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_3 \\right)"
+      },
+      "lq3_2321": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_1 \\right)"
+      },
+      "lq3_2322": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_2 \\right)"
+      },
+      "lq3_2323": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_3 \\right)"
+      },
+      "lq3_2331": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_1 \\right)"
+      },
+      "lq3_2332": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_2 \\right)"
+      },
+      "lq3_2333": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_3 \\right)"
+      },
+      "ee_1123": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_1 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "ee_2223": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "ee_2333": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
+      },
+      "eu_2311": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_1 \\right)"
+      },
+      "eu_2312": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_2 \\right)"
+      },
+      "eu_2313": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_3 \\right)"
+      },
+      "eu_2321": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_1 \\right)"
+      },
+      "eu_2322": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_2 \\right)"
+      },
+      "eu_2323": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_3 \\right)"
+      },
+      "eu_2331": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_1 \\right)"
+      },
+      "eu_2332": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_2 \\right)"
+      },
+      "eu_2333": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
+      },
+      "ed_2311": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_1 \\right)"
+      },
+      "ed_2312": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_2 \\right)"
+      },
+      "ed_2313": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_3 \\right)"
+      },
+      "ed_2321": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_1 \\right)"
+      },
+      "ed_2322": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_2 \\right)"
+      },
+      "ed_2323": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_3 \\right)"
+      },
+      "ed_2331": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_1 \\right)"
+      },
+      "ed_2332": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_2 \\right)"
+      },
+      "ed_2333": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
+      },
+      "le_1123": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "le_1231": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_1 \\right)"
+      },
+      "le_1321": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_1 \\right)"
+      },
+      "le_2223": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "le_2311": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
+      },
+      "le_2322": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
+      },
+      "le_2333": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
+      },
+      "le_3323": {
+        "tex": "\\left( \\bar \\ell_3 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "lu_2311": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_1 \\right)"
+      },
+      "lu_2312": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_2 \\right)"
+      },
+      "lu_2313": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_3 \\right)"
+      },
+      "lu_2321": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_1 \\right)"
+      },
+      "lu_2322": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_2 \\right)"
+      },
+      "lu_2323": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_3 \\right)"
+      },
+      "lu_2331": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_1 \\right)"
+      },
+      "lu_2332": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_2 \\right)"
+      },
+      "lu_2333": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
+      },
+      "ld_2311": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_1 \\right)"
+      },
+      "ld_2312": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_2 \\right)"
+      },
+      "ld_2313": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_3 \\right)"
+      },
+      "ld_2321": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_1 \\right)"
+      },
+      "ld_2322": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_2 \\right)"
+      },
+      "ld_2323": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_3 \\right)"
+      },
+      "ld_2331": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_1 \\right)"
+      },
+      "ld_2332": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_2 \\right)"
+      },
+      "ld_2333": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
+      },
+      "qe_1123": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_1 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "qe_1223": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "qe_1232": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_2 \\right)"
+      },
+      "qe_1323": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "qe_1332": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_2 \\right)"
+      },
+      "qe_2223": {
+        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "qe_2323": {
+        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "qe_2332": {
+        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_2 \\right)"
+      },
+      "qe_3323": {
+        "tex": "\\left( \\bar q_3 \\gamma_\\mu q_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "ledq_2311": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_1 q_1 \\right)"
+      },
+      "ledq_2312": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_1 q_2 \\right)"
+      },
+      "ledq_2313": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_1 q_3 \\right)"
+      },
+      "ledq_2321": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_2 q_1 \\right)"
+      },
+      "ledq_2322": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_2 q_2 \\right)"
+      },
+      "ledq_2323": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_2 q_3 \\right)"
+      },
+      "ledq_2331": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_3 q_1 \\right)"
+      },
+      "ledq_2332": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_3 q_2 \\right)"
+      },
+      "ledq_2333": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_3 q_3 \\right)"
+      },
+      "ledq_3211": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_1 q_1 \\right)"
+      },
+      "ledq_3212": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_1 q_2 \\right)"
+      },
+      "ledq_3213": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_1 q_3 \\right)"
+      },
+      "ledq_3221": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_2 q_1 \\right)"
+      },
+      "ledq_3222": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_2 q_2 \\right)"
+      },
+      "ledq_3223": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_2 q_3 \\right)"
+      },
+      "ledq_3231": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_3 q_1 \\right)"
+      },
+      "ledq_3232": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_3 q_2 \\right)"
+      },
+      "ledq_3233": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_3 q_3 \\right)"
+      },
+      "lequ1_2311": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_1 \\right)"
+      },
+      "lequ1_2312": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_2 \\right)"
+      },
+      "lequ1_2313": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_3 \\right)"
+      },
+      "lequ1_2321": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_1 \\right)"
+      },
+      "lequ1_2322": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_2 \\right)"
+      },
+      "lequ1_2323": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_3 \\right)"
+      },
+      "lequ1_2331": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_1 \\right)"
+      },
+      "lequ1_2332": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_2 \\right)"
+      },
+      "lequ1_2333": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_3 \\right)"
+      },
+      "lequ1_3211": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_1 \\right)"
+      },
+      "lequ1_3212": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_2 \\right)"
+      },
+      "lequ1_3213": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_3 \\right)"
+      },
+      "lequ1_3221": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_1 \\right)"
+      },
+      "lequ1_3222": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_2 \\right)"
+      },
+      "lequ1_3223": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_3 \\right)"
+      },
+      "lequ1_3231": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_1 \\right)"
+      },
+      "lequ1_3232": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_2 \\right)"
+      },
+      "lequ1_3233": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_3 \\right)"
       },
       "lequ3_2311": {
         "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_1 \\right)"
@@ -4116,33 +4113,6 @@
       "lequ3_2333": {
         "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_3 \\right)"
       },
-      "lequ3_3111": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_1 \\right)"
-      },
-      "lequ3_3112": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_2 \\right)"
-      },
-      "lequ3_3113": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_3 \\right)"
-      },
-      "lequ3_3121": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_1 \\right)"
-      },
-      "lequ3_3122": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_2 \\right)"
-      },
-      "lequ3_3123": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_3 \\right)"
-      },
-      "lequ3_3131": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_1 \\right)"
-      },
-      "lequ3_3132": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_2 \\right)"
-      },
-      "lequ3_3133": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_3 \\right)"
-      },
       "lequ3_3211": {
         "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_1 \\right)"
       },
@@ -4169,33 +4139,81 @@
       },
       "lequ3_3233": {
         "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_3 \\right)"
+      }
+    },
+    "muemue": {
+      "ll_1212": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_1 \\gamma^\\mu \\ell_2 \\right)"
       },
-      "lequ3_3311": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_1 \\right)"
+      "ee_1212": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
       },
-      "lequ3_3312": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_2 \\right)"
+      "le_1212": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
+      }
+    },
+    "etauemu": {
+      "ll_1213": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_1 \\gamma^\\mu \\ell_3 \\right)"
       },
-      "lequ3_3313": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_3 \\right)"
+      "ee_1213": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
       },
-      "lequ3_3321": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_1 \\right)"
+      "le_1213": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
       },
-      "lequ3_3322": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_2 \\right)"
+      "le_1312": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
+      }
+    },
+    "muemutau": {
+      "ll_1232": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_2 \\right)"
       },
-      "lequ3_3323": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_3 \\right)"
+      "ee_1232": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_2 \\right)"
       },
-      "lequ3_3331": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_1 \\right)"
+      "le_1232": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_2 \\right)"
       },
-      "lequ3_3332": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_2 \\right)"
+      "le_2321": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_1 \\right)"
+      }
+    },
+    "tauetaue": {
+      "ll_1313": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_1 \\gamma^\\mu \\ell_3 \\right)"
       },
-      "lequ3_3333": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_3 \\right)"
+      "ee_1313": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
+      },
+      "le_1313": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
+      }
+    },
+    "tauetaumu": {
+      "ll_1323": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_3 \\right)"
+      },
+      "ee_1323": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "le_1323": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "le_2313": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
+      }
+    },
+    "taumutaumu": {
+      "ll_2323": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_3 \\right)"
+      },
+      "ee_2323": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "le_2323": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
       }
     },
     "dB=dL=1": {

--- a/smeft.higgs.basis.yml
+++ b/smeft.higgs.basis.yml
@@ -2880,551 +2880,553 @@ sectors:
       tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
     le_2323:
       tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
-  dB=dL=1:
+  dB=de=1:
     duql_1111:
       tex: \left( d_1 C u_1 \right) \left( q_1 C \ell_1 \right)
-    duql_1112:
-      tex: \left( d_1 C u_1 \right) \left( q_1 C \ell_2 \right)
-    duql_1113:
-      tex: \left( d_1 C u_1 \right) \left( q_1 C \ell_3 \right)
     duql_1121:
       tex: \left( d_1 C u_1 \right) \left( q_2 C \ell_1 \right)
-    duql_1122:
-      tex: \left( d_1 C u_1 \right) \left( q_2 C \ell_2 \right)
-    duql_1123:
-      tex: \left( d_1 C u_1 \right) \left( q_2 C \ell_3 \right)
     duql_1131:
       tex: \left( d_1 C u_1 \right) \left( q_3 C \ell_1 \right)
-    duql_1132:
-      tex: \left( d_1 C u_1 \right) \left( q_3 C \ell_2 \right)
-    duql_1133:
-      tex: \left( d_1 C u_1 \right) \left( q_3 C \ell_3 \right)
     duql_1211:
       tex: \left( d_1 C u_2 \right) \left( q_1 C \ell_1 \right)
-    duql_1212:
-      tex: \left( d_1 C u_2 \right) \left( q_1 C \ell_2 \right)
-    duql_1213:
-      tex: \left( d_1 C u_2 \right) \left( q_1 C \ell_3 \right)
     duql_1221:
       tex: \left( d_1 C u_2 \right) \left( q_2 C \ell_1 \right)
-    duql_1222:
-      tex: \left( d_1 C u_2 \right) \left( q_2 C \ell_2 \right)
-    duql_1223:
-      tex: \left( d_1 C u_2 \right) \left( q_2 C \ell_3 \right)
     duql_1231:
       tex: \left( d_1 C u_2 \right) \left( q_3 C \ell_1 \right)
-    duql_1232:
-      tex: \left( d_1 C u_2 \right) \left( q_3 C \ell_2 \right)
-    duql_1233:
-      tex: \left( d_1 C u_2 \right) \left( q_3 C \ell_3 \right)
     duql_1311:
       tex: \left( d_1 C u_3 \right) \left( q_1 C \ell_1 \right)
-    duql_1312:
-      tex: \left( d_1 C u_3 \right) \left( q_1 C \ell_2 \right)
-    duql_1313:
-      tex: \left( d_1 C u_3 \right) \left( q_1 C \ell_3 \right)
     duql_1321:
       tex: \left( d_1 C u_3 \right) \left( q_2 C \ell_1 \right)
-    duql_1322:
-      tex: \left( d_1 C u_3 \right) \left( q_2 C \ell_2 \right)
-    duql_1323:
-      tex: \left( d_1 C u_3 \right) \left( q_2 C \ell_3 \right)
     duql_1331:
       tex: \left( d_1 C u_3 \right) \left( q_3 C \ell_1 \right)
-    duql_1332:
-      tex: \left( d_1 C u_3 \right) \left( q_3 C \ell_2 \right)
-    duql_1333:
-      tex: \left( d_1 C u_3 \right) \left( q_3 C \ell_3 \right)
     duql_2111:
       tex: \left( d_2 C u_1 \right) \left( q_1 C \ell_1 \right)
-    duql_2112:
-      tex: \left( d_2 C u_1 \right) \left( q_1 C \ell_2 \right)
-    duql_2113:
-      tex: \left( d_2 C u_1 \right) \left( q_1 C \ell_3 \right)
     duql_2121:
       tex: \left( d_2 C u_1 \right) \left( q_2 C \ell_1 \right)
-    duql_2122:
-      tex: \left( d_2 C u_1 \right) \left( q_2 C \ell_2 \right)
-    duql_2123:
-      tex: \left( d_2 C u_1 \right) \left( q_2 C \ell_3 \right)
     duql_2131:
       tex: \left( d_2 C u_1 \right) \left( q_3 C \ell_1 \right)
-    duql_2132:
-      tex: \left( d_2 C u_1 \right) \left( q_3 C \ell_2 \right)
-    duql_2133:
-      tex: \left( d_2 C u_1 \right) \left( q_3 C \ell_3 \right)
     duql_2211:
       tex: \left( d_2 C u_2 \right) \left( q_1 C \ell_1 \right)
-    duql_2212:
-      tex: \left( d_2 C u_2 \right) \left( q_1 C \ell_2 \right)
-    duql_2213:
-      tex: \left( d_2 C u_2 \right) \left( q_1 C \ell_3 \right)
     duql_2221:
       tex: \left( d_2 C u_2 \right) \left( q_2 C \ell_1 \right)
-    duql_2222:
-      tex: \left( d_2 C u_2 \right) \left( q_2 C \ell_2 \right)
-    duql_2223:
-      tex: \left( d_2 C u_2 \right) \left( q_2 C \ell_3 \right)
     duql_2231:
       tex: \left( d_2 C u_2 \right) \left( q_3 C \ell_1 \right)
-    duql_2232:
-      tex: \left( d_2 C u_2 \right) \left( q_3 C \ell_2 \right)
-    duql_2233:
-      tex: \left( d_2 C u_2 \right) \left( q_3 C \ell_3 \right)
     duql_2311:
       tex: \left( d_2 C u_3 \right) \left( q_1 C \ell_1 \right)
-    duql_2312:
-      tex: \left( d_2 C u_3 \right) \left( q_1 C \ell_2 \right)
-    duql_2313:
-      tex: \left( d_2 C u_3 \right) \left( q_1 C \ell_3 \right)
     duql_2321:
       tex: \left( d_2 C u_3 \right) \left( q_2 C \ell_1 \right)
-    duql_2322:
-      tex: \left( d_2 C u_3 \right) \left( q_2 C \ell_2 \right)
-    duql_2323:
-      tex: \left( d_2 C u_3 \right) \left( q_2 C \ell_3 \right)
     duql_2331:
       tex: \left( d_2 C u_3 \right) \left( q_3 C \ell_1 \right)
-    duql_2332:
-      tex: \left( d_2 C u_3 \right) \left( q_3 C \ell_2 \right)
-    duql_2333:
-      tex: \left( d_2 C u_3 \right) \left( q_3 C \ell_3 \right)
     duql_3111:
       tex: \left( d_3 C u_1 \right) \left( q_1 C \ell_1 \right)
-    duql_3112:
-      tex: \left( d_3 C u_1 \right) \left( q_1 C \ell_2 \right)
-    duql_3113:
-      tex: \left( d_3 C u_1 \right) \left( q_1 C \ell_3 \right)
     duql_3121:
       tex: \left( d_3 C u_1 \right) \left( q_2 C \ell_1 \right)
-    duql_3122:
-      tex: \left( d_3 C u_1 \right) \left( q_2 C \ell_2 \right)
-    duql_3123:
-      tex: \left( d_3 C u_1 \right) \left( q_2 C \ell_3 \right)
     duql_3131:
       tex: \left( d_3 C u_1 \right) \left( q_3 C \ell_1 \right)
-    duql_3132:
-      tex: \left( d_3 C u_1 \right) \left( q_3 C \ell_2 \right)
-    duql_3133:
-      tex: \left( d_3 C u_1 \right) \left( q_3 C \ell_3 \right)
     duql_3211:
       tex: \left( d_3 C u_2 \right) \left( q_1 C \ell_1 \right)
-    duql_3212:
-      tex: \left( d_3 C u_2 \right) \left( q_1 C \ell_2 \right)
-    duql_3213:
-      tex: \left( d_3 C u_2 \right) \left( q_1 C \ell_3 \right)
     duql_3221:
       tex: \left( d_3 C u_2 \right) \left( q_2 C \ell_1 \right)
-    duql_3222:
-      tex: \left( d_3 C u_2 \right) \left( q_2 C \ell_2 \right)
-    duql_3223:
-      tex: \left( d_3 C u_2 \right) \left( q_2 C \ell_3 \right)
     duql_3231:
       tex: \left( d_3 C u_2 \right) \left( q_3 C \ell_1 \right)
-    duql_3232:
-      tex: \left( d_3 C u_2 \right) \left( q_3 C \ell_2 \right)
-    duql_3233:
-      tex: \left( d_3 C u_2 \right) \left( q_3 C \ell_3 \right)
     duql_3311:
       tex: \left( d_3 C u_3 \right) \left( q_1 C \ell_1 \right)
-    duql_3312:
-      tex: \left( d_3 C u_3 \right) \left( q_1 C \ell_2 \right)
-    duql_3313:
-      tex: \left( d_3 C u_3 \right) \left( q_1 C \ell_3 \right)
     duql_3321:
       tex: \left( d_3 C u_3 \right) \left( q_2 C \ell_1 \right)
-    duql_3322:
-      tex: \left( d_3 C u_3 \right) \left( q_2 C \ell_2 \right)
-    duql_3323:
-      tex: \left( d_3 C u_3 \right) \left( q_2 C \ell_3 \right)
     duql_3331:
       tex: \left( d_3 C u_3 \right) \left( q_3 C \ell_1 \right)
-    duql_3332:
-      tex: \left( d_3 C u_3 \right) \left( q_3 C \ell_2 \right)
-    duql_3333:
-      tex: \left( d_3 C u_3 \right) \left( q_3 C \ell_3 \right)
     qque_1111:
       tex: \left( q_1 C q_1 \right) \left( u_1 C e_1 \right)
-    qque_1112:
-      tex: \left( q_1 C q_1 \right) \left( u_1 C e_2 \right)
-    qque_1113:
-      tex: \left( q_1 C q_1 \right) \left( u_1 C e_3 \right)
     qque_1121:
       tex: \left( q_1 C q_1 \right) \left( u_2 C e_1 \right)
-    qque_1122:
-      tex: \left( q_1 C q_1 \right) \left( u_2 C e_2 \right)
-    qque_1123:
-      tex: \left( q_1 C q_1 \right) \left( u_2 C e_3 \right)
     qque_1131:
       tex: \left( q_1 C q_1 \right) \left( u_3 C e_1 \right)
-    qque_1132:
-      tex: \left( q_1 C q_1 \right) \left( u_3 C e_2 \right)
-    qque_1133:
-      tex: \left( q_1 C q_1 \right) \left( u_3 C e_3 \right)
     qque_1211:
       tex: \left( q_1 C q_2 \right) \left( u_1 C e_1 \right)
-    qque_1212:
-      tex: \left( q_1 C q_2 \right) \left( u_1 C e_2 \right)
-    qque_1213:
-      tex: \left( q_1 C q_2 \right) \left( u_1 C e_3 \right)
     qque_1221:
       tex: \left( q_1 C q_2 \right) \left( u_2 C e_1 \right)
-    qque_1222:
-      tex: \left( q_1 C q_2 \right) \left( u_2 C e_2 \right)
-    qque_1223:
-      tex: \left( q_1 C q_2 \right) \left( u_2 C e_3 \right)
     qque_1231:
       tex: \left( q_1 C q_2 \right) \left( u_3 C e_1 \right)
-    qque_1232:
-      tex: \left( q_1 C q_2 \right) \left( u_3 C e_2 \right)
-    qque_1233:
-      tex: \left( q_1 C q_2 \right) \left( u_3 C e_3 \right)
     qque_1311:
       tex: \left( q_1 C q_3 \right) \left( u_1 C e_1 \right)
-    qque_1312:
-      tex: \left( q_1 C q_3 \right) \left( u_1 C e_2 \right)
-    qque_1313:
-      tex: \left( q_1 C q_3 \right) \left( u_1 C e_3 \right)
     qque_1321:
       tex: \left( q_1 C q_3 \right) \left( u_2 C e_1 \right)
-    qque_1322:
-      tex: \left( q_1 C q_3 \right) \left( u_2 C e_2 \right)
-    qque_1323:
-      tex: \left( q_1 C q_3 \right) \left( u_2 C e_3 \right)
     qque_1331:
       tex: \left( q_1 C q_3 \right) \left( u_3 C e_1 \right)
-    qque_1332:
-      tex: \left( q_1 C q_3 \right) \left( u_3 C e_2 \right)
-    qque_1333:
-      tex: \left( q_1 C q_3 \right) \left( u_3 C e_3 \right)
     qque_2211:
       tex: \left( q_2 C q_2 \right) \left( u_1 C e_1 \right)
-    qque_2212:
-      tex: \left( q_2 C q_2 \right) \left( u_1 C e_2 \right)
-    qque_2213:
-      tex: \left( q_2 C q_2 \right) \left( u_1 C e_3 \right)
     qque_2221:
       tex: \left( q_2 C q_2 \right) \left( u_2 C e_1 \right)
-    qque_2222:
-      tex: \left( q_2 C q_2 \right) \left( u_2 C e_2 \right)
-    qque_2223:
-      tex: \left( q_2 C q_2 \right) \left( u_2 C e_3 \right)
     qque_2231:
       tex: \left( q_2 C q_2 \right) \left( u_3 C e_1 \right)
-    qque_2232:
-      tex: \left( q_2 C q_2 \right) \left( u_3 C e_2 \right)
-    qque_2233:
-      tex: \left( q_2 C q_2 \right) \left( u_3 C e_3 \right)
     qque_2311:
       tex: \left( q_2 C q_3 \right) \left( u_1 C e_1 \right)
-    qque_2312:
-      tex: \left( q_2 C q_3 \right) \left( u_1 C e_2 \right)
-    qque_2313:
-      tex: \left( q_2 C q_3 \right) \left( u_1 C e_3 \right)
     qque_2321:
       tex: \left( q_2 C q_3 \right) \left( u_2 C e_1 \right)
-    qque_2322:
-      tex: \left( q_2 C q_3 \right) \left( u_2 C e_2 \right)
-    qque_2323:
-      tex: \left( q_2 C q_3 \right) \left( u_2 C e_3 \right)
     qque_2331:
       tex: \left( q_2 C q_3 \right) \left( u_3 C e_1 \right)
-    qque_2332:
-      tex: \left( q_2 C q_3 \right) \left( u_3 C e_2 \right)
-    qque_2333:
-      tex: \left( q_2 C q_3 \right) \left( u_3 C e_3 \right)
     qque_3311:
       tex: \left( q_3 C q_3 \right) \left( u_1 C e_1 \right)
-    qque_3312:
-      tex: \left( q_3 C q_3 \right) \left( u_1 C e_2 \right)
-    qque_3313:
-      tex: \left( q_3 C q_3 \right) \left( u_1 C e_3 \right)
     qque_3321:
       tex: \left( q_3 C q_3 \right) \left( u_2 C e_1 \right)
-    qque_3322:
-      tex: \left( q_3 C q_3 \right) \left( u_2 C e_2 \right)
-    qque_3323:
-      tex: \left( q_3 C q_3 \right) \left( u_2 C e_3 \right)
     qque_3331:
       tex: \left( q_3 C q_3 \right) \left( u_3 C e_1 \right)
-    qque_3332:
-      tex: \left( q_3 C q_3 \right) \left( u_3 C e_2 \right)
-    qque_3333:
-      tex: \left( q_3 C q_3 \right) \left( u_3 C e_3 \right)
     qqql_1111:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_1 C \ell_1 \right)
-    qqql_1112:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_1 C \ell_2 \right)
-    qqql_1113:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_1 C \ell_3 \right)
     qqql_1121:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_2 C \ell_1 \right)
-    qqql_1122:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_2 C \ell_2 \right)
-    qqql_1123:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_2 C \ell_3 \right)
     qqql_1131:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_3 C \ell_1 \right)
-    qqql_1132:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_3 C \ell_2 \right)
-    qqql_1133:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_3 C \ell_3 \right)
     qqql_1211:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_1 C \ell_1 \right)
-    qqql_1212:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_1 C \ell_2 \right)
-    qqql_1213:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_1 C \ell_3 \right)
     qqql_1221:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_2 C \ell_1 \right)
-    qqql_1222:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_2 C \ell_2 \right)
-    qqql_1223:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_2 C \ell_3 \right)
     qqql_1231:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_3 C \ell_1 \right)
-    qqql_1232:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_3 C \ell_2 \right)
-    qqql_1233:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_3 C \ell_3 \right)
     qqql_1311:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_1 C \ell_1 \right)
-    qqql_1312:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_1 C \ell_2 \right)
-    qqql_1313:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_1 C \ell_3 \right)
     qqql_1321:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_2 C \ell_1 \right)
-    qqql_1322:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_2 C \ell_2 \right)
-    qqql_1323:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_2 C \ell_3 \right)
     qqql_1331:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_3 C \ell_1 \right)
-    qqql_1332:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_3 C \ell_2 \right)
-    qqql_1333:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_3 C \ell_3 \right)
     qqql_2121:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_1 \right) \left( q_2 C \ell_1 \right)
-    qqql_2122:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_1 \right) \left( q_2 C \ell_2 \right)
-    qqql_2123:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_1 \right) \left( q_2 C \ell_3 \right)
     qqql_2131:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_1 \right) \left( q_3 C \ell_1 \right)
-    qqql_2132:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_1 \right) \left( q_3 C \ell_2 \right)
-    qqql_2133:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_1 \right) \left( q_3 C \ell_3 \right)
     qqql_2221:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_2 \right) \left( q_2 C \ell_1 \right)
-    qqql_2222:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_2 \right) \left( q_2 C \ell_2 \right)
-    qqql_2223:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_2 \right) \left( q_2 C \ell_3 \right)
     qqql_2231:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_2 \right) \left( q_3 C \ell_1 \right)
-    qqql_2232:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_2 \right) \left( q_3 C \ell_2 \right)
-    qqql_2233:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_2 \right) \left( q_3 C \ell_3 \right)
     qqql_2311:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_1 C \ell_1 \right)
-    qqql_2312:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_1 C \ell_2 \right)
-    qqql_2313:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_1 C \ell_3 \right)
     qqql_2321:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_2 C \ell_1 \right)
-    qqql_2322:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_2 C \ell_2 \right)
-    qqql_2323:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_2 C \ell_3 \right)
     qqql_2331:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_3 C \ell_1 \right)
-    qqql_2332:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_3 C \ell_2 \right)
-    qqql_2333:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_3 C \ell_3 \right)
     qqql_3131:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_1 \right) \left( q_3 C \ell_1 \right)
-    qqql_3132:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_1 \right) \left( q_3 C \ell_2 \right)
-    qqql_3133:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_1 \right) \left( q_3 C \ell_3 \right)
     qqql_3231:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_2 \right) \left( q_3 C \ell_1 \right)
-    qqql_3232:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_2 \right) \left( q_3 C \ell_2 \right)
-    qqql_3233:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_2 \right) \left( q_3 C \ell_3 \right)
     qqql_3331:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_3 \right) \left( q_3 C \ell_1 \right)
-    qqql_3332:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_3 \right) \left( q_3 C \ell_2 \right)
-    qqql_3333:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_3 \right) \left( q_3 C \ell_3 \right)
     duue_1111:
       tex: \left( d_1 C u_1 \right) \left( u_1 C e_1 \right)
-    duue_1112:
-      tex: \left( d_1 C u_1 \right) \left( u_1 C e_2 \right)
-    duue_1113:
-      tex: \left( d_1 C u_1 \right) \left( u_1 C e_3 \right)
     duue_1121:
       tex: \left( d_1 C u_1 \right) \left( u_2 C e_1 \right)
-    duue_1122:
-      tex: \left( d_1 C u_1 \right) \left( u_2 C e_2 \right)
-    duue_1123:
-      tex: \left( d_1 C u_1 \right) \left( u_2 C e_3 \right)
     duue_1131:
       tex: \left( d_1 C u_1 \right) \left( u_3 C e_1 \right)
-    duue_1132:
-      tex: \left( d_1 C u_1 \right) \left( u_3 C e_2 \right)
-    duue_1133:
-      tex: \left( d_1 C u_1 \right) \left( u_3 C e_3 \right)
     duue_1211:
       tex: \left( d_1 C u_2 \right) \left( u_1 C e_1 \right)
-    duue_1212:
-      tex: \left( d_1 C u_2 \right) \left( u_1 C e_2 \right)
-    duue_1213:
-      tex: \left( d_1 C u_2 \right) \left( u_1 C e_3 \right)
     duue_1221:
       tex: \left( d_1 C u_2 \right) \left( u_2 C e_1 \right)
-    duue_1222:
-      tex: \left( d_1 C u_2 \right) \left( u_2 C e_2 \right)
-    duue_1223:
-      tex: \left( d_1 C u_2 \right) \left( u_2 C e_3 \right)
     duue_1231:
       tex: \left( d_1 C u_2 \right) \left( u_3 C e_1 \right)
-    duue_1232:
-      tex: \left( d_1 C u_2 \right) \left( u_3 C e_2 \right)
-    duue_1233:
-      tex: \left( d_1 C u_2 \right) \left( u_3 C e_3 \right)
     duue_1311:
       tex: \left( d_1 C u_3 \right) \left( u_1 C e_1 \right)
-    duue_1312:
-      tex: \left( d_1 C u_3 \right) \left( u_1 C e_2 \right)
-    duue_1313:
-      tex: \left( d_1 C u_3 \right) \left( u_1 C e_3 \right)
     duue_1321:
       tex: \left( d_1 C u_3 \right) \left( u_2 C e_1 \right)
-    duue_1322:
-      tex: \left( d_1 C u_3 \right) \left( u_2 C e_2 \right)
-    duue_1323:
-      tex: \left( d_1 C u_3 \right) \left( u_2 C e_3 \right)
     duue_1331:
       tex: \left( d_1 C u_3 \right) \left( u_3 C e_1 \right)
-    duue_1332:
-      tex: \left( d_1 C u_3 \right) \left( u_3 C e_2 \right)
-    duue_1333:
-      tex: \left( d_1 C u_3 \right) \left( u_3 C e_3 \right)
     duue_2111:
       tex: \left( d_2 C u_1 \right) \left( u_1 C e_1 \right)
-    duue_2112:
-      tex: \left( d_2 C u_1 \right) \left( u_1 C e_2 \right)
-    duue_2113:
-      tex: \left( d_2 C u_1 \right) \left( u_1 C e_3 \right)
     duue_2121:
       tex: \left( d_2 C u_1 \right) \left( u_2 C e_1 \right)
-    duue_2122:
-      tex: \left( d_2 C u_1 \right) \left( u_2 C e_2 \right)
-    duue_2123:
-      tex: \left( d_2 C u_1 \right) \left( u_2 C e_3 \right)
     duue_2131:
       tex: \left( d_2 C u_1 \right) \left( u_3 C e_1 \right)
-    duue_2132:
-      tex: \left( d_2 C u_1 \right) \left( u_3 C e_2 \right)
-    duue_2133:
-      tex: \left( d_2 C u_1 \right) \left( u_3 C e_3 \right)
     duue_2211:
       tex: \left( d_2 C u_2 \right) \left( u_1 C e_1 \right)
-    duue_2212:
-      tex: \left( d_2 C u_2 \right) \left( u_1 C e_2 \right)
-    duue_2213:
-      tex: \left( d_2 C u_2 \right) \left( u_1 C e_3 \right)
     duue_2221:
       tex: \left( d_2 C u_2 \right) \left( u_2 C e_1 \right)
-    duue_2222:
-      tex: \left( d_2 C u_2 \right) \left( u_2 C e_2 \right)
-    duue_2223:
-      tex: \left( d_2 C u_2 \right) \left( u_2 C e_3 \right)
     duue_2231:
       tex: \left( d_2 C u_2 \right) \left( u_3 C e_1 \right)
-    duue_2232:
-      tex: \left( d_2 C u_2 \right) \left( u_3 C e_2 \right)
-    duue_2233:
-      tex: \left( d_2 C u_2 \right) \left( u_3 C e_3 \right)
     duue_2311:
       tex: \left( d_2 C u_3 \right) \left( u_1 C e_1 \right)
-    duue_2312:
-      tex: \left( d_2 C u_3 \right) \left( u_1 C e_2 \right)
-    duue_2313:
-      tex: \left( d_2 C u_3 \right) \left( u_1 C e_3 \right)
     duue_2321:
       tex: \left( d_2 C u_3 \right) \left( u_2 C e_1 \right)
-    duue_2322:
-      tex: \left( d_2 C u_3 \right) \left( u_2 C e_2 \right)
-    duue_2323:
-      tex: \left( d_2 C u_3 \right) \left( u_2 C e_3 \right)
     duue_2331:
       tex: \left( d_2 C u_3 \right) \left( u_3 C e_1 \right)
-    duue_2332:
-      tex: \left( d_2 C u_3 \right) \left( u_3 C e_2 \right)
-    duue_2333:
-      tex: \left( d_2 C u_3 \right) \left( u_3 C e_3 \right)
     duue_3111:
       tex: \left( d_3 C u_1 \right) \left( u_1 C e_1 \right)
-    duue_3112:
-      tex: \left( d_3 C u_1 \right) \left( u_1 C e_2 \right)
-    duue_3113:
-      tex: \left( d_3 C u_1 \right) \left( u_1 C e_3 \right)
     duue_3121:
       tex: \left( d_3 C u_1 \right) \left( u_2 C e_1 \right)
-    duue_3122:
-      tex: \left( d_3 C u_1 \right) \left( u_2 C e_2 \right)
-    duue_3123:
-      tex: \left( d_3 C u_1 \right) \left( u_2 C e_3 \right)
     duue_3131:
       tex: \left( d_3 C u_1 \right) \left( u_3 C e_1 \right)
-    duue_3132:
-      tex: \left( d_3 C u_1 \right) \left( u_3 C e_2 \right)
-    duue_3133:
-      tex: \left( d_3 C u_1 \right) \left( u_3 C e_3 \right)
     duue_3211:
       tex: \left( d_3 C u_2 \right) \left( u_1 C e_1 \right)
-    duue_3212:
-      tex: \left( d_3 C u_2 \right) \left( u_1 C e_2 \right)
-    duue_3213:
-      tex: \left( d_3 C u_2 \right) \left( u_1 C e_3 \right)
     duue_3221:
       tex: \left( d_3 C u_2 \right) \left( u_2 C e_1 \right)
-    duue_3222:
-      tex: \left( d_3 C u_2 \right) \left( u_2 C e_2 \right)
-    duue_3223:
-      tex: \left( d_3 C u_2 \right) \left( u_2 C e_3 \right)
     duue_3231:
       tex: \left( d_3 C u_2 \right) \left( u_3 C e_1 \right)
-    duue_3232:
-      tex: \left( d_3 C u_2 \right) \left( u_3 C e_2 \right)
-    duue_3233:
-      tex: \left( d_3 C u_2 \right) \left( u_3 C e_3 \right)
     duue_3311:
       tex: \left( d_3 C u_3 \right) \left( u_1 C e_1 \right)
-    duue_3312:
-      tex: \left( d_3 C u_3 \right) \left( u_1 C e_2 \right)
-    duue_3313:
-      tex: \left( d_3 C u_3 \right) \left( u_1 C e_3 \right)
     duue_3321:
       tex: \left( d_3 C u_3 \right) \left( u_2 C e_1 \right)
-    duue_3322:
-      tex: \left( d_3 C u_3 \right) \left( u_2 C e_2 \right)
-    duue_3323:
-      tex: \left( d_3 C u_3 \right) \left( u_2 C e_3 \right)
     duue_3331:
       tex: \left( d_3 C u_3 \right) \left( u_3 C e_1 \right)
+  dB=dmu=1:
+    duql_1112:
+      tex: \left( d_1 C u_1 \right) \left( q_1 C \ell_2 \right)
+    duql_1122:
+      tex: \left( d_1 C u_1 \right) \left( q_2 C \ell_2 \right)
+    duql_1132:
+      tex: \left( d_1 C u_1 \right) \left( q_3 C \ell_2 \right)
+    duql_1212:
+      tex: \left( d_1 C u_2 \right) \left( q_1 C \ell_2 \right)
+    duql_1222:
+      tex: \left( d_1 C u_2 \right) \left( q_2 C \ell_2 \right)
+    duql_1232:
+      tex: \left( d_1 C u_2 \right) \left( q_3 C \ell_2 \right)
+    duql_1312:
+      tex: \left( d_1 C u_3 \right) \left( q_1 C \ell_2 \right)
+    duql_1322:
+      tex: \left( d_1 C u_3 \right) \left( q_2 C \ell_2 \right)
+    duql_1332:
+      tex: \left( d_1 C u_3 \right) \left( q_3 C \ell_2 \right)
+    duql_2112:
+      tex: \left( d_2 C u_1 \right) \left( q_1 C \ell_2 \right)
+    duql_2122:
+      tex: \left( d_2 C u_1 \right) \left( q_2 C \ell_2 \right)
+    duql_2132:
+      tex: \left( d_2 C u_1 \right) \left( q_3 C \ell_2 \right)
+    duql_2212:
+      tex: \left( d_2 C u_2 \right) \left( q_1 C \ell_2 \right)
+    duql_2222:
+      tex: \left( d_2 C u_2 \right) \left( q_2 C \ell_2 \right)
+    duql_2232:
+      tex: \left( d_2 C u_2 \right) \left( q_3 C \ell_2 \right)
+    duql_2312:
+      tex: \left( d_2 C u_3 \right) \left( q_1 C \ell_2 \right)
+    duql_2322:
+      tex: \left( d_2 C u_3 \right) \left( q_2 C \ell_2 \right)
+    duql_2332:
+      tex: \left( d_2 C u_3 \right) \left( q_3 C \ell_2 \right)
+    duql_3112:
+      tex: \left( d_3 C u_1 \right) \left( q_1 C \ell_2 \right)
+    duql_3122:
+      tex: \left( d_3 C u_1 \right) \left( q_2 C \ell_2 \right)
+    duql_3132:
+      tex: \left( d_3 C u_1 \right) \left( q_3 C \ell_2 \right)
+    duql_3212:
+      tex: \left( d_3 C u_2 \right) \left( q_1 C \ell_2 \right)
+    duql_3222:
+      tex: \left( d_3 C u_2 \right) \left( q_2 C \ell_2 \right)
+    duql_3232:
+      tex: \left( d_3 C u_2 \right) \left( q_3 C \ell_2 \right)
+    duql_3312:
+      tex: \left( d_3 C u_3 \right) \left( q_1 C \ell_2 \right)
+    duql_3322:
+      tex: \left( d_3 C u_3 \right) \left( q_2 C \ell_2 \right)
+    duql_3332:
+      tex: \left( d_3 C u_3 \right) \left( q_3 C \ell_2 \right)
+    qque_1112:
+      tex: \left( q_1 C q_1 \right) \left( u_1 C e_2 \right)
+    qque_1122:
+      tex: \left( q_1 C q_1 \right) \left( u_2 C e_2 \right)
+    qque_1132:
+      tex: \left( q_1 C q_1 \right) \left( u_3 C e_2 \right)
+    qque_1212:
+      tex: \left( q_1 C q_2 \right) \left( u_1 C e_2 \right)
+    qque_1222:
+      tex: \left( q_1 C q_2 \right) \left( u_2 C e_2 \right)
+    qque_1232:
+      tex: \left( q_1 C q_2 \right) \left( u_3 C e_2 \right)
+    qque_1312:
+      tex: \left( q_1 C q_3 \right) \left( u_1 C e_2 \right)
+    qque_1322:
+      tex: \left( q_1 C q_3 \right) \left( u_2 C e_2 \right)
+    qque_1332:
+      tex: \left( q_1 C q_3 \right) \left( u_3 C e_2 \right)
+    qque_2212:
+      tex: \left( q_2 C q_2 \right) \left( u_1 C e_2 \right)
+    qque_2222:
+      tex: \left( q_2 C q_2 \right) \left( u_2 C e_2 \right)
+    qque_2232:
+      tex: \left( q_2 C q_2 \right) \left( u_3 C e_2 \right)
+    qque_2312:
+      tex: \left( q_2 C q_3 \right) \left( u_1 C e_2 \right)
+    qque_2322:
+      tex: \left( q_2 C q_3 \right) \left( u_2 C e_2 \right)
+    qque_2332:
+      tex: \left( q_2 C q_3 \right) \left( u_3 C e_2 \right)
+    qque_3312:
+      tex: \left( q_3 C q_3 \right) \left( u_1 C e_2 \right)
+    qque_3322:
+      tex: \left( q_3 C q_3 \right) \left( u_2 C e_2 \right)
+    qque_3332:
+      tex: \left( q_3 C q_3 \right) \left( u_3 C e_2 \right)
+    qqql_1112:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_1 C \ell_2 \right)
+    qqql_1122:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_2 C \ell_2 \right)
+    qqql_1132:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_3 C \ell_2 \right)
+    qqql_1212:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_1 C \ell_2 \right)
+    qqql_1222:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_2 C \ell_2 \right)
+    qqql_1232:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_3 C \ell_2 \right)
+    qqql_1312:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_1 C \ell_2 \right)
+    qqql_1322:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_2 C \ell_2 \right)
+    qqql_1332:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_3 C \ell_2 \right)
+    qqql_2122:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_1 \right) \left( q_2 C \ell_2 \right)
+    qqql_2132:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_1 \right) \left( q_3 C \ell_2 \right)
+    qqql_2222:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_2 \right) \left( q_2 C \ell_2 \right)
+    qqql_2232:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_2 \right) \left( q_3 C \ell_2 \right)
+    qqql_2312:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_1 C \ell_2 \right)
+    qqql_2322:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_2 C \ell_2 \right)
+    qqql_2332:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_3 C \ell_2 \right)
+    qqql_3132:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_1 \right) \left( q_3 C \ell_2 \right)
+    qqql_3232:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_2 \right) \left( q_3 C \ell_2 \right)
+    qqql_3332:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_3 \right) \left( q_3 C \ell_2 \right)
+    duue_1112:
+      tex: \left( d_1 C u_1 \right) \left( u_1 C e_2 \right)
+    duue_1122:
+      tex: \left( d_1 C u_1 \right) \left( u_2 C e_2 \right)
+    duue_1132:
+      tex: \left( d_1 C u_1 \right) \left( u_3 C e_2 \right)
+    duue_1212:
+      tex: \left( d_1 C u_2 \right) \left( u_1 C e_2 \right)
+    duue_1222:
+      tex: \left( d_1 C u_2 \right) \left( u_2 C e_2 \right)
+    duue_1232:
+      tex: \left( d_1 C u_2 \right) \left( u_3 C e_2 \right)
+    duue_1312:
+      tex: \left( d_1 C u_3 \right) \left( u_1 C e_2 \right)
+    duue_1322:
+      tex: \left( d_1 C u_3 \right) \left( u_2 C e_2 \right)
+    duue_1332:
+      tex: \left( d_1 C u_3 \right) \left( u_3 C e_2 \right)
+    duue_2112:
+      tex: \left( d_2 C u_1 \right) \left( u_1 C e_2 \right)
+    duue_2122:
+      tex: \left( d_2 C u_1 \right) \left( u_2 C e_2 \right)
+    duue_2132:
+      tex: \left( d_2 C u_1 \right) \left( u_3 C e_2 \right)
+    duue_2212:
+      tex: \left( d_2 C u_2 \right) \left( u_1 C e_2 \right)
+    duue_2222:
+      tex: \left( d_2 C u_2 \right) \left( u_2 C e_2 \right)
+    duue_2232:
+      tex: \left( d_2 C u_2 \right) \left( u_3 C e_2 \right)
+    duue_2312:
+      tex: \left( d_2 C u_3 \right) \left( u_1 C e_2 \right)
+    duue_2322:
+      tex: \left( d_2 C u_3 \right) \left( u_2 C e_2 \right)
+    duue_2332:
+      tex: \left( d_2 C u_3 \right) \left( u_3 C e_2 \right)
+    duue_3112:
+      tex: \left( d_3 C u_1 \right) \left( u_1 C e_2 \right)
+    duue_3122:
+      tex: \left( d_3 C u_1 \right) \left( u_2 C e_2 \right)
+    duue_3132:
+      tex: \left( d_3 C u_1 \right) \left( u_3 C e_2 \right)
+    duue_3212:
+      tex: \left( d_3 C u_2 \right) \left( u_1 C e_2 \right)
+    duue_3222:
+      tex: \left( d_3 C u_2 \right) \left( u_2 C e_2 \right)
+    duue_3232:
+      tex: \left( d_3 C u_2 \right) \left( u_3 C e_2 \right)
+    duue_3312:
+      tex: \left( d_3 C u_3 \right) \left( u_1 C e_2 \right)
+    duue_3322:
+      tex: \left( d_3 C u_3 \right) \left( u_2 C e_2 \right)
     duue_3332:
       tex: \left( d_3 C u_3 \right) \left( u_3 C e_2 \right)
+  dB=dtau=1:
+    duql_1113:
+      tex: \left( d_1 C u_1 \right) \left( q_1 C \ell_3 \right)
+    duql_1123:
+      tex: \left( d_1 C u_1 \right) \left( q_2 C \ell_3 \right)
+    duql_1133:
+      tex: \left( d_1 C u_1 \right) \left( q_3 C \ell_3 \right)
+    duql_1213:
+      tex: \left( d_1 C u_2 \right) \left( q_1 C \ell_3 \right)
+    duql_1223:
+      tex: \left( d_1 C u_2 \right) \left( q_2 C \ell_3 \right)
+    duql_1233:
+      tex: \left( d_1 C u_2 \right) \left( q_3 C \ell_3 \right)
+    duql_1313:
+      tex: \left( d_1 C u_3 \right) \left( q_1 C \ell_3 \right)
+    duql_1323:
+      tex: \left( d_1 C u_3 \right) \left( q_2 C \ell_3 \right)
+    duql_1333:
+      tex: \left( d_1 C u_3 \right) \left( q_3 C \ell_3 \right)
+    duql_2113:
+      tex: \left( d_2 C u_1 \right) \left( q_1 C \ell_3 \right)
+    duql_2123:
+      tex: \left( d_2 C u_1 \right) \left( q_2 C \ell_3 \right)
+    duql_2133:
+      tex: \left( d_2 C u_1 \right) \left( q_3 C \ell_3 \right)
+    duql_2213:
+      tex: \left( d_2 C u_2 \right) \left( q_1 C \ell_3 \right)
+    duql_2223:
+      tex: \left( d_2 C u_2 \right) \left( q_2 C \ell_3 \right)
+    duql_2233:
+      tex: \left( d_2 C u_2 \right) \left( q_3 C \ell_3 \right)
+    duql_2313:
+      tex: \left( d_2 C u_3 \right) \left( q_1 C \ell_3 \right)
+    duql_2323:
+      tex: \left( d_2 C u_3 \right) \left( q_2 C \ell_3 \right)
+    duql_2333:
+      tex: \left( d_2 C u_3 \right) \left( q_3 C \ell_3 \right)
+    duql_3113:
+      tex: \left( d_3 C u_1 \right) \left( q_1 C \ell_3 \right)
+    duql_3123:
+      tex: \left( d_3 C u_1 \right) \left( q_2 C \ell_3 \right)
+    duql_3133:
+      tex: \left( d_3 C u_1 \right) \left( q_3 C \ell_3 \right)
+    duql_3213:
+      tex: \left( d_3 C u_2 \right) \left( q_1 C \ell_3 \right)
+    duql_3223:
+      tex: \left( d_3 C u_2 \right) \left( q_2 C \ell_3 \right)
+    duql_3233:
+      tex: \left( d_3 C u_2 \right) \left( q_3 C \ell_3 \right)
+    duql_3313:
+      tex: \left( d_3 C u_3 \right) \left( q_1 C \ell_3 \right)
+    duql_3323:
+      tex: \left( d_3 C u_3 \right) \left( q_2 C \ell_3 \right)
+    duql_3333:
+      tex: \left( d_3 C u_3 \right) \left( q_3 C \ell_3 \right)
+    qque_1113:
+      tex: \left( q_1 C q_1 \right) \left( u_1 C e_3 \right)
+    qque_1123:
+      tex: \left( q_1 C q_1 \right) \left( u_2 C e_3 \right)
+    qque_1133:
+      tex: \left( q_1 C q_1 \right) \left( u_3 C e_3 \right)
+    qque_1213:
+      tex: \left( q_1 C q_2 \right) \left( u_1 C e_3 \right)
+    qque_1223:
+      tex: \left( q_1 C q_2 \right) \left( u_2 C e_3 \right)
+    qque_1233:
+      tex: \left( q_1 C q_2 \right) \left( u_3 C e_3 \right)
+    qque_1313:
+      tex: \left( q_1 C q_3 \right) \left( u_1 C e_3 \right)
+    qque_1323:
+      tex: \left( q_1 C q_3 \right) \left( u_2 C e_3 \right)
+    qque_1333:
+      tex: \left( q_1 C q_3 \right) \left( u_3 C e_3 \right)
+    qque_2213:
+      tex: \left( q_2 C q_2 \right) \left( u_1 C e_3 \right)
+    qque_2223:
+      tex: \left( q_2 C q_2 \right) \left( u_2 C e_3 \right)
+    qque_2233:
+      tex: \left( q_2 C q_2 \right) \left( u_3 C e_3 \right)
+    qque_2313:
+      tex: \left( q_2 C q_3 \right) \left( u_1 C e_3 \right)
+    qque_2323:
+      tex: \left( q_2 C q_3 \right) \left( u_2 C e_3 \right)
+    qque_2333:
+      tex: \left( q_2 C q_3 \right) \left( u_3 C e_3 \right)
+    qque_3313:
+      tex: \left( q_3 C q_3 \right) \left( u_1 C e_3 \right)
+    qque_3323:
+      tex: \left( q_3 C q_3 \right) \left( u_2 C e_3 \right)
+    qque_3333:
+      tex: \left( q_3 C q_3 \right) \left( u_3 C e_3 \right)
+    qqql_1113:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_1 C \ell_3 \right)
+    qqql_1123:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_2 C \ell_3 \right)
+    qqql_1133:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_3 C \ell_3 \right)
+    qqql_1213:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_1 C \ell_3 \right)
+    qqql_1223:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_2 C \ell_3 \right)
+    qqql_1233:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_3 C \ell_3 \right)
+    qqql_1313:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_1 C \ell_3 \right)
+    qqql_1323:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_2 C \ell_3 \right)
+    qqql_1333:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_3 C \ell_3 \right)
+    qqql_2123:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_1 \right) \left( q_2 C \ell_3 \right)
+    qqql_2133:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_1 \right) \left( q_3 C \ell_3 \right)
+    qqql_2223:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_2 \right) \left( q_2 C \ell_3 \right)
+    qqql_2233:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_2 \right) \left( q_3 C \ell_3 \right)
+    qqql_2313:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_1 C \ell_3 \right)
+    qqql_2323:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_2 C \ell_3 \right)
+    qqql_2333:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_3 C \ell_3 \right)
+    qqql_3133:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_1 \right) \left( q_3 C \ell_3 \right)
+    qqql_3233:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_2 \right) \left( q_3 C \ell_3 \right)
+    qqql_3333:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_3 \right) \left( q_3 C \ell_3 \right)
+    duue_1113:
+      tex: \left( d_1 C u_1 \right) \left( u_1 C e_3 \right)
+    duue_1123:
+      tex: \left( d_1 C u_1 \right) \left( u_2 C e_3 \right)
+    duue_1133:
+      tex: \left( d_1 C u_1 \right) \left( u_3 C e_3 \right)
+    duue_1213:
+      tex: \left( d_1 C u_2 \right) \left( u_1 C e_3 \right)
+    duue_1223:
+      tex: \left( d_1 C u_2 \right) \left( u_2 C e_3 \right)
+    duue_1233:
+      tex: \left( d_1 C u_2 \right) \left( u_3 C e_3 \right)
+    duue_1313:
+      tex: \left( d_1 C u_3 \right) \left( u_1 C e_3 \right)
+    duue_1323:
+      tex: \left( d_1 C u_3 \right) \left( u_2 C e_3 \right)
+    duue_1333:
+      tex: \left( d_1 C u_3 \right) \left( u_3 C e_3 \right)
+    duue_2113:
+      tex: \left( d_2 C u_1 \right) \left( u_1 C e_3 \right)
+    duue_2123:
+      tex: \left( d_2 C u_1 \right) \left( u_2 C e_3 \right)
+    duue_2133:
+      tex: \left( d_2 C u_1 \right) \left( u_3 C e_3 \right)
+    duue_2213:
+      tex: \left( d_2 C u_2 \right) \left( u_1 C e_3 \right)
+    duue_2223:
+      tex: \left( d_2 C u_2 \right) \left( u_2 C e_3 \right)
+    duue_2233:
+      tex: \left( d_2 C u_2 \right) \left( u_3 C e_3 \right)
+    duue_2313:
+      tex: \left( d_2 C u_3 \right) \left( u_1 C e_3 \right)
+    duue_2323:
+      tex: \left( d_2 C u_3 \right) \left( u_2 C e_3 \right)
+    duue_2333:
+      tex: \left( d_2 C u_3 \right) \left( u_3 C e_3 \right)
+    duue_3113:
+      tex: \left( d_3 C u_1 \right) \left( u_1 C e_3 \right)
+    duue_3123:
+      tex: \left( d_3 C u_1 \right) \left( u_2 C e_3 \right)
+    duue_3133:
+      tex: \left( d_3 C u_1 \right) \left( u_3 C e_3 \right)
+    duue_3213:
+      tex: \left( d_3 C u_2 \right) \left( u_1 C e_3 \right)
+    duue_3223:
+      tex: \left( d_3 C u_2 \right) \left( u_2 C e_3 \right)
+    duue_3233:
+      tex: \left( d_3 C u_2 \right) \left( u_3 C e_3 \right)
+    duue_3313:
+      tex: \left( d_3 C u_3 \right) \left( u_1 C e_3 \right)
+    duue_3323:
+      tex: \left( d_3 C u_3 \right) \left( u_2 C e_3 \right)
     duue_3333:
       tex: \left( d_3 C u_3 \right) \left( u_3 C e_3 \right)
   dL=2:

--- a/smeft.higgs.basis.yml
+++ b/smeft.higgs.basis.yml
@@ -1,16 +1,11 @@
 eft: SMEFT
 basis: Higgs-Warsaw up
 metadata:
-  description: >
-    This is a mixture between the Higgs basis as defined e.g. in arXiv:1610.07922
-    and the Warsaw up basis. All bosonic operators involving at least one
-    Higgs field as well as the operators of type $\psi^2 \phi^2 D$
-    are taken from the Higgs basis (with dimensionful Wilson coefficients
-    rather than normalizing by $1/v^2$), while all other operators (in particular
-    $\psi^2\phi^3$ and four-fermion operators) are defined as in the Warsaw
-    up basis.
+  description: 'This is a mixture between the Higgs basis as defined e.g. in arXiv:1610.07922 and the Warsaw up basis. All bosonic operators involving at least one Higgs field as well as the operators of type $\psi^2 \phi^2 D$ are taken from the Higgs basis (with dimensionful Wilson coefficients rather than normalizing by $1/v^2$), while all other operators (in particular $\psi^2\phi^3$ and four-fermion operators) are defined as in the Warsaw up basis.
+
+    '
 sectors:
-  dB=dL=0:
+  dB=de=dmu=dtau=0:
     G:
       real: true
       tex: f^{ABC} G_\mu^{A \nu} G_\nu^{B \rho} G_\rho^{C \mu}
@@ -85,56 +80,20 @@ sectors:
       tex: \left( \varphi^\dagger \varphi \right) \left( \bar q_3 d_3 \varphi \right)
     ephi_11:
       tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_1 e_1 \varphi \right)
-    ephi_12:
-      tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_1 e_2 \varphi \right)
-    ephi_13:
-      tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_1 e_3 \varphi \right)
-    ephi_21:
-      tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_2 e_1 \varphi \right)
     ephi_22:
       tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_2 e_2 \varphi \right)
-    ephi_23:
-      tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_2 e_3 \varphi \right)
-    ephi_31:
-      tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_3 e_1 \varphi \right)
-    ephi_32:
-      tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_3 e_2 \varphi \right)
     ephi_33:
       tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_3 e_3 \varphi \right)
     eW_11:
       tex: \left( \bar \ell_1 \sigma^{\mu \nu} e_1 \right) \tau^I \varphi W_{\mu \nu}^I
-    eW_12:
-      tex: \left( \bar \ell_1 \sigma^{\mu \nu} e_2 \right) \tau^I \varphi W_{\mu \nu}^I
-    eW_13:
-      tex: \left( \bar \ell_1 \sigma^{\mu \nu} e_3 \right) \tau^I \varphi W_{\mu \nu}^I
-    eW_21:
-      tex: \left( \bar \ell_2 \sigma^{\mu \nu} e_1 \right) \tau^I \varphi W_{\mu \nu}^I
     eW_22:
       tex: \left( \bar \ell_2 \sigma^{\mu \nu} e_2 \right) \tau^I \varphi W_{\mu \nu}^I
-    eW_23:
-      tex: \left( \bar \ell_2 \sigma^{\mu \nu} e_3 \right) \tau^I \varphi W_{\mu \nu}^I
-    eW_31:
-      tex: \left( \bar \ell_3 \sigma^{\mu \nu} e_1 \right) \tau^I \varphi W_{\mu \nu}^I
-    eW_32:
-      tex: \left( \bar \ell_3 \sigma^{\mu \nu} e_2 \right) \tau^I \varphi W_{\mu \nu}^I
     eW_33:
       tex: \left( \bar \ell_3 \sigma^{\mu \nu} e_3 \right) \tau^I \varphi W_{\mu \nu}^I
     eB_11:
       tex: \left( \bar \ell_1 \sigma^{\mu \nu} e_1 \right) \varphi B_{\mu \nu}
-    eB_12:
-      tex: \left( \bar \ell_1 \sigma^{\mu \nu} e_2 \right) \varphi B_{\mu \nu}
-    eB_13:
-      tex: \left( \bar \ell_1 \sigma^{\mu \nu} e_3 \right) \varphi B_{\mu \nu}
-    eB_21:
-      tex: \left( \bar \ell_2 \sigma^{\mu \nu} e_1 \right) \varphi B_{\mu \nu}
     eB_22:
       tex: \left( \bar \ell_2 \sigma^{\mu \nu} e_2 \right) \varphi B_{\mu \nu}
-    eB_23:
-      tex: \left( \bar \ell_2 \sigma^{\mu \nu} e_3 \right) \varphi B_{\mu \nu}
-    eB_31:
-      tex: \left( \bar \ell_3 \sigma^{\mu \nu} e_1 \right) \varphi B_{\mu \nu}
-    eB_32:
-      tex: \left( \bar \ell_3 \sigma^{\mu \nu} e_2 \right) \varphi B_{\mu \nu}
     eB_33:
       tex: \left( \bar \ell_3 \sigma^{\mu \nu} e_3 \right) \varphi B_{\mu \nu}
     uG_11:
@@ -247,29 +206,20 @@ sectors:
       tex: \left( \bar q_3 \sigma^{\mu \nu} d_3 \right) \varphi B_{\mu \nu}
     deltagZeL_11:
       real: true
-    deltagZeL_12:
-    deltagZeL_13:
     deltagZeL_22:
       real: true
-    deltagZeL_23:
     deltagZeL_33:
       real: true
     deltagWlL_11:
       real: true
-    deltagWlL_12:
-    deltagWlL_13:
     deltagWlL_22:
       real: true
-    deltagWlL_23:
     deltagWlL_33:
       real: true
     deltagZeR_11:
       real: true
-    deltagZeR_12:
-    deltagZeR_13:
     deltagZeR_22:
       real: true
-    deltagZeR_23:
     deltagZeR_33:
       real: true
     deltagZuL_11:
@@ -320,63 +270,27 @@ sectors:
     ll_1111:
       real: true
       tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar \ell_1 \gamma^\mu \ell_1 \right)
-    ll_1112:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar \ell_1 \gamma^\mu \ell_2 \right)
-    ll_1113:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar \ell_1 \gamma^\mu \ell_3 \right)
     ll_1122:
       real: true
       tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar \ell_2 \gamma^\mu \ell_2 \right)
-    ll_1123:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar \ell_2 \gamma^\mu \ell_3 \right)
     ll_1133:
       real: true
       tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar \ell_3 \gamma^\mu \ell_3 \right)
-    ll_1212:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_1 \gamma^\mu \ell_2 \right)
-    ll_1213:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_1 \gamma^\mu \ell_3 \right)
     ll_1221:
       real: true
       tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_2 \gamma^\mu \ell_1 \right)
-    ll_1222:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_2 \gamma^\mu \ell_2 \right)
-    ll_1223:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_2 \gamma^\mu \ell_3 \right)
-    ll_1231:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_3 \gamma^\mu \ell_1 \right)
-    ll_1232:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_3 \gamma^\mu \ell_2 \right)
-    ll_1233:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_3 \gamma^\mu \ell_3 \right)
-    ll_1313:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar \ell_1 \gamma^\mu \ell_3 \right)
-    ll_1322:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar \ell_2 \gamma^\mu \ell_2 \right)
-    ll_1323:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar \ell_2 \gamma^\mu \ell_3 \right)
     ll_1331:
       real: true
       tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar \ell_3 \gamma^\mu \ell_1 \right)
-    ll_1332:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar \ell_3 \gamma^\mu \ell_2 \right)
-    ll_1333:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar \ell_3 \gamma^\mu \ell_3 \right)
     ll_2222:
       real: true
       tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar \ell_2 \gamma^\mu \ell_2 \right)
-    ll_2223:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar \ell_2 \gamma^\mu \ell_3 \right)
     ll_2233:
       real: true
       tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar \ell_3 \gamma^\mu \ell_3 \right)
-    ll_2323:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar \ell_2 \gamma^\mu \ell_3 \right)
     ll_2332:
       real: true
       tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar \ell_3 \gamma^\mu \ell_2 \right)
-    ll_2333:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar \ell_3 \gamma^\mu \ell_3 \right)
     ll_3333:
       real: true
       tex: \left( \bar \ell_3 \gamma_\mu \ell_3 \right) \left( \bar \ell_3 \gamma^\mu \ell_3 \right)
@@ -521,42 +435,6 @@ sectors:
     lq1_1133:
       real: true
       tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar q_3 \gamma^\mu q_3 \right)
-    lq1_1211:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_1 \gamma^\mu q_1 \right)
-    lq1_1212:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_1 \gamma^\mu q_2 \right)
-    lq1_1213:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_1 \gamma^\mu q_3 \right)
-    lq1_1221:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_2 \gamma^\mu q_1 \right)
-    lq1_1222:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_2 \gamma^\mu q_2 \right)
-    lq1_1223:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_2 \gamma^\mu q_3 \right)
-    lq1_1231:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_3 \gamma^\mu q_1 \right)
-    lq1_1232:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_3 \gamma^\mu q_2 \right)
-    lq1_1233:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_3 \gamma^\mu q_3 \right)
-    lq1_1311:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_1 \gamma^\mu q_1 \right)
-    lq1_1312:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_1 \gamma^\mu q_2 \right)
-    lq1_1313:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_1 \gamma^\mu q_3 \right)
-    lq1_1321:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_2 \gamma^\mu q_1 \right)
-    lq1_1322:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_2 \gamma^\mu q_2 \right)
-    lq1_1323:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_2 \gamma^\mu q_3 \right)
-    lq1_1331:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_3 \gamma^\mu q_1 \right)
-    lq1_1332:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_3 \gamma^\mu q_2 \right)
-    lq1_1333:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_3 \gamma^\mu q_3 \right)
     lq1_2211:
       real: true
       tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar q_1 \gamma^\mu q_1 \right)
@@ -572,24 +450,6 @@ sectors:
     lq1_2233:
       real: true
       tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar q_3 \gamma^\mu q_3 \right)
-    lq1_2311:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_1 \gamma^\mu q_1 \right)
-    lq1_2312:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_1 \gamma^\mu q_2 \right)
-    lq1_2313:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_1 \gamma^\mu q_3 \right)
-    lq1_2321:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_2 \gamma^\mu q_1 \right)
-    lq1_2322:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_2 \gamma^\mu q_2 \right)
-    lq1_2323:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_2 \gamma^\mu q_3 \right)
-    lq1_2331:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_3 \gamma^\mu q_1 \right)
-    lq1_2332:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_3 \gamma^\mu q_2 \right)
-    lq1_2333:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_3 \gamma^\mu q_3 \right)
     lq1_3311:
       real: true
       tex: \left( \bar \ell_3 \gamma_\mu \ell_3 \right) \left( \bar q_1 \gamma^\mu q_1 \right)
@@ -620,42 +480,6 @@ sectors:
     lq3_1133:
       real: true
       tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_1 \right) \left( \bar q_3 \gamma^\mu \tau^I q_3 \right)
-    lq3_1211:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_1 \gamma^\mu \tau^I q_1 \right)
-    lq3_1212:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_1 \gamma^\mu \tau^I q_2 \right)
-    lq3_1213:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_1 \gamma^\mu \tau^I q_3 \right)
-    lq3_1221:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_2 \gamma^\mu \tau^I q_1 \right)
-    lq3_1222:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_2 \gamma^\mu \tau^I q_2 \right)
-    lq3_1223:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_2 \gamma^\mu \tau^I q_3 \right)
-    lq3_1231:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_3 \gamma^\mu \tau^I q_1 \right)
-    lq3_1232:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_3 \gamma^\mu \tau^I q_2 \right)
-    lq3_1233:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_3 \gamma^\mu \tau^I q_3 \right)
-    lq3_1311:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_1 \gamma^\mu \tau^I q_1 \right)
-    lq3_1312:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_1 \gamma^\mu \tau^I q_2 \right)
-    lq3_1313:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_1 \gamma^\mu \tau^I q_3 \right)
-    lq3_1321:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_2 \gamma^\mu \tau^I q_1 \right)
-    lq3_1322:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_2 \gamma^\mu \tau^I q_2 \right)
-    lq3_1323:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_2 \gamma^\mu \tau^I q_3 \right)
-    lq3_1331:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_3 \gamma^\mu \tau^I q_1 \right)
-    lq3_1332:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_3 \gamma^\mu \tau^I q_2 \right)
-    lq3_1333:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_3 \gamma^\mu \tau^I q_3 \right)
     lq3_2211:
       real: true
       tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_1 \gamma^\mu \tau^I q_1 \right)
@@ -671,24 +495,6 @@ sectors:
     lq3_2233:
       real: true
       tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_3 \gamma^\mu \tau^I q_3 \right)
-    lq3_2311:
-      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_1 \gamma^\mu \tau^I q_1 \right)
-    lq3_2312:
-      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_1 \gamma^\mu \tau^I q_2 \right)
-    lq3_2313:
-      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_1 \gamma^\mu \tau^I q_3 \right)
-    lq3_2321:
-      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_2 \gamma^\mu \tau^I q_1 \right)
-    lq3_2322:
-      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_2 \gamma^\mu \tau^I q_2 \right)
-    lq3_2323:
-      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_2 \gamma^\mu \tau^I q_3 \right)
-    lq3_2331:
-      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_3 \gamma^\mu \tau^I q_1 \right)
-    lq3_2332:
-      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_3 \gamma^\mu \tau^I q_2 \right)
-    lq3_2333:
-      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_3 \gamma^\mu \tau^I q_3 \right)
     lq3_3311:
       real: true
       tex: \left( \bar \ell_3 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_1 \gamma^\mu \tau^I q_1 \right)
@@ -707,48 +513,18 @@ sectors:
     ee_1111:
       real: true
       tex: \left( \bar e_1 \gamma_\mu e_1 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
-    ee_1112:
-      tex: \left( \bar e_1 \gamma_\mu e_1 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    ee_1113:
-      tex: \left( \bar e_1 \gamma_\mu e_1 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
     ee_1122:
       real: true
       tex: \left( \bar e_1 \gamma_\mu e_1 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    ee_1123:
-      tex: \left( \bar e_1 \gamma_\mu e_1 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
     ee_1133:
       real: true
       tex: \left( \bar e_1 \gamma_\mu e_1 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
-    ee_1212:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    ee_1213:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
-    ee_1222:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    ee_1223:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
-    ee_1232:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar e_3 \gamma^\mu e_2 \right)
-    ee_1233:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
-    ee_1313:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
-    ee_1323:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
-    ee_1333:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
     ee_2222:
       real: true
       tex: \left( \bar e_2 \gamma_\mu e_2 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    ee_2223:
-      tex: \left( \bar e_2 \gamma_\mu e_2 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
     ee_2233:
       real: true
       tex: \left( \bar e_2 \gamma_\mu e_2 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
-    ee_2323:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
-    ee_2333:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
     ee_3333:
       real: true
       tex: \left( \bar e_3 \gamma_\mu e_3 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
@@ -893,42 +669,6 @@ sectors:
     eu_1133:
       real: true
       tex: \left( \bar e_1 \gamma_\mu e_1 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
-    eu_1211:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
-    eu_1212:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_1 \gamma^\mu u_2 \right)
-    eu_1213:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_1 \gamma^\mu u_3 \right)
-    eu_1221:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_2 \gamma^\mu u_1 \right)
-    eu_1222:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_2 \gamma^\mu u_2 \right)
-    eu_1223:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_2 \gamma^\mu u_3 \right)
-    eu_1231:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_3 \gamma^\mu u_1 \right)
-    eu_1232:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_3 \gamma^\mu u_2 \right)
-    eu_1233:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
-    eu_1311:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
-    eu_1312:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_1 \gamma^\mu u_2 \right)
-    eu_1313:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_1 \gamma^\mu u_3 \right)
-    eu_1321:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_2 \gamma^\mu u_1 \right)
-    eu_1322:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_2 \gamma^\mu u_2 \right)
-    eu_1323:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_2 \gamma^\mu u_3 \right)
-    eu_1331:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_3 \gamma^\mu u_1 \right)
-    eu_1332:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_3 \gamma^\mu u_2 \right)
-    eu_1333:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
     eu_2211:
       real: true
       tex: \left( \bar e_2 \gamma_\mu e_2 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
@@ -944,24 +684,6 @@ sectors:
     eu_2233:
       real: true
       tex: \left( \bar e_2 \gamma_\mu e_2 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
-    eu_2311:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
-    eu_2312:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_1 \gamma^\mu u_2 \right)
-    eu_2313:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_1 \gamma^\mu u_3 \right)
-    eu_2321:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_2 \gamma^\mu u_1 \right)
-    eu_2322:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_2 \gamma^\mu u_2 \right)
-    eu_2323:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_2 \gamma^\mu u_3 \right)
-    eu_2331:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_3 \gamma^\mu u_1 \right)
-    eu_2332:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_3 \gamma^\mu u_2 \right)
-    eu_2333:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
     eu_3311:
       real: true
       tex: \left( \bar e_3 \gamma_\mu e_3 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
@@ -992,42 +714,6 @@ sectors:
     ed_1133:
       real: true
       tex: \left( \bar e_1 \gamma_\mu e_1 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
-    ed_1211:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
-    ed_1212:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_1 \gamma^\mu d_2 \right)
-    ed_1213:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_1 \gamma^\mu d_3 \right)
-    ed_1221:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_2 \gamma^\mu d_1 \right)
-    ed_1222:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_2 \gamma^\mu d_2 \right)
-    ed_1223:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_2 \gamma^\mu d_3 \right)
-    ed_1231:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_3 \gamma^\mu d_1 \right)
-    ed_1232:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_3 \gamma^\mu d_2 \right)
-    ed_1233:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
-    ed_1311:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
-    ed_1312:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_1 \gamma^\mu d_2 \right)
-    ed_1313:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_1 \gamma^\mu d_3 \right)
-    ed_1321:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_2 \gamma^\mu d_1 \right)
-    ed_1322:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_2 \gamma^\mu d_2 \right)
-    ed_1323:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_2 \gamma^\mu d_3 \right)
-    ed_1331:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_3 \gamma^\mu d_1 \right)
-    ed_1332:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_3 \gamma^\mu d_2 \right)
-    ed_1333:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
     ed_2211:
       real: true
       tex: \left( \bar e_2 \gamma_\mu e_2 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
@@ -1043,24 +729,6 @@ sectors:
     ed_2233:
       real: true
       tex: \left( \bar e_2 \gamma_\mu e_2 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
-    ed_2311:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
-    ed_2312:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_1 \gamma^\mu d_2 \right)
-    ed_2313:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_1 \gamma^\mu d_3 \right)
-    ed_2321:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_2 \gamma^\mu d_1 \right)
-    ed_2322:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_2 \gamma^\mu d_2 \right)
-    ed_2323:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_2 \gamma^\mu d_3 \right)
-    ed_2331:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_3 \gamma^\mu d_1 \right)
-    ed_2332:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_3 \gamma^\mu d_2 \right)
-    ed_2333:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
     ed_3311:
       real: true
       tex: \left( \bar e_3 \gamma_\mu e_3 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
@@ -1277,99 +945,33 @@ sectors:
     le_1111:
       real: true
       tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
-    le_1112:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    le_1113:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
     le_1122:
       real: true
       tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    le_1123:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
     le_1133:
       real: true
       tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
-    le_1211:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
-    le_1212:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    le_1213:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
     le_1221:
       tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_2 \gamma^\mu e_1 \right)
-    le_1222:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    le_1223:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
-    le_1231:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_3 \gamma^\mu e_1 \right)
-    le_1232:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_3 \gamma^\mu e_2 \right)
-    le_1233:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
-    le_1311:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
-    le_1312:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    le_1313:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
-    le_1321:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_1 \right)
-    le_1322:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    le_1323:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
     le_1331:
       tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_3 \gamma^\mu e_1 \right)
-    le_1332:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_3 \gamma^\mu e_2 \right)
-    le_1333:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
     le_2211:
       real: true
       tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
-    le_2212:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    le_2213:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
     le_2222:
       real: true
       tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    le_2223:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
     le_2233:
       real: true
       tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
-    le_2311:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
-    le_2312:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    le_2313:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
-    le_2321:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_1 \right)
-    le_2322:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    le_2323:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
-    le_2331:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_3 \gamma^\mu e_1 \right)
     le_2332:
       tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_3 \gamma^\mu e_2 \right)
-    le_2333:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
     le_3311:
       real: true
       tex: \left( \bar \ell_3 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
-    le_3312:
-      tex: \left( \bar \ell_3 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    le_3313:
-      tex: \left( \bar \ell_3 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
     le_3322:
       real: true
       tex: \left( \bar \ell_3 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    le_3323:
-      tex: \left( \bar \ell_3 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
     le_3333:
       real: true
       tex: \left( \bar \ell_3 \gamma_\mu \ell_3 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
@@ -1388,42 +990,6 @@ sectors:
     lu_1133:
       real: true
       tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
-    lu_1211:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
-    lu_1212:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_1 \gamma^\mu u_2 \right)
-    lu_1213:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_1 \gamma^\mu u_3 \right)
-    lu_1221:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_2 \gamma^\mu u_1 \right)
-    lu_1222:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_2 \gamma^\mu u_2 \right)
-    lu_1223:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_2 \gamma^\mu u_3 \right)
-    lu_1231:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_3 \gamma^\mu u_1 \right)
-    lu_1232:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_3 \gamma^\mu u_2 \right)
-    lu_1233:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
-    lu_1311:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
-    lu_1312:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_1 \gamma^\mu u_2 \right)
-    lu_1313:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_1 \gamma^\mu u_3 \right)
-    lu_1321:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_2 \gamma^\mu u_1 \right)
-    lu_1322:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_2 \gamma^\mu u_2 \right)
-    lu_1323:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_2 \gamma^\mu u_3 \right)
-    lu_1331:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_3 \gamma^\mu u_1 \right)
-    lu_1332:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_3 \gamma^\mu u_2 \right)
-    lu_1333:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
     lu_2211:
       real: true
       tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
@@ -1439,24 +1005,6 @@ sectors:
     lu_2233:
       real: true
       tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
-    lu_2311:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
-    lu_2312:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_1 \gamma^\mu u_2 \right)
-    lu_2313:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_1 \gamma^\mu u_3 \right)
-    lu_2321:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_2 \gamma^\mu u_1 \right)
-    lu_2322:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_2 \gamma^\mu u_2 \right)
-    lu_2323:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_2 \gamma^\mu u_3 \right)
-    lu_2331:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_3 \gamma^\mu u_1 \right)
-    lu_2332:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_3 \gamma^\mu u_2 \right)
-    lu_2333:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
     lu_3311:
       real: true
       tex: \left( \bar \ell_3 \gamma_\mu \ell_3 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
@@ -1487,42 +1035,6 @@ sectors:
     ld_1133:
       real: true
       tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
-    ld_1211:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
-    ld_1212:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_1 \gamma^\mu d_2 \right)
-    ld_1213:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_1 \gamma^\mu d_3 \right)
-    ld_1221:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_2 \gamma^\mu d_1 \right)
-    ld_1222:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_2 \gamma^\mu d_2 \right)
-    ld_1223:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_2 \gamma^\mu d_3 \right)
-    ld_1231:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_3 \gamma^\mu d_1 \right)
-    ld_1232:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_3 \gamma^\mu d_2 \right)
-    ld_1233:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
-    ld_1311:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
-    ld_1312:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_1 \gamma^\mu d_2 \right)
-    ld_1313:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_1 \gamma^\mu d_3 \right)
-    ld_1321:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_2 \gamma^\mu d_1 \right)
-    ld_1322:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_2 \gamma^\mu d_2 \right)
-    ld_1323:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_2 \gamma^\mu d_3 \right)
-    ld_1331:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_3 \gamma^\mu d_1 \right)
-    ld_1332:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_3 \gamma^\mu d_2 \right)
-    ld_1333:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
     ld_2211:
       real: true
       tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
@@ -1538,24 +1050,6 @@ sectors:
     ld_2233:
       real: true
       tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
-    ld_2311:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
-    ld_2312:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_1 \gamma^\mu d_2 \right)
-    ld_2313:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_1 \gamma^\mu d_3 \right)
-    ld_2321:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_2 \gamma^\mu d_1 \right)
-    ld_2322:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_2 \gamma^\mu d_2 \right)
-    ld_2323:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_2 \gamma^\mu d_3 \right)
-    ld_2331:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_3 \gamma^\mu d_1 \right)
-    ld_2332:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_3 \gamma^\mu d_2 \right)
-    ld_2333:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
     ld_3311:
       real: true
       tex: \left( \bar \ell_3 \gamma_\mu \ell_3 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
@@ -1574,99 +1068,45 @@ sectors:
     qe_1111:
       real: true
       tex: \left( \bar q_1 \gamma_\mu q_1 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
-    qe_1112:
-      tex: \left( \bar q_1 \gamma_\mu q_1 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    qe_1113:
-      tex: \left( \bar q_1 \gamma_\mu q_1 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
     qe_1122:
       real: true
       tex: \left( \bar q_1 \gamma_\mu q_1 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    qe_1123:
-      tex: \left( \bar q_1 \gamma_\mu q_1 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
     qe_1133:
       real: true
       tex: \left( \bar q_1 \gamma_\mu q_1 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
     qe_1211:
       tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
-    qe_1212:
-      tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    qe_1213:
-      tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
-    qe_1221:
-      tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_2 \gamma^\mu e_1 \right)
     qe_1222:
       tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    qe_1223:
-      tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
-    qe_1231:
-      tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_3 \gamma^\mu e_1 \right)
-    qe_1232:
-      tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_3 \gamma^\mu e_2 \right)
     qe_1233:
       tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
     qe_1311:
       tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
-    qe_1312:
-      tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    qe_1313:
-      tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
-    qe_1321:
-      tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_2 \gamma^\mu e_1 \right)
     qe_1322:
       tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    qe_1323:
-      tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
-    qe_1331:
-      tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_3 \gamma^\mu e_1 \right)
-    qe_1332:
-      tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_3 \gamma^\mu e_2 \right)
     qe_1333:
       tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
     qe_2211:
       real: true
       tex: \left( \bar q_2 \gamma_\mu q_2 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
-    qe_2212:
-      tex: \left( \bar q_2 \gamma_\mu q_2 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    qe_2213:
-      tex: \left( \bar q_2 \gamma_\mu q_2 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
     qe_2222:
       real: true
       tex: \left( \bar q_2 \gamma_\mu q_2 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    qe_2223:
-      tex: \left( \bar q_2 \gamma_\mu q_2 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
     qe_2233:
       real: true
       tex: \left( \bar q_2 \gamma_\mu q_2 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
     qe_2311:
       tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
-    qe_2312:
-      tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    qe_2313:
-      tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
-    qe_2321:
-      tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_2 \gamma^\mu e_1 \right)
     qe_2322:
       tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    qe_2323:
-      tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
-    qe_2331:
-      tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_3 \gamma^\mu e_1 \right)
-    qe_2332:
-      tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_3 \gamma^\mu e_2 \right)
     qe_2333:
       tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
     qe_3311:
       real: true
       tex: \left( \bar q_3 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
-    qe_3312:
-      tex: \left( \bar q_3 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    qe_3313:
-      tex: \left( \bar q_3 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
     qe_3322:
       real: true
       tex: \left( \bar q_3 \gamma_\mu q_3 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    qe_3323:
-      tex: \left( \bar q_3 \gamma_\mu q_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
     qe_3333:
       real: true
       tex: \left( \bar q_3 \gamma_\mu q_3 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
@@ -2084,60 +1524,6 @@ sectors:
       tex: \left( \bar \ell_1 e_1 \right) \left( \bar d_3 q_2 \right)
     ledq_1133:
       tex: \left( \bar \ell_1 e_1 \right) \left( \bar d_3 q_3 \right)
-    ledq_1211:
-      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_1 q_1 \right)
-    ledq_1212:
-      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_1 q_2 \right)
-    ledq_1213:
-      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_1 q_3 \right)
-    ledq_1221:
-      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_2 q_1 \right)
-    ledq_1222:
-      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_2 q_2 \right)
-    ledq_1223:
-      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_2 q_3 \right)
-    ledq_1231:
-      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_3 q_1 \right)
-    ledq_1232:
-      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_3 q_2 \right)
-    ledq_1233:
-      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_3 q_3 \right)
-    ledq_1311:
-      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_1 q_1 \right)
-    ledq_1312:
-      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_1 q_2 \right)
-    ledq_1313:
-      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_1 q_3 \right)
-    ledq_1321:
-      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_2 q_1 \right)
-    ledq_1322:
-      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_2 q_2 \right)
-    ledq_1323:
-      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_2 q_3 \right)
-    ledq_1331:
-      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_3 q_1 \right)
-    ledq_1332:
-      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_3 q_2 \right)
-    ledq_1333:
-      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_3 q_3 \right)
-    ledq_2111:
-      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_1 q_1 \right)
-    ledq_2112:
-      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_1 q_2 \right)
-    ledq_2113:
-      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_1 q_3 \right)
-    ledq_2121:
-      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_2 q_1 \right)
-    ledq_2122:
-      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_2 q_2 \right)
-    ledq_2123:
-      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_2 q_3 \right)
-    ledq_2131:
-      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_3 q_1 \right)
-    ledq_2132:
-      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_3 q_2 \right)
-    ledq_2133:
-      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_3 q_3 \right)
     ledq_2211:
       tex: \left( \bar \ell_2 e_2 \right) \left( \bar d_1 q_1 \right)
     ledq_2212:
@@ -2156,60 +1542,6 @@ sectors:
       tex: \left( \bar \ell_2 e_2 \right) \left( \bar d_3 q_2 \right)
     ledq_2233:
       tex: \left( \bar \ell_2 e_2 \right) \left( \bar d_3 q_3 \right)
-    ledq_2311:
-      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_1 q_1 \right)
-    ledq_2312:
-      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_1 q_2 \right)
-    ledq_2313:
-      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_1 q_3 \right)
-    ledq_2321:
-      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_2 q_1 \right)
-    ledq_2322:
-      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_2 q_2 \right)
-    ledq_2323:
-      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_2 q_3 \right)
-    ledq_2331:
-      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_3 q_1 \right)
-    ledq_2332:
-      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_3 q_2 \right)
-    ledq_2333:
-      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_3 q_3 \right)
-    ledq_3111:
-      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_1 q_1 \right)
-    ledq_3112:
-      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_1 q_2 \right)
-    ledq_3113:
-      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_1 q_3 \right)
-    ledq_3121:
-      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_2 q_1 \right)
-    ledq_3122:
-      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_2 q_2 \right)
-    ledq_3123:
-      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_2 q_3 \right)
-    ledq_3131:
-      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_3 q_1 \right)
-    ledq_3132:
-      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_3 q_2 \right)
-    ledq_3133:
-      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_3 q_3 \right)
-    ledq_3211:
-      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_1 q_1 \right)
-    ledq_3212:
-      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_1 q_2 \right)
-    ledq_3213:
-      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_1 q_3 \right)
-    ledq_3221:
-      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_2 q_1 \right)
-    ledq_3222:
-      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_2 q_2 \right)
-    ledq_3223:
-      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_2 q_3 \right)
-    ledq_3231:
-      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_3 q_1 \right)
-    ledq_3232:
-      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_3 q_2 \right)
-    ledq_3233:
-      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_3 q_3 \right)
     ledq_3311:
       tex: \left( \bar \ell_3 e_3 \right) \left( \bar d_1 q_1 \right)
     ledq_3312:
@@ -2570,60 +1902,6 @@ sectors:
       tex: \left( \bar \ell_1 e_1 \right) \epsilon_{jk} \left( \bar q_3 u_2 \right)
     lequ1_1133:
       tex: \left( \bar \ell_1 e_1 \right) \epsilon_{jk} \left( \bar q_3 u_3 \right)
-    lequ1_1211:
-      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_1 u_1 \right)
-    lequ1_1212:
-      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_1 u_2 \right)
-    lequ1_1213:
-      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_1 u_3 \right)
-    lequ1_1221:
-      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_2 u_1 \right)
-    lequ1_1222:
-      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_2 u_2 \right)
-    lequ1_1223:
-      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_2 u_3 \right)
-    lequ1_1231:
-      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_3 u_1 \right)
-    lequ1_1232:
-      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_3 u_2 \right)
-    lequ1_1233:
-      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_3 u_3 \right)
-    lequ1_1311:
-      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_1 u_1 \right)
-    lequ1_1312:
-      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_1 u_2 \right)
-    lequ1_1313:
-      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_1 u_3 \right)
-    lequ1_1321:
-      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_2 u_1 \right)
-    lequ1_1322:
-      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_2 u_2 \right)
-    lequ1_1323:
-      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_2 u_3 \right)
-    lequ1_1331:
-      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_3 u_1 \right)
-    lequ1_1332:
-      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_3 u_2 \right)
-    lequ1_1333:
-      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_3 u_3 \right)
-    lequ1_2111:
-      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_1 u_1 \right)
-    lequ1_2112:
-      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_1 u_2 \right)
-    lequ1_2113:
-      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_1 u_3 \right)
-    lequ1_2121:
-      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_2 u_1 \right)
-    lequ1_2122:
-      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_2 u_2 \right)
-    lequ1_2123:
-      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_2 u_3 \right)
-    lequ1_2131:
-      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_3 u_1 \right)
-    lequ1_2132:
-      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_3 u_2 \right)
-    lequ1_2133:
-      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_3 u_3 \right)
     lequ1_2211:
       tex: \left( \bar \ell_2 e_2 \right) \epsilon_{jk} \left( \bar q_1 u_1 \right)
     lequ1_2212:
@@ -2642,60 +1920,6 @@ sectors:
       tex: \left( \bar \ell_2 e_2 \right) \epsilon_{jk} \left( \bar q_3 u_2 \right)
     lequ1_2233:
       tex: \left( \bar \ell_2 e_2 \right) \epsilon_{jk} \left( \bar q_3 u_3 \right)
-    lequ1_2311:
-      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_1 u_1 \right)
-    lequ1_2312:
-      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_1 u_2 \right)
-    lequ1_2313:
-      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_1 u_3 \right)
-    lequ1_2321:
-      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_2 u_1 \right)
-    lequ1_2322:
-      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_2 u_2 \right)
-    lequ1_2323:
-      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_2 u_3 \right)
-    lequ1_2331:
-      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_3 u_1 \right)
-    lequ1_2332:
-      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_3 u_2 \right)
-    lequ1_2333:
-      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_3 u_3 \right)
-    lequ1_3111:
-      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_1 u_1 \right)
-    lequ1_3112:
-      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_1 u_2 \right)
-    lequ1_3113:
-      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_1 u_3 \right)
-    lequ1_3121:
-      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_2 u_1 \right)
-    lequ1_3122:
-      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_2 u_2 \right)
-    lequ1_3123:
-      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_2 u_3 \right)
-    lequ1_3131:
-      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_3 u_1 \right)
-    lequ1_3132:
-      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_3 u_2 \right)
-    lequ1_3133:
-      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_3 u_3 \right)
-    lequ1_3211:
-      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_1 u_1 \right)
-    lequ1_3212:
-      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_1 u_2 \right)
-    lequ1_3213:
-      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_1 u_3 \right)
-    lequ1_3221:
-      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_2 u_1 \right)
-    lequ1_3222:
-      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_2 u_2 \right)
-    lequ1_3223:
-      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_2 u_3 \right)
-    lequ1_3231:
-      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_3 u_1 \right)
-    lequ1_3232:
-      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_3 u_2 \right)
-    lequ1_3233:
-      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_3 u_3 \right)
     lequ1_3311:
       tex: \left( \bar \ell_3 e_3 \right) \epsilon_{jk} \left( \bar q_1 u_1 \right)
     lequ1_3312:
@@ -2732,60 +1956,6 @@ sectors:
       tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
     lequ3_1133:
       tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
-    lequ3_1211:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_1 \right)
-    lequ3_1212:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_2 \right)
-    lequ3_1213:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_3 \right)
-    lequ3_1221:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_1 \right)
-    lequ3_1222:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_2 \right)
-    lequ3_1223:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_3 \right)
-    lequ3_1231:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_1 \right)
-    lequ3_1232:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
-    lequ3_1233:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
-    lequ3_1311:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_1 \right)
-    lequ3_1312:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_2 \right)
-    lequ3_1313:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_3 \right)
-    lequ3_1321:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_1 \right)
-    lequ3_1322:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_2 \right)
-    lequ3_1323:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_3 \right)
-    lequ3_1331:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_1 \right)
-    lequ3_1332:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
-    lequ3_1333:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
-    lequ3_2111:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_1 \right)
-    lequ3_2112:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_2 \right)
-    lequ3_2113:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_3 \right)
-    lequ3_2121:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_1 \right)
-    lequ3_2122:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_2 \right)
-    lequ3_2123:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_3 \right)
-    lequ3_2131:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_1 \right)
-    lequ3_2132:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
-    lequ3_2133:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
     lequ3_2211:
       tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_1 \right)
     lequ3_2212:
@@ -2804,60 +1974,6 @@ sectors:
       tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
     lequ3_2233:
       tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
-    lequ3_2311:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_1 \right)
-    lequ3_2312:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_2 \right)
-    lequ3_2313:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_3 \right)
-    lequ3_2321:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_1 \right)
-    lequ3_2322:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_2 \right)
-    lequ3_2323:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_3 \right)
-    lequ3_2331:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_1 \right)
-    lequ3_2332:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
-    lequ3_2333:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
-    lequ3_3111:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_1 \right)
-    lequ3_3112:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_2 \right)
-    lequ3_3113:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_3 \right)
-    lequ3_3121:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_1 \right)
-    lequ3_3122:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_2 \right)
-    lequ3_3123:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_3 \right)
-    lequ3_3131:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_1 \right)
-    lequ3_3132:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
-    lequ3_3133:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
-    lequ3_3211:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_1 \right)
-    lequ3_3212:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_2 \right)
-    lequ3_3213:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_3 \right)
-    lequ3_3221:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_1 \right)
-    lequ3_3222:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_2 \right)
-    lequ3_3223:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_3 \right)
-    lequ3_3231:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_1 \right)
-    lequ3_3232:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
-    lequ3_3233:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
     lequ3_3311:
       tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_1 \right)
     lequ3_3312:
@@ -2876,6 +1992,894 @@ sectors:
       tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
     lequ3_3333:
       tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
+  mue:
+    ephi_12:
+      tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_1 e_2 \varphi \right)
+    ephi_21:
+      tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_2 e_1 \varphi \right)
+    eW_12:
+      tex: \left( \bar \ell_1 \sigma^{\mu \nu} e_2 \right) \tau^I \varphi W_{\mu \nu}^I
+    eW_21:
+      tex: \left( \bar \ell_2 \sigma^{\mu \nu} e_1 \right) \tau^I \varphi W_{\mu \nu}^I
+    eB_12:
+      tex: \left( \bar \ell_1 \sigma^{\mu \nu} e_2 \right) \varphi B_{\mu \nu}
+    eB_21:
+      tex: \left( \bar \ell_2 \sigma^{\mu \nu} e_1 \right) \varphi B_{\mu \nu}
+    deltagZeL_12:
+    deltagWlL_12:
+    deltagZeR_12:
+    ll_1112:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar \ell_1 \gamma^\mu \ell_2 \right)
+    ll_1222:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_2 \gamma^\mu \ell_2 \right)
+    ll_1233:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_3 \gamma^\mu \ell_3 \right)
+    ll_1332:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar \ell_3 \gamma^\mu \ell_2 \right)
+    lq1_1211:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_1 \gamma^\mu q_1 \right)
+    lq1_1212:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_1 \gamma^\mu q_2 \right)
+    lq1_1213:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_1 \gamma^\mu q_3 \right)
+    lq1_1221:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_2 \gamma^\mu q_1 \right)
+    lq1_1222:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_2 \gamma^\mu q_2 \right)
+    lq1_1223:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_2 \gamma^\mu q_3 \right)
+    lq1_1231:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_3 \gamma^\mu q_1 \right)
+    lq1_1232:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_3 \gamma^\mu q_2 \right)
+    lq1_1233:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_3 \gamma^\mu q_3 \right)
+    lq3_1211:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_1 \gamma^\mu \tau^I q_1 \right)
+    lq3_1212:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_1 \gamma^\mu \tau^I q_2 \right)
+    lq3_1213:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_1 \gamma^\mu \tau^I q_3 \right)
+    lq3_1221:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_2 \gamma^\mu \tau^I q_1 \right)
+    lq3_1222:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_2 \gamma^\mu \tau^I q_2 \right)
+    lq3_1223:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_2 \gamma^\mu \tau^I q_3 \right)
+    lq3_1231:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_3 \gamma^\mu \tau^I q_1 \right)
+    lq3_1232:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_3 \gamma^\mu \tau^I q_2 \right)
+    lq3_1233:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_3 \gamma^\mu \tau^I q_3 \right)
+    ee_1112:
+      tex: \left( \bar e_1 \gamma_\mu e_1 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+    ee_1222:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
+    ee_1233:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
+    eu_1211:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
+    eu_1212:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_1 \gamma^\mu u_2 \right)
+    eu_1213:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_1 \gamma^\mu u_3 \right)
+    eu_1221:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_2 \gamma^\mu u_1 \right)
+    eu_1222:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_2 \gamma^\mu u_2 \right)
+    eu_1223:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_2 \gamma^\mu u_3 \right)
+    eu_1231:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_3 \gamma^\mu u_1 \right)
+    eu_1232:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_3 \gamma^\mu u_2 \right)
+    eu_1233:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
+    ed_1211:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
+    ed_1212:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_1 \gamma^\mu d_2 \right)
+    ed_1213:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_1 \gamma^\mu d_3 \right)
+    ed_1221:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_2 \gamma^\mu d_1 \right)
+    ed_1222:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_2 \gamma^\mu d_2 \right)
+    ed_1223:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_2 \gamma^\mu d_3 \right)
+    ed_1231:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_3 \gamma^\mu d_1 \right)
+    ed_1232:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_3 \gamma^\mu d_2 \right)
+    ed_1233:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
+    le_1112:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+    le_1211:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
+    le_1222:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
+    le_1233:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
+    le_1332:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_3 \gamma^\mu e_2 \right)
+    le_2212:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+    le_2331:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_3 \gamma^\mu e_1 \right)
+    le_3312:
+      tex: \left( \bar \ell_3 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+    lu_1211:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
+    lu_1212:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_1 \gamma^\mu u_2 \right)
+    lu_1213:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_1 \gamma^\mu u_3 \right)
+    lu_1221:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_2 \gamma^\mu u_1 \right)
+    lu_1222:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_2 \gamma^\mu u_2 \right)
+    lu_1223:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_2 \gamma^\mu u_3 \right)
+    lu_1231:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_3 \gamma^\mu u_1 \right)
+    lu_1232:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_3 \gamma^\mu u_2 \right)
+    lu_1233:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
+    ld_1211:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
+    ld_1212:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_1 \gamma^\mu d_2 \right)
+    ld_1213:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_1 \gamma^\mu d_3 \right)
+    ld_1221:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_2 \gamma^\mu d_1 \right)
+    ld_1222:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_2 \gamma^\mu d_2 \right)
+    ld_1223:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_2 \gamma^\mu d_3 \right)
+    ld_1231:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_3 \gamma^\mu d_1 \right)
+    ld_1232:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_3 \gamma^\mu d_2 \right)
+    ld_1233:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
+    qe_1112:
+      tex: \left( \bar q_1 \gamma_\mu q_1 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+    qe_1212:
+      tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+    qe_1221:
+      tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_2 \gamma^\mu e_1 \right)
+    qe_1312:
+      tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+    qe_1321:
+      tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_2 \gamma^\mu e_1 \right)
+    qe_2212:
+      tex: \left( \bar q_2 \gamma_\mu q_2 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+    qe_2312:
+      tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+    qe_2321:
+      tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_2 \gamma^\mu e_1 \right)
+    qe_3312:
+      tex: \left( \bar q_3 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+    ledq_1211:
+      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_1 q_1 \right)
+    ledq_1212:
+      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_1 q_2 \right)
+    ledq_1213:
+      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_1 q_3 \right)
+    ledq_1221:
+      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_2 q_1 \right)
+    ledq_1222:
+      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_2 q_2 \right)
+    ledq_1223:
+      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_2 q_3 \right)
+    ledq_1231:
+      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_3 q_1 \right)
+    ledq_1232:
+      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_3 q_2 \right)
+    ledq_1233:
+      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_3 q_3 \right)
+    ledq_2111:
+      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_1 q_1 \right)
+    ledq_2112:
+      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_1 q_2 \right)
+    ledq_2113:
+      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_1 q_3 \right)
+    ledq_2121:
+      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_2 q_1 \right)
+    ledq_2122:
+      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_2 q_2 \right)
+    ledq_2123:
+      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_2 q_3 \right)
+    ledq_2131:
+      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_3 q_1 \right)
+    ledq_2132:
+      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_3 q_2 \right)
+    ledq_2133:
+      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_3 q_3 \right)
+    lequ1_1211:
+      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_1 u_1 \right)
+    lequ1_1212:
+      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_1 u_2 \right)
+    lequ1_1213:
+      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_1 u_3 \right)
+    lequ1_1221:
+      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_2 u_1 \right)
+    lequ1_1222:
+      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_2 u_2 \right)
+    lequ1_1223:
+      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_2 u_3 \right)
+    lequ1_1231:
+      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_3 u_1 \right)
+    lequ1_1232:
+      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_3 u_2 \right)
+    lequ1_1233:
+      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_3 u_3 \right)
+    lequ1_2111:
+      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_1 u_1 \right)
+    lequ1_2112:
+      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_1 u_2 \right)
+    lequ1_2113:
+      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_1 u_3 \right)
+    lequ1_2121:
+      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_2 u_1 \right)
+    lequ1_2122:
+      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_2 u_2 \right)
+    lequ1_2123:
+      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_2 u_3 \right)
+    lequ1_2131:
+      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_3 u_1 \right)
+    lequ1_2132:
+      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_3 u_2 \right)
+    lequ1_2133:
+      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_3 u_3 \right)
+    lequ3_1211:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_1 \right)
+    lequ3_1212:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_2 \right)
+    lequ3_1213:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_3 \right)
+    lequ3_1221:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_1 \right)
+    lequ3_1222:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_2 \right)
+    lequ3_1223:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_3 \right)
+    lequ3_1231:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_1 \right)
+    lequ3_1232:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
+    lequ3_1233:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
+    lequ3_2111:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_1 \right)
+    lequ3_2112:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_2 \right)
+    lequ3_2113:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_3 \right)
+    lequ3_2121:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_1 \right)
+    lequ3_2122:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_2 \right)
+    lequ3_2123:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_3 \right)
+    lequ3_2131:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_1 \right)
+    lequ3_2132:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
+    lequ3_2133:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
+  taue:
+    ephi_13:
+      tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_1 e_3 \varphi \right)
+    ephi_31:
+      tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_3 e_1 \varphi \right)
+    eW_13:
+      tex: \left( \bar \ell_1 \sigma^{\mu \nu} e_3 \right) \tau^I \varphi W_{\mu \nu}^I
+    eW_31:
+      tex: \left( \bar \ell_3 \sigma^{\mu \nu} e_1 \right) \tau^I \varphi W_{\mu \nu}^I
+    eB_13:
+      tex: \left( \bar \ell_1 \sigma^{\mu \nu} e_3 \right) \varphi B_{\mu \nu}
+    eB_31:
+      tex: \left( \bar \ell_3 \sigma^{\mu \nu} e_1 \right) \varphi B_{\mu \nu}
+    deltagZeL_13:
+    deltagWlL_13:
+    deltagZeR_13:
+    ll_1113:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar \ell_1 \gamma^\mu \ell_3 \right)
+    ll_1223:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_2 \gamma^\mu \ell_3 \right)
+    ll_1322:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar \ell_2 \gamma^\mu \ell_2 \right)
+    ll_1333:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar \ell_3 \gamma^\mu \ell_3 \right)
+    lq1_1311:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_1 \gamma^\mu q_1 \right)
+    lq1_1312:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_1 \gamma^\mu q_2 \right)
+    lq1_1313:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_1 \gamma^\mu q_3 \right)
+    lq1_1321:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_2 \gamma^\mu q_1 \right)
+    lq1_1322:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_2 \gamma^\mu q_2 \right)
+    lq1_1323:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_2 \gamma^\mu q_3 \right)
+    lq1_1331:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_3 \gamma^\mu q_1 \right)
+    lq1_1332:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_3 \gamma^\mu q_2 \right)
+    lq1_1333:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_3 \gamma^\mu q_3 \right)
+    lq3_1311:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_1 \gamma^\mu \tau^I q_1 \right)
+    lq3_1312:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_1 \gamma^\mu \tau^I q_2 \right)
+    lq3_1313:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_1 \gamma^\mu \tau^I q_3 \right)
+    lq3_1321:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_2 \gamma^\mu \tau^I q_1 \right)
+    lq3_1322:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_2 \gamma^\mu \tau^I q_2 \right)
+    lq3_1323:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_2 \gamma^\mu \tau^I q_3 \right)
+    lq3_1331:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_3 \gamma^\mu \tau^I q_1 \right)
+    lq3_1332:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_3 \gamma^\mu \tau^I q_2 \right)
+    lq3_1333:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_3 \gamma^\mu \tau^I q_3 \right)
+    ee_1113:
+      tex: \left( \bar e_1 \gamma_\mu e_1 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+    ee_1223:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    ee_1333:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
+    eu_1311:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
+    eu_1312:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_1 \gamma^\mu u_2 \right)
+    eu_1313:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_1 \gamma^\mu u_3 \right)
+    eu_1321:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_2 \gamma^\mu u_1 \right)
+    eu_1322:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_2 \gamma^\mu u_2 \right)
+    eu_1323:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_2 \gamma^\mu u_3 \right)
+    eu_1331:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_3 \gamma^\mu u_1 \right)
+    eu_1332:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_3 \gamma^\mu u_2 \right)
+    eu_1333:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
+    ed_1311:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
+    ed_1312:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_1 \gamma^\mu d_2 \right)
+    ed_1313:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_1 \gamma^\mu d_3 \right)
+    ed_1321:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_2 \gamma^\mu d_1 \right)
+    ed_1322:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_2 \gamma^\mu d_2 \right)
+    ed_1323:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_2 \gamma^\mu d_3 \right)
+    ed_1331:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_3 \gamma^\mu d_1 \right)
+    ed_1332:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_3 \gamma^\mu d_2 \right)
+    ed_1333:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
+    le_1113:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+    le_1223:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    le_1311:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
+    le_1322:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
+    le_1333:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
+    le_2213:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+    le_2312:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+    le_3313:
+      tex: \left( \bar \ell_3 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+    lu_1311:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
+    lu_1312:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_1 \gamma^\mu u_2 \right)
+    lu_1313:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_1 \gamma^\mu u_3 \right)
+    lu_1321:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_2 \gamma^\mu u_1 \right)
+    lu_1322:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_2 \gamma^\mu u_2 \right)
+    lu_1323:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_2 \gamma^\mu u_3 \right)
+    lu_1331:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_3 \gamma^\mu u_1 \right)
+    lu_1332:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_3 \gamma^\mu u_2 \right)
+    lu_1333:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
+    ld_1311:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
+    ld_1312:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_1 \gamma^\mu d_2 \right)
+    ld_1313:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_1 \gamma^\mu d_3 \right)
+    ld_1321:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_2 \gamma^\mu d_1 \right)
+    ld_1322:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_2 \gamma^\mu d_2 \right)
+    ld_1323:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_2 \gamma^\mu d_3 \right)
+    ld_1331:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_3 \gamma^\mu d_1 \right)
+    ld_1332:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_3 \gamma^\mu d_2 \right)
+    ld_1333:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
+    qe_1113:
+      tex: \left( \bar q_1 \gamma_\mu q_1 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+    qe_1213:
+      tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+    qe_1231:
+      tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_3 \gamma^\mu e_1 \right)
+    qe_1313:
+      tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+    qe_1331:
+      tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_3 \gamma^\mu e_1 \right)
+    qe_2213:
+      tex: \left( \bar q_2 \gamma_\mu q_2 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+    qe_2313:
+      tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+    qe_2331:
+      tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_3 \gamma^\mu e_1 \right)
+    qe_3313:
+      tex: \left( \bar q_3 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+    ledq_1311:
+      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_1 q_1 \right)
+    ledq_1312:
+      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_1 q_2 \right)
+    ledq_1313:
+      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_1 q_3 \right)
+    ledq_1321:
+      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_2 q_1 \right)
+    ledq_1322:
+      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_2 q_2 \right)
+    ledq_1323:
+      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_2 q_3 \right)
+    ledq_1331:
+      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_3 q_1 \right)
+    ledq_1332:
+      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_3 q_2 \right)
+    ledq_1333:
+      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_3 q_3 \right)
+    ledq_3111:
+      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_1 q_1 \right)
+    ledq_3112:
+      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_1 q_2 \right)
+    ledq_3113:
+      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_1 q_3 \right)
+    ledq_3121:
+      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_2 q_1 \right)
+    ledq_3122:
+      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_2 q_2 \right)
+    ledq_3123:
+      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_2 q_3 \right)
+    ledq_3131:
+      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_3 q_1 \right)
+    ledq_3132:
+      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_3 q_2 \right)
+    ledq_3133:
+      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_3 q_3 \right)
+    lequ1_1311:
+      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_1 u_1 \right)
+    lequ1_1312:
+      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_1 u_2 \right)
+    lequ1_1313:
+      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_1 u_3 \right)
+    lequ1_1321:
+      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_2 u_1 \right)
+    lequ1_1322:
+      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_2 u_2 \right)
+    lequ1_1323:
+      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_2 u_3 \right)
+    lequ1_1331:
+      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_3 u_1 \right)
+    lequ1_1332:
+      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_3 u_2 \right)
+    lequ1_1333:
+      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_3 u_3 \right)
+    lequ1_3111:
+      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_1 u_1 \right)
+    lequ1_3112:
+      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_1 u_2 \right)
+    lequ1_3113:
+      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_1 u_3 \right)
+    lequ1_3121:
+      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_2 u_1 \right)
+    lequ1_3122:
+      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_2 u_2 \right)
+    lequ1_3123:
+      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_2 u_3 \right)
+    lequ1_3131:
+      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_3 u_1 \right)
+    lequ1_3132:
+      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_3 u_2 \right)
+    lequ1_3133:
+      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_3 u_3 \right)
+    lequ3_1311:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_1 \right)
+    lequ3_1312:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_2 \right)
+    lequ3_1313:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_3 \right)
+    lequ3_1321:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_1 \right)
+    lequ3_1322:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_2 \right)
+    lequ3_1323:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_3 \right)
+    lequ3_1331:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_1 \right)
+    lequ3_1332:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
+    lequ3_1333:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
+    lequ3_3111:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_1 \right)
+    lequ3_3112:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_2 \right)
+    lequ3_3113:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_3 \right)
+    lequ3_3121:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_1 \right)
+    lequ3_3122:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_2 \right)
+    lequ3_3123:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_3 \right)
+    lequ3_3131:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_1 \right)
+    lequ3_3132:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
+    lequ3_3133:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
+  mutau:
+    ephi_23:
+      tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_2 e_3 \varphi \right)
+    ephi_32:
+      tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_3 e_2 \varphi \right)
+    eW_23:
+      tex: \left( \bar \ell_2 \sigma^{\mu \nu} e_3 \right) \tau^I \varphi W_{\mu \nu}^I
+    eW_32:
+      tex: \left( \bar \ell_3 \sigma^{\mu \nu} e_2 \right) \tau^I \varphi W_{\mu \nu}^I
+    eB_23:
+      tex: \left( \bar \ell_2 \sigma^{\mu \nu} e_3 \right) \varphi B_{\mu \nu}
+    eB_32:
+      tex: \left( \bar \ell_3 \sigma^{\mu \nu} e_2 \right) \varphi B_{\mu \nu}
+    deltagZeL_23:
+    deltagWlL_23:
+    deltagZeR_23:
+    ll_1123:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar \ell_2 \gamma^\mu \ell_3 \right)
+    ll_1231:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_3 \gamma^\mu \ell_1 \right)
+    ll_2223:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar \ell_2 \gamma^\mu \ell_3 \right)
+    ll_2333:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar \ell_3 \gamma^\mu \ell_3 \right)
+    lq1_2311:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_1 \gamma^\mu q_1 \right)
+    lq1_2312:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_1 \gamma^\mu q_2 \right)
+    lq1_2313:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_1 \gamma^\mu q_3 \right)
+    lq1_2321:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_2 \gamma^\mu q_1 \right)
+    lq1_2322:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_2 \gamma^\mu q_2 \right)
+    lq1_2323:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_2 \gamma^\mu q_3 \right)
+    lq1_2331:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_3 \gamma^\mu q_1 \right)
+    lq1_2332:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_3 \gamma^\mu q_2 \right)
+    lq1_2333:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_3 \gamma^\mu q_3 \right)
+    lq3_2311:
+      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_1 \gamma^\mu \tau^I q_1 \right)
+    lq3_2312:
+      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_1 \gamma^\mu \tau^I q_2 \right)
+    lq3_2313:
+      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_1 \gamma^\mu \tau^I q_3 \right)
+    lq3_2321:
+      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_2 \gamma^\mu \tau^I q_1 \right)
+    lq3_2322:
+      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_2 \gamma^\mu \tau^I q_2 \right)
+    lq3_2323:
+      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_2 \gamma^\mu \tau^I q_3 \right)
+    lq3_2331:
+      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_3 \gamma^\mu \tau^I q_1 \right)
+    lq3_2332:
+      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_3 \gamma^\mu \tau^I q_2 \right)
+    lq3_2333:
+      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_3 \gamma^\mu \tau^I q_3 \right)
+    ee_1123:
+      tex: \left( \bar e_1 \gamma_\mu e_1 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    ee_2223:
+      tex: \left( \bar e_2 \gamma_\mu e_2 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    ee_2333:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
+    eu_2311:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
+    eu_2312:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_1 \gamma^\mu u_2 \right)
+    eu_2313:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_1 \gamma^\mu u_3 \right)
+    eu_2321:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_2 \gamma^\mu u_1 \right)
+    eu_2322:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_2 \gamma^\mu u_2 \right)
+    eu_2323:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_2 \gamma^\mu u_3 \right)
+    eu_2331:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_3 \gamma^\mu u_1 \right)
+    eu_2332:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_3 \gamma^\mu u_2 \right)
+    eu_2333:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
+    ed_2311:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
+    ed_2312:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_1 \gamma^\mu d_2 \right)
+    ed_2313:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_1 \gamma^\mu d_3 \right)
+    ed_2321:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_2 \gamma^\mu d_1 \right)
+    ed_2322:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_2 \gamma^\mu d_2 \right)
+    ed_2323:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_2 \gamma^\mu d_3 \right)
+    ed_2331:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_3 \gamma^\mu d_1 \right)
+    ed_2332:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_3 \gamma^\mu d_2 \right)
+    ed_2333:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
+    le_1123:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    le_1231:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_3 \gamma^\mu e_1 \right)
+    le_1321:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_1 \right)
+    le_2223:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    le_2311:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
+    le_2322:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
+    le_2333:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
+    le_3323:
+      tex: \left( \bar \ell_3 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    lu_2311:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
+    lu_2312:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_1 \gamma^\mu u_2 \right)
+    lu_2313:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_1 \gamma^\mu u_3 \right)
+    lu_2321:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_2 \gamma^\mu u_1 \right)
+    lu_2322:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_2 \gamma^\mu u_2 \right)
+    lu_2323:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_2 \gamma^\mu u_3 \right)
+    lu_2331:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_3 \gamma^\mu u_1 \right)
+    lu_2332:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_3 \gamma^\mu u_2 \right)
+    lu_2333:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
+    ld_2311:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
+    ld_2312:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_1 \gamma^\mu d_2 \right)
+    ld_2313:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_1 \gamma^\mu d_3 \right)
+    ld_2321:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_2 \gamma^\mu d_1 \right)
+    ld_2322:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_2 \gamma^\mu d_2 \right)
+    ld_2323:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_2 \gamma^\mu d_3 \right)
+    ld_2331:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_3 \gamma^\mu d_1 \right)
+    ld_2332:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_3 \gamma^\mu d_2 \right)
+    ld_2333:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
+    qe_1123:
+      tex: \left( \bar q_1 \gamma_\mu q_1 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    qe_1223:
+      tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    qe_1232:
+      tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_3 \gamma^\mu e_2 \right)
+    qe_1323:
+      tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    qe_1332:
+      tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_3 \gamma^\mu e_2 \right)
+    qe_2223:
+      tex: \left( \bar q_2 \gamma_\mu q_2 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    qe_2323:
+      tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    qe_2332:
+      tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_3 \gamma^\mu e_2 \right)
+    qe_3323:
+      tex: \left( \bar q_3 \gamma_\mu q_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    ledq_2311:
+      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_1 q_1 \right)
+    ledq_2312:
+      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_1 q_2 \right)
+    ledq_2313:
+      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_1 q_3 \right)
+    ledq_2321:
+      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_2 q_1 \right)
+    ledq_2322:
+      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_2 q_2 \right)
+    ledq_2323:
+      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_2 q_3 \right)
+    ledq_2331:
+      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_3 q_1 \right)
+    ledq_2332:
+      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_3 q_2 \right)
+    ledq_2333:
+      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_3 q_3 \right)
+    ledq_3211:
+      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_1 q_1 \right)
+    ledq_3212:
+      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_1 q_2 \right)
+    ledq_3213:
+      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_1 q_3 \right)
+    ledq_3221:
+      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_2 q_1 \right)
+    ledq_3222:
+      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_2 q_2 \right)
+    ledq_3223:
+      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_2 q_3 \right)
+    ledq_3231:
+      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_3 q_1 \right)
+    ledq_3232:
+      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_3 q_2 \right)
+    ledq_3233:
+      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_3 q_3 \right)
+    lequ1_2311:
+      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_1 u_1 \right)
+    lequ1_2312:
+      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_1 u_2 \right)
+    lequ1_2313:
+      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_1 u_3 \right)
+    lequ1_2321:
+      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_2 u_1 \right)
+    lequ1_2322:
+      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_2 u_2 \right)
+    lequ1_2323:
+      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_2 u_3 \right)
+    lequ1_2331:
+      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_3 u_1 \right)
+    lequ1_2332:
+      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_3 u_2 \right)
+    lequ1_2333:
+      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_3 u_3 \right)
+    lequ1_3211:
+      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_1 u_1 \right)
+    lequ1_3212:
+      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_1 u_2 \right)
+    lequ1_3213:
+      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_1 u_3 \right)
+    lequ1_3221:
+      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_2 u_1 \right)
+    lequ1_3222:
+      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_2 u_2 \right)
+    lequ1_3223:
+      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_2 u_3 \right)
+    lequ1_3231:
+      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_3 u_1 \right)
+    lequ1_3232:
+      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_3 u_2 \right)
+    lequ1_3233:
+      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_3 u_3 \right)
+    lequ3_2311:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_1 \right)
+    lequ3_2312:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_2 \right)
+    lequ3_2313:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_3 \right)
+    lequ3_2321:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_1 \right)
+    lequ3_2322:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_2 \right)
+    lequ3_2323:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_3 \right)
+    lequ3_2331:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_1 \right)
+    lequ3_2332:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
+    lequ3_2333:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
+    lequ3_3211:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_1 \right)
+    lequ3_3212:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_2 \right)
+    lequ3_3213:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_3 \right)
+    lequ3_3221:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_1 \right)
+    lequ3_3222:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_2 \right)
+    lequ3_3223:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_3 \right)
+    lequ3_3231:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_1 \right)
+    lequ3_3232:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
+    lequ3_3233:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
+  muemue:
+    ll_1212:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_1 \gamma^\mu \ell_2 \right)
+    ee_1212:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+    le_1212:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+  etauemu:
+    ll_1213:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_1 \gamma^\mu \ell_3 \right)
+    ee_1213:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+    le_1213:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+    le_1312:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+  muemutau:
+    ll_1232:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_3 \gamma^\mu \ell_2 \right)
+    ee_1232:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar e_3 \gamma^\mu e_2 \right)
+    le_1232:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_3 \gamma^\mu e_2 \right)
+    le_2321:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_1 \right)
+  tauetaue:
+    ll_1313:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar \ell_1 \gamma^\mu \ell_3 \right)
+    ee_1313:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+    le_1313:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+  tauetaumu:
+    ll_1323:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar \ell_2 \gamma^\mu \ell_3 \right)
+    ee_1323:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    le_1323:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    le_2313:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+  taumutaumu:
+    ll_2323:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar \ell_2 \gamma^\mu \ell_3 \right)
+    ee_2323:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    le_2323:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
   dB=dL=1:
     duql_1111:
       tex: \left( d_1 C u_1 \right) \left( q_1 C \ell_1 \right)

--- a/smeft.smeftsim-general.basis.json
+++ b/smeft.smeftsim-general.basis.json
@@ -5,7 +5,7 @@
     "description": "Basis used in the `SMEFTsim_general` UFO models, version 3.0.0 or later. Implements Warsaw basis with generic flavor indices for all fermions. $q,u,d$ are the left- and right-handed quark fields. $\\ell, e$ are left- and right-handed lepton fields. Quark fields are in the up-aligned basis. This basis definition corresponds to a fixed `LambdaSMEFT=1e+3` in the UFO models. Notation and conventions can vary compared to the Warsaw basis paper, see [arXiv:2012.11343](https://arxiv.org/abs/2012.11343) for all definitions."
   },
   "sectors": {
-    "dB=dL=0": {
+    "dB=de=dmu=dtau=0": {
       "cG": {
         "real": true,
         "tex": "f^{ABC} G_\\mu^{A \\nu} G_\\nu^{B \\rho} G_\\rho^{C \\mu} / \\text{TeV}^2"
@@ -78,30 +78,6 @@
         "real": true,
         "tex": "(\\bar \\ell_3 H e_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "ceHRe12": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 H e_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceHRe13": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 H e_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceHRe21": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 H e_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceHRe23": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 H e_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceHRe31": {
-        "real": true,
-        "tex": "(\\bar \\ell_3 H e_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceHRe32": {
-        "real": true,
-        "tex": "(\\bar \\ell_3 H e_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "ceHIm11": {
         "real": true,
         "tex": "i (\\bar \\ell_1 H e_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
@@ -113,30 +89,6 @@
       "ceHIm33": {
         "real": true,
         "tex": "i (\\bar \\ell_3 H e_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceHIm12": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 H e_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceHIm13": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 H e_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceHIm21": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 H e_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceHIm23": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 H e_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceHIm31": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3 H e_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceHIm32": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3 H e_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuHRe11": {
         "real": true,
@@ -294,30 +246,6 @@
         "real": true,
         "tex": "(\\bar \\ell_3 \\sigma^I H \\sigma^{\\mu\\nu} e_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "ceWRe12": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\sigma^I H \\sigma^{\\mu\\nu} e_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceWRe13": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\sigma^I H \\sigma^{\\mu\\nu} e_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceWRe21": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\sigma^I H \\sigma^{\\mu\\nu} e_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceWRe23": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\sigma^I H \\sigma^{\\mu\\nu} e_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceWRe31": {
-        "real": true,
-        "tex": "(\\bar \\ell_3 \\sigma^I H \\sigma^{\\mu\\nu} e_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceWRe32": {
-        "real": true,
-        "tex": "(\\bar \\ell_3 \\sigma^I H \\sigma^{\\mu\\nu} e_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "ceWIm11": {
         "real": true,
         "tex": "i (\\bar \\ell_1 \\sigma^I H \\sigma^{\\mu\\nu} e_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
@@ -329,30 +257,6 @@
       "ceWIm33": {
         "real": true,
         "tex": "i (\\bar \\ell_3 \\sigma^I H \\sigma^{\\mu\\nu} e_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceWIm12": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\sigma^I H \\sigma^{\\mu\\nu} e_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceWIm13": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\sigma^I H \\sigma^{\\mu\\nu} e_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceWIm21": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\sigma^I H \\sigma^{\\mu\\nu} e_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceWIm23": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\sigma^I H \\sigma^{\\mu\\nu} e_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceWIm31": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3 \\sigma^I H \\sigma^{\\mu\\nu} e_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceWIm32": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3 \\sigma^I H \\sigma^{\\mu\\nu} e_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceBRe11": {
         "real": true,
@@ -366,30 +270,6 @@
         "real": true,
         "tex": "(\\bar \\ell_3 H  \\sigma^{\\mu\\nu} e_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "ceBRe12": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 H  \\sigma^{\\mu\\nu} e_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceBRe13": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 H  \\sigma^{\\mu\\nu} e_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceBRe21": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 H  \\sigma^{\\mu\\nu} e_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceBRe23": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 H  \\sigma^{\\mu\\nu} e_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceBRe31": {
-        "real": true,
-        "tex": "(\\bar \\ell_3 H  \\sigma^{\\mu\\nu} e_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceBRe32": {
-        "real": true,
-        "tex": "(\\bar \\ell_3 H  \\sigma^{\\mu\\nu} e_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "ceBIm11": {
         "real": true,
         "tex": "i (\\bar \\ell_1 H  \\sigma^{\\mu\\nu} e_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
@@ -401,30 +281,6 @@
       "ceBIm33": {
         "real": true,
         "tex": "i (\\bar \\ell_3 H  \\sigma^{\\mu\\nu} e_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceBIm12": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 H  \\sigma^{\\mu\\nu} e_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceBIm13": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 H  \\sigma^{\\mu\\nu} e_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceBIm21": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 H  \\sigma^{\\mu\\nu} e_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceBIm23": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 H  \\sigma^{\\mu\\nu} e_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceBIm31": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3 H  \\sigma^{\\mu\\nu} e_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceBIm32": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3 H  \\sigma^{\\mu\\nu} e_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cuGRe11": {
         "real": true,
@@ -870,30 +726,6 @@
         "real": true,
         "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2"
       },
-      "cHl1Re12": {
-        "real": true,
-        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_1 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cHl1Re13": {
-        "real": true,
-        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cHl1Re23": {
-        "real": true,
-        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cHl1Im12": {
-        "real": true,
-        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_1 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cHl1Im13": {
-        "real": true,
-        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cHl1Im23": {
-        "real": true,
-        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cHl3Re11": {
         "real": true,
         "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_1 \\gamma^\\mu \\sigma^I \\ell_1) / \\text{TeV}^2"
@@ -905,30 +737,6 @@
       "cHl3Re33": {
         "real": true,
         "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_3 \\gamma^\\mu \\sigma^I \\ell_3) / \\text{TeV}^2"
-      },
-      "cHl3Re12": {
-        "real": true,
-        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_1 \\gamma^\\mu \\sigma^I \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cHl3Re13": {
-        "real": true,
-        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_1 \\gamma^\\mu \\sigma^I \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cHl3Re23": {
-        "real": true,
-        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_2 \\gamma^\\mu \\sigma^I \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cHl3Im12": {
-        "real": true,
-        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_1 \\gamma^\\mu \\sigma^I \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cHl3Im13": {
-        "real": true,
-        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_1 \\gamma^\\mu \\sigma^I \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cHl3Im23": {
-        "real": true,
-        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_2 \\gamma^\\mu \\sigma^I \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cHq1Re11": {
         "real": true,
@@ -1013,30 +821,6 @@
       "cHeRe33": {
         "real": true,
         "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2"
-      },
-      "cHeRe12": {
-        "real": true,
-        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cHeRe13": {
-        "real": true,
-        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cHeRe23": {
-        "real": true,
-        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cHeIm12": {
-        "real": true,
-        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cHeIm13": {
-        "real": true,
-        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cHeIm23": {
-        "real": true,
-        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cHuRe11": {
         "real": true,
@@ -1218,150 +1002,6 @@
         "real": true,
         "tex": "2 (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2"
       },
-      "cllRe1112": {
-        "real": true,
-        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_1 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllRe1113": {
-        "real": true,
-        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllRe1123": {
-        "real": true,
-        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllRe1212": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_1 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllRe1213": {
-        "real": true,
-        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllRe1222": {
-        "real": true,
-        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllRe1232": {
-        "real": true,
-        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllRe1233": {
-        "real": true,
-        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllRe1313": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllRe1322": {
-        "real": true,
-        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllRe1323": {
-        "real": true,
-        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllRe1333": {
-        "real": true,
-        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllRe2223": {
-        "real": true,
-        "tex": "2 (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllRe2323": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllRe3323": {
-        "real": true,
-        "tex": "2 (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllRe1231": {
-        "real": true,
-        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllRe1223": {
-        "real": true,
-        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllRe1332": {
-        "real": true,
-        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllIm1112": {
-        "real": true,
-        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_1 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllIm1113": {
-        "real": true,
-        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllIm1123": {
-        "real": true,
-        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllIm1212": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_1 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllIm1213": {
-        "real": true,
-        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllIm1222": {
-        "real": true,
-        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllIm1232": {
-        "real": true,
-        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllIm1233": {
-        "real": true,
-        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllIm1313": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllIm1322": {
-        "real": true,
-        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllIm1323": {
-        "real": true,
-        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllIm1333": {
-        "real": true,
-        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllIm2223": {
-        "real": true,
-        "tex": "2 i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllIm2323": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllIm3323": {
-        "real": true,
-        "tex": "2 i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllIm1231": {
-        "real": true,
-        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllIm1223": {
-        "real": true,
-        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cllIm1332": {
-        "real": true,
-        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "clq1Re1111": {
         "real": true,
         "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2"
@@ -1385,18 +1025,6 @@
       "clq1Re3333": {
         "real": true,
         "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2"
-      },
-      "clq1Re1221": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Re1331": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Re2332": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "clq1Re2211": {
         "real": true,
@@ -1422,81 +1050,13 @@
         "real": true,
         "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clq1Re1212": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Re1213": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Re1222": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Re1232": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Re1233": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Re1313": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Re1322": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Re1323": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Re1333": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "clq1Re2223": {
         "real": true,
         "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clq1Re2323": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "clq1Re3323": {
         "real": true,
         "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Re1231": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Re1223": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Re1332": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Re1211": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Re1311": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Re1312": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Re1321": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "clq1Re2212": {
         "real": true,
@@ -1506,34 +1066,6 @@
         "real": true,
         "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clq1Re2311": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Re2312": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Re2313": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Re2321": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Re2322": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Re2331": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Re2333": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "clq1Re3312": {
         "real": true,
         "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
@@ -1541,18 +1073,6 @@
       "clq1Re3313": {
         "real": true,
         "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Im1221": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Im1331": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Im2332": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "clq1Im1112": {
         "real": true,
@@ -1566,81 +1086,13 @@
         "real": true,
         "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clq1Im1212": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Im1213": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Im1222": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Im1232": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Im1233": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Im1313": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Im1322": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Im1323": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Im1333": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "clq1Im2223": {
         "real": true,
         "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clq1Im2323": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "clq1Im3323": {
         "real": true,
         "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Im1231": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Im1223": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Im1332": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Im1211": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Im1311": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Im1312": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Im1321": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "clq1Im2212": {
         "real": true,
@@ -1649,34 +1101,6 @@
       "clq1Im2213": {
         "real": true,
         "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Im2311": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Im2312": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Im2313": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Im2321": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Im2322": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Im2331": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq1Im2333": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "clq1Im3312": {
         "real": true,
@@ -1710,18 +1134,6 @@
         "real": true,
         "tex": "(\\bar \\ell_3 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2"
       },
-      "clq3Re1221": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Re1331": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Re2332": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "clq3Re2211": {
         "real": true,
         "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2"
@@ -1746,81 +1158,13 @@
         "real": true,
         "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_1)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clq3Re1212": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Re1213": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Re1222": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Re1232": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Re1233": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Re1313": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Re1322": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Re1323": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Re1333": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "clq3Re2223": {
         "real": true,
         "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clq3Re2323": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "clq3Re3323": {
         "real": true,
         "tex": "(\\bar \\ell_3 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Re1231": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Re1223": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Re1332": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Re1211": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Re1311": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Re1312": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Re1321": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "clq3Re2212": {
         "real": true,
@@ -1830,34 +1174,6 @@
         "real": true,
         "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clq3Re2311": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Re2312": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Re2313": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Re2321": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Re2322": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Re2331": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Re2333": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "clq3Re3312": {
         "real": true,
         "tex": "(\\bar \\ell_3 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
@@ -1865,18 +1181,6 @@
       "clq3Re3313": {
         "real": true,
         "tex": "(\\bar \\ell_3 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Im1221": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Im1331": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Im2332": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "clq3Im1112": {
         "real": true,
@@ -1890,81 +1194,13 @@
         "real": true,
         "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_1)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clq3Im1212": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Im1213": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Im1222": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Im1232": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Im1233": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Im1313": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Im1322": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Im1323": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Im1333": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "clq3Im2223": {
         "real": true,
         "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clq3Im2323": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "clq3Im3323": {
         "real": true,
         "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Im1231": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Im1223": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Im1332": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Im1211": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Im1311": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Im1312": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Im1321": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "clq3Im2212": {
         "real": true,
@@ -1973,34 +1209,6 @@
       "clq3Im2213": {
         "real": true,
         "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Im2311": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Im2312": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Im2313": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Im2321": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Im2322": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Im2331": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clq3Im2333": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "clq3Im3312": {
         "real": true,
@@ -2394,126 +1602,6 @@
         "real": true,
         "tex": "4 (\\bar e_2 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2"
       },
-      "ceeRe1112": {
-        "real": true,
-        "tex": "2 (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeRe1113": {
-        "real": true,
-        "tex": "2 (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeRe1123": {
-        "real": true,
-        "tex": "4 (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeRe1212": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeRe1213": {
-        "real": true,
-        "tex": "2 (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeRe1222": {
-        "real": true,
-        "tex": "2 (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeRe1232": {
-        "real": true,
-        "tex": "2 (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeRe1233": {
-        "real": true,
-        "tex": "4 (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeRe1313": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeRe1322": {
-        "real": true,
-        "tex": "4 (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeRe1323": {
-        "real": true,
-        "tex": "2 (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeRe1333": {
-        "real": true,
-        "tex": "2 (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeRe2223": {
-        "real": true,
-        "tex": "2 (\\bar e_2 \\gamma_\\mu e_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeRe2323": {
-        "real": true,
-        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeRe3323": {
-        "real": true,
-        "tex": "2 (\\bar e_3 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeIm1112": {
-        "real": true,
-        "tex": "2 i (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeIm1113": {
-        "real": true,
-        "tex": "2 i (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeIm1123": {
-        "real": true,
-        "tex": "4 i (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeIm1212": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeIm1213": {
-        "real": true,
-        "tex": "2 i (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeIm1222": {
-        "real": true,
-        "tex": "2 i (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeIm1232": {
-        "real": true,
-        "tex": "2 i (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeIm1233": {
-        "real": true,
-        "tex": "4 i (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeIm1313": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeIm1322": {
-        "real": true,
-        "tex": "4 i (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeIm1323": {
-        "real": true,
-        "tex": "2 i (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeIm1333": {
-        "real": true,
-        "tex": "2 i (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeIm2223": {
-        "real": true,
-        "tex": "2 i (\\bar e_2 \\gamma_\\mu e_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeIm2323": {
-        "real": true,
-        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceeIm3323": {
-        "real": true,
-        "tex": "2 i (\\bar e_3 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cuuRe1111": {
         "real": true,
         "tex": "(\\bar u_1 \\gamma_\\mu u_1)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2"
@@ -2898,18 +1986,6 @@
         "real": true,
         "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
       },
-      "ceuRe1221": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuRe1331": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuRe2332": {
-        "real": true,
-        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "ceuRe2211": {
         "real": true,
         "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2"
@@ -2934,81 +2010,13 @@
         "real": true,
         "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "ceuRe1212": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuRe1213": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuRe1222": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuRe1232": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuRe1233": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuRe1313": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuRe1322": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuRe1323": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuRe1333": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "ceuRe2223": {
         "real": true,
         "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "ceuRe2323": {
-        "real": true,
-        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "ceuRe3323": {
         "real": true,
         "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuRe1231": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuRe1223": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuRe1332": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuRe1211": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuRe1311": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuRe1312": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuRe1321": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceuRe2212": {
         "real": true,
@@ -3018,34 +2026,6 @@
         "real": true,
         "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "ceuRe2311": {
-        "real": true,
-        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuRe2312": {
-        "real": true,
-        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuRe2313": {
-        "real": true,
-        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuRe2321": {
-        "real": true,
-        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuRe2322": {
-        "real": true,
-        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuRe2331": {
-        "real": true,
-        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuRe2333": {
-        "real": true,
-        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "ceuRe3312": {
         "real": true,
         "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
@@ -3053,18 +2033,6 @@
       "ceuRe3313": {
         "real": true,
         "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuIm1221": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuIm1331": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuIm2332": {
-        "real": true,
-        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceuIm1112": {
         "real": true,
@@ -3078,81 +2046,13 @@
         "real": true,
         "tex": "i (\\bar e_1 \\gamma_\\mu e_1)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "ceuIm1212": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuIm1213": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuIm1222": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuIm1232": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuIm1233": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuIm1313": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuIm1322": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuIm1323": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuIm1333": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "ceuIm2223": {
         "real": true,
         "tex": "i (\\bar e_2 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "ceuIm2323": {
-        "real": true,
-        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "ceuIm3323": {
         "real": true,
         "tex": "i (\\bar e_3 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuIm1231": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuIm1223": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuIm1332": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuIm1211": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuIm1311": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuIm1312": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuIm1321": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceuIm2212": {
         "real": true,
@@ -3161,34 +2061,6 @@
       "ceuIm2213": {
         "real": true,
         "tex": "i (\\bar e_2 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuIm2311": {
-        "real": true,
-        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuIm2312": {
-        "real": true,
-        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuIm2313": {
-        "real": true,
-        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuIm2321": {
-        "real": true,
-        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuIm2322": {
-        "real": true,
-        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuIm2331": {
-        "real": true,
-        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "ceuIm2333": {
-        "real": true,
-        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "ceuIm3312": {
         "real": true,
@@ -3222,18 +2094,6 @@
         "real": true,
         "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
       },
-      "cedRe1221": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedRe1331": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedRe2332": {
-        "real": true,
-        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cedRe2211": {
         "real": true,
         "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
@@ -3258,81 +2118,13 @@
         "real": true,
         "tex": "(\\bar e_1 \\gamma_\\mu e_1)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "cedRe1212": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedRe1213": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedRe1222": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedRe1232": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedRe1233": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedRe1313": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedRe1322": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedRe1323": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedRe1333": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cedRe2223": {
         "real": true,
         "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "cedRe2323": {
-        "real": true,
-        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cedRe3323": {
         "real": true,
         "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedRe1231": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedRe1223": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedRe1332": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedRe1211": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedRe1311": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedRe1312": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedRe1321": {
-        "real": true,
-        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cedRe2212": {
         "real": true,
@@ -3342,34 +2134,6 @@
         "real": true,
         "tex": "(\\bar e_2 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "cedRe2311": {
-        "real": true,
-        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedRe2312": {
-        "real": true,
-        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedRe2313": {
-        "real": true,
-        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedRe2321": {
-        "real": true,
-        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedRe2322": {
-        "real": true,
-        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedRe2331": {
-        "real": true,
-        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedRe2333": {
-        "real": true,
-        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cedRe3312": {
         "real": true,
         "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
@@ -3377,18 +2141,6 @@
       "cedRe3313": {
         "real": true,
         "tex": "(\\bar e_3 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedIm1221": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedIm1331": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedIm2332": {
-        "real": true,
-        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cedIm1112": {
         "real": true,
@@ -3402,81 +2154,13 @@
         "real": true,
         "tex": "i (\\bar e_1 \\gamma_\\mu e_1)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "cedIm1212": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedIm1213": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedIm1222": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedIm1232": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedIm1233": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedIm1313": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedIm1322": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedIm1323": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedIm1333": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cedIm2223": {
         "real": true,
         "tex": "i (\\bar e_2 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "cedIm2323": {
-        "real": true,
-        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cedIm3323": {
         "real": true,
         "tex": "i (\\bar e_3 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedIm1231": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedIm1223": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedIm1332": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedIm1211": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedIm1311": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedIm1312": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedIm1321": {
-        "real": true,
-        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cedIm2212": {
         "real": true,
@@ -3485,34 +2169,6 @@
       "cedIm2213": {
         "real": true,
         "tex": "i (\\bar e_2 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedIm2311": {
-        "real": true,
-        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedIm2312": {
-        "real": true,
-        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedIm2313": {
-        "real": true,
-        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedIm2321": {
-        "real": true,
-        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedIm2322": {
-        "real": true,
-        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedIm2331": {
-        "real": true,
-        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cedIm2333": {
-        "real": true,
-        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cedIm3312": {
         "real": true,
@@ -4218,138 +2874,6 @@
         "real": true,
         "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2"
       },
-      "cleRe1112": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe1113": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe1123": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe1212": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe1213": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe1222": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe1232": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe1233": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe1313": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe1322": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe1323": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe1333": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe2223": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe2323": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe3323": {
-        "real": true,
-        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe1231": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe1223": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe1332": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe1211": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe1311": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe1312": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe1321": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe2212": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe2213": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe2311": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe2312": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe2313": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe2321": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe2322": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe2331": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe2333": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe3312": {
-        "real": true,
-        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleRe3313": {
-        "real": true,
-        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cleIm1221": {
         "real": true,
         "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
@@ -4361,138 +2885,6 @@
       "cleIm2332": {
         "real": true,
         "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm1112": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm1113": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm1123": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm1212": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm1213": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm1222": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm1232": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm1233": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm1313": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm1322": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm1323": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm1333": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm2223": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm2323": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm3323": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm1231": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm1223": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm1332": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm1211": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm1311": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm1312": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm1321": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm2212": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm2213": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm2311": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm2312": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm2313": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm2321": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm2322": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm2331": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm2333": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm3312": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cleIm3313": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cluRe1111": {
         "real": true,
@@ -4518,18 +2910,6 @@
         "real": true,
         "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2"
       },
-      "cluRe1221": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluRe1331": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluRe2332": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cluRe2211": {
         "real": true,
         "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2"
@@ -4554,81 +2934,13 @@
         "real": true,
         "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "cluRe1212": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluRe1213": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluRe1222": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluRe1232": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluRe1233": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluRe1313": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluRe1322": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluRe1323": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluRe1333": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cluRe2223": {
         "real": true,
         "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "cluRe2323": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cluRe3323": {
         "real": true,
         "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluRe1231": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluRe1223": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluRe1332": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluRe1211": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluRe1311": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluRe1312": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluRe1321": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cluRe2212": {
         "real": true,
@@ -4638,34 +2950,6 @@
         "real": true,
         "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "cluRe2311": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluRe2312": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluRe2313": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluRe2321": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluRe2322": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluRe2331": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluRe2333": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cluRe3312": {
         "real": true,
         "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
@@ -4673,18 +2957,6 @@
       "cluRe3313": {
         "real": true,
         "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluIm1221": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluIm1331": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluIm2332": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cluIm1112": {
         "real": true,
@@ -4698,81 +2970,13 @@
         "real": true,
         "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "cluIm1212": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluIm1213": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluIm1222": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluIm1232": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluIm1233": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluIm1313": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluIm1322": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluIm1323": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluIm1333": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cluIm2223": {
         "real": true,
         "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "cluIm2323": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cluIm3323": {
         "real": true,
         "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluIm1231": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluIm1223": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluIm1332": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluIm1211": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluIm1311": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluIm1312": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluIm1321": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cluIm2212": {
         "real": true,
@@ -4781,34 +2985,6 @@
       "cluIm2213": {
         "real": true,
         "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluIm2311": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluIm2312": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluIm2313": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluIm2321": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluIm2322": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluIm2331": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cluIm2333": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cluIm3312": {
         "real": true,
@@ -4842,18 +3018,6 @@
         "real": true,
         "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2"
       },
-      "cldRe1221": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldRe1331": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldRe2332": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cldRe2211": {
         "real": true,
         "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2"
@@ -4878,81 +3042,13 @@
         "real": true,
         "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "cldRe1212": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldRe1213": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldRe1222": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldRe1232": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldRe1233": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldRe1313": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldRe1322": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldRe1323": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldRe1333": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cldRe2223": {
         "real": true,
         "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "cldRe2323": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cldRe3323": {
         "real": true,
         "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldRe1231": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldRe1223": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldRe1332": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldRe1211": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldRe1311": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldRe1312": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldRe1321": {
-        "real": true,
-        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cldRe2212": {
         "real": true,
@@ -4962,34 +3058,6 @@
         "real": true,
         "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "cldRe2311": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldRe2312": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldRe2313": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldRe2321": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldRe2322": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldRe2331": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldRe2333": {
-        "real": true,
-        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cldRe3312": {
         "real": true,
         "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
@@ -4997,18 +3065,6 @@
       "cldRe3313": {
         "real": true,
         "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldIm1221": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldIm1331": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldIm2332": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cldIm1112": {
         "real": true,
@@ -5022,81 +3078,13 @@
         "real": true,
         "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "cldIm1212": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldIm1213": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldIm1222": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldIm1232": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldIm1233": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldIm1313": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldIm1322": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldIm1323": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldIm1333": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cldIm2223": {
         "real": true,
         "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "cldIm2323": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cldIm3323": {
         "real": true,
         "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldIm1231": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldIm1223": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldIm1332": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldIm1211": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldIm1311": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldIm1312": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldIm1321": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cldIm2212": {
         "real": true,
@@ -5105,34 +3093,6 @@
       "cldIm2213": {
         "real": true,
         "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldIm2311": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldIm2312": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldIm2313": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldIm2321": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldIm2322": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldIm2331": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cldIm2333": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cldIm3312": {
         "real": true,
@@ -5166,18 +3126,6 @@
         "real": true,
         "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2"
       },
-      "cqeRe1221": {
-        "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeRe1331": {
-        "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeRe2332": {
-        "real": true,
-        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cqeRe2211": {
         "real": true,
         "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2"
@@ -5190,77 +3138,21 @@
         "real": true,
         "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2"
       },
-      "cqeRe1112": {
-        "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeRe1113": {
-        "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeRe1123": {
-        "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeRe1212": {
-        "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeRe1213": {
-        "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cqeRe1222": {
         "real": true,
         "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeRe1232": {
-        "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqeRe1233": {
         "real": true,
         "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "cqeRe1313": {
-        "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cqeRe1322": {
         "real": true,
         "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "cqeRe1323": {
-        "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cqeRe1333": {
         "real": true,
         "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeRe2223": {
-        "real": true,
-        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeRe2323": {
-        "real": true,
-        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeRe3323": {
-        "real": true,
-        "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeRe1231": {
-        "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeRe1223": {
-        "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeRe1332": {
-        "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqeRe1211": {
         "real": true,
@@ -5270,141 +3162,33 @@
         "real": true,
         "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "cqeRe1312": {
-        "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeRe1321": {
-        "real": true,
-        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeRe2212": {
-        "real": true,
-        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeRe2213": {
-        "real": true,
-        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cqeRe2311": {
         "real": true,
         "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeRe2312": {
-        "real": true,
-        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeRe2313": {
-        "real": true,
-        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeRe2321": {
-        "real": true,
-        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqeRe2322": {
         "real": true,
         "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "cqeRe2331": {
-        "real": true,
-        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cqeRe2333": {
         "real": true,
         "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeRe3312": {
-        "real": true,
-        "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeRe3313": {
-        "real": true,
-        "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeIm1221": {
-        "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeIm1331": {
-        "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeIm2332": {
-        "real": true,
-        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeIm1112": {
-        "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeIm1113": {
-        "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeIm1123": {
-        "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeIm1212": {
-        "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeIm1213": {
-        "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqeIm1222": {
         "real": true,
         "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "cqeIm1232": {
-        "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cqeIm1233": {
         "real": true,
         "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeIm1313": {
-        "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqeIm1322": {
         "real": true,
         "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "cqeIm1323": {
-        "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cqeIm1333": {
         "real": true,
         "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeIm2223": {
-        "real": true,
-        "tex": "i (\\bar q_2 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeIm2323": {
-        "real": true,
-        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeIm3323": {
-        "real": true,
-        "tex": "i (\\bar q_3 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeIm1231": {
-        "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeIm1223": {
-        "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeIm1332": {
-        "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqeIm1211": {
         "real": true,
@@ -5414,57 +3198,17 @@
         "real": true,
         "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "cqeIm1312": {
-        "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeIm1321": {
-        "real": true,
-        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeIm2212": {
-        "real": true,
-        "tex": "i (\\bar q_2 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeIm2213": {
-        "real": true,
-        "tex": "i (\\bar q_2 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cqeIm2311": {
         "real": true,
         "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeIm2312": {
-        "real": true,
-        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeIm2313": {
-        "real": true,
-        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeIm2321": {
-        "real": true,
-        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqeIm2322": {
         "real": true,
         "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "cqeIm2331": {
-        "real": true,
-        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cqeIm2333": {
         "real": true,
         "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeIm3312": {
-        "real": true,
-        "tex": "i (\\bar q_3 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cqeIm3313": {
-        "real": true,
-        "tex": "i (\\bar q_3 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cqu1Re1111": {
         "real": true,
@@ -6798,114 +4542,6 @@
         "real": true,
         "tex": "(\\bar \\ell_1^I e_1)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "cledqRe1211": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_2)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe1212": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_2)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe1213": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_2)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe1221": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_2)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe1222": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_2)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe1223": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_2)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe1231": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_2)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe1232": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_2)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe1233": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_2)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe1311": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_3)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe1312": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_3)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe1313": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_3)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe1321": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_3)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe1322": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_3)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe1323": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_3)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe1331": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_3)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe1332": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_3)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe1333": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_3)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe2111": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_1)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe2112": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_1)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe2113": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_1)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe2121": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_1)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe2122": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_1)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe2123": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_1)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe2131": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_1)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe2132": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_1)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe2133": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_1)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cledqRe2211": {
         "real": true,
         "tex": "(\\bar \\ell_2^I e_2)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
@@ -6941,114 +4577,6 @@
       "cledqRe2233": {
         "real": true,
         "tex": "(\\bar \\ell_2^I e_2)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe2311": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_3)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe2312": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_3)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe2313": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_3)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe2321": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_3)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe2322": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_3)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe2323": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_3)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe2331": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_3)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe2332": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_3)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe2333": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_3)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe3111": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_1)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe3112": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_1)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe3113": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_1)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe3121": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_1)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe3122": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_1)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe3123": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_1)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe3131": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_1)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe3132": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_1)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe3133": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_1)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe3211": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_2)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe3212": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_2)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe3213": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_2)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe3221": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_2)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe3222": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_2)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe3223": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_2)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe3231": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_2)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe3232": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_2)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqRe3233": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_2)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cledqRe3311": {
         "real": true,
@@ -7122,114 +4650,6 @@
         "real": true,
         "tex": "i (\\bar \\ell_1^I e_1)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "cledqIm1211": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm1212": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm1213": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm1221": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm1222": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm1223": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm1231": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm1232": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm1233": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm1311": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm1312": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm1313": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm1321": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm1322": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm1323": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm1331": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm1332": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm1333": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm2111": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm2112": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm2113": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm2121": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm2122": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm2123": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm2131": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm2132": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm2133": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "cledqIm2211": {
         "real": true,
         "tex": "i (\\bar \\ell_2^I e_2)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
@@ -7265,114 +4685,6 @@
       "cledqIm2233": {
         "real": true,
         "tex": "i (\\bar \\ell_2^I e_2)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm2311": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm2312": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm2313": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm2321": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm2322": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm2323": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm2331": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm2332": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm2333": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm3111": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm3112": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm3113": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm3121": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm3122": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm3123": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm3131": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm3132": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm3133": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm3211": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm3212": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm3213": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm3221": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm3222": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm3223": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm3231": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm3232": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "cledqIm3233": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
       },
       "cledqIm3311": {
         "real": true,
@@ -8742,114 +6054,6 @@
         "real": true,
         "tex": "(\\bar \\ell_1^I e_1)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ1Re1211": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re1212": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re1213": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re1221": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re1222": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re1223": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re1231": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re1232": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re1233": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re1311": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re1312": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re1313": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re1321": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re1322": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re1323": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re1331": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re1332": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re1333": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re2111": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re2112": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re2113": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re2121": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re2122": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re2123": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re2131": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re2132": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re2133": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "clequ1Re2211": {
         "real": true,
         "tex": "(\\bar \\ell_2^I e_2)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
@@ -8885,114 +6089,6 @@
       "clequ1Re2233": {
         "real": true,
         "tex": "(\\bar \\ell_2^I e_2)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re2311": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re2312": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re2313": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re2321": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re2322": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re2323": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re2331": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re2332": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re2333": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re3111": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re3112": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re3113": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re3121": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re3122": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re3123": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re3131": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re3132": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re3133": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re3211": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re3212": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re3213": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re3221": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re3222": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re3223": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re3231": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re3232": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Re3233": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
       },
       "clequ1Re3311": {
         "real": true,
@@ -9066,114 +6162,6 @@
         "real": true,
         "tex": "i (\\bar \\ell_1^I e_1)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ1Im1211": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im1212": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im1213": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im1221": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im1222": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im1223": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im1231": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im1232": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im1233": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im1311": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im1312": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im1313": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im1321": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im1322": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im1323": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im1331": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im1332": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im1333": {
-        "real": true,
-        "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im2111": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im2112": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im2113": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im2121": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im2122": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im2123": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im2131": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im2132": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im2133": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "clequ1Im2211": {
         "real": true,
         "tex": "i (\\bar \\ell_2^I e_2)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
@@ -9209,114 +6197,6 @@
       "clequ1Im2233": {
         "real": true,
         "tex": "i (\\bar \\ell_2^I e_2)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im2311": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im2312": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im2313": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im2321": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im2322": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im2323": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im2331": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im2332": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im2333": {
-        "real": true,
-        "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im3111": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im3112": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im3113": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im3121": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im3122": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im3123": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im3131": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im3132": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im3133": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im3211": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im3212": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im3213": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im3221": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im3222": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im3223": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im3231": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im3232": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ1Im3233": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
       },
       "clequ1Im3311": {
         "real": true,
@@ -9390,114 +6270,6 @@
         "real": true,
         "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ3Re1211": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re1212": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re1213": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re1221": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re1222": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re1223": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re1231": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re1232": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re1233": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re1311": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re1312": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re1313": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re1321": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re1322": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re1323": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re1331": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re1332": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re1333": {
-        "real": true,
-        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re2111": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re2112": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re2113": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re2121": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re2122": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re2123": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re2131": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re2132": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re2133": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "clequ3Re2211": {
         "real": true,
         "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
@@ -9533,114 +6305,6 @@
       "clequ3Re2233": {
         "real": true,
         "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re2311": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re2312": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re2313": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re2321": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re2322": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re2323": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re2331": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re2332": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re2333": {
-        "real": true,
-        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re3111": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re3112": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re3113": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re3121": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re3122": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re3123": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re3131": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re3132": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re3133": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re3211": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re3212": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re3213": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re3221": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re3222": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re3223": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re3231": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re3232": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Re3233": {
-        "real": true,
-        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
       },
       "clequ3Re3311": {
         "real": true,
@@ -9714,6 +6378,1136 @@
         "real": true,
         "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
       },
+      "clequ3Im2211": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2221": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2222": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2231": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2232": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2233": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im3333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      }
+    },
+    "mue": {
+      "ceHRe12": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 H e_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceHRe21": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 H e_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceHIm12": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 H e_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceHIm21": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 H e_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceWRe12": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\sigma^I H \\sigma^{\\mu\\nu} e_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceWRe21": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\sigma^I H \\sigma^{\\mu\\nu} e_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceWIm12": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\sigma^I H \\sigma^{\\mu\\nu} e_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceWIm21": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\sigma^I H \\sigma^{\\mu\\nu} e_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceBRe12": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 H  \\sigma^{\\mu\\nu} e_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceBRe21": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 H  \\sigma^{\\mu\\nu} e_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceBIm12": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 H  \\sigma^{\\mu\\nu} e_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceBIm21": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 H  \\sigma^{\\mu\\nu} e_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHl1Re12": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_1 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHl1Im12": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_1 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHl3Re12": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_1 \\gamma^\\mu \\sigma^I \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHl3Im12": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_1 \\gamma^\\mu \\sigma^I \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHeRe12": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHeIm12": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe1112": {
+        "real": true,
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_1 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe1222": {
+        "real": true,
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe1233": {
+        "real": true,
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe1332": {
+        "real": true,
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm1112": {
+        "real": true,
+        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_1 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm1222": {
+        "real": true,
+        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm1233": {
+        "real": true,
+        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm1332": {
+        "real": true,
+        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1221": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1212": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1213": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1222": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1232": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1233": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1231": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1223": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1211": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1221": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1222": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1232": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1233": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1231": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1211": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1221": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1212": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1213": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1222": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1232": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1233": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1231": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1223": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1211": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1221": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1222": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1232": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1233": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1231": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1211": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_2)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeRe1112": {
+        "real": true,
+        "tex": "2 (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeRe1222": {
+        "real": true,
+        "tex": "2 (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeRe1233": {
+        "real": true,
+        "tex": "4 (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeIm1112": {
+        "real": true,
+        "tex": "2 i (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeIm1222": {
+        "real": true,
+        "tex": "2 i (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeIm1233": {
+        "real": true,
+        "tex": "4 i (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1221": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1212": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1213": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1222": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1232": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1233": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1231": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1223": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1211": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1221": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1212": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1213": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1222": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1232": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1233": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1231": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1223": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1211": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1221": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1212": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1213": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1222": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1232": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1233": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1231": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1223": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1211": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1221": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1212": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1213": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1222": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1232": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1233": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1231": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1223": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1211": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1112": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1222": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1233": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1332": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1211": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe2212": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe2331": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe3312": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1112": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1222": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1233": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1211": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm2212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm2331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm3312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1221": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1212": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1213": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1222": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1232": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1233": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1231": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1223": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1211": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1221": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1222": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1232": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1233": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1231": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1211": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1221": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1212": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1213": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1222": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1232": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1233": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1231": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1223": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1211": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1221": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1222": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1232": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1233": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1231": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1211": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1221": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1112": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1212": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1312": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1321": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe2212": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe2312": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe2321": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe3312": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1221": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1112": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1212": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1312": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1321": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm2212": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm2312": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm2321": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm3312": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1211": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1212": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1213": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1221": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1222": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1223": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1231": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1232": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1233": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2111": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2112": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2113": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2121": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2122": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2123": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2131": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2132": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2133": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1211": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1221": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1222": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1231": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1232": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1233": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2111": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2112": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2113": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2121": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2122": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2123": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2131": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2132": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2133": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1211": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1212": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1213": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1221": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1222": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1223": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1231": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1232": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1233": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_2)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2111": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2112": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2113": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2121": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2122": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2123": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2131": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2132": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2133": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_1)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1211": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1221": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1222": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1231": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1232": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1233": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_2)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2111": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2112": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2113": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2121": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2122": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2123": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2131": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2132": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2133": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_1)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1211": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1212": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1213": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1221": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1222": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1223": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1231": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1232": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1233": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2111": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2112": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2113": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2121": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2122": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2123": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2131": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2132": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2133": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
       "clequ3Im1211": {
         "real": true,
         "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
@@ -9749,6 +7543,1100 @@
       "clequ3Im1233": {
         "real": true,
         "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2111": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2112": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2113": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2121": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2122": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2123": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2131": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2132": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Im2133": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      }
+    },
+    "taue": {
+      "ceHRe13": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 H e_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceHRe31": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 H e_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceHIm13": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 H e_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceHIm31": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 H e_1) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceWRe13": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\sigma^I H \\sigma^{\\mu\\nu} e_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceWRe31": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\sigma^I H \\sigma^{\\mu\\nu} e_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceWIm13": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\sigma^I H \\sigma^{\\mu\\nu} e_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceWIm31": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 \\sigma^I H \\sigma^{\\mu\\nu} e_1) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceBRe13": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 H  \\sigma^{\\mu\\nu} e_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceBRe31": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 H  \\sigma^{\\mu\\nu} e_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceBIm13": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 H  \\sigma^{\\mu\\nu} e_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceBIm31": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 H  \\sigma^{\\mu\\nu} e_1) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHl1Re13": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHl1Im13": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHl3Re13": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_1 \\gamma^\\mu \\sigma^I \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHl3Im13": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_1 \\gamma^\\mu \\sigma^I \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHeRe13": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHeIm13": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe1113": {
+        "real": true,
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe1322": {
+        "real": true,
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe1333": {
+        "real": true,
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe1223": {
+        "real": true,
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm1113": {
+        "real": true,
+        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm1322": {
+        "real": true,
+        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm1333": {
+        "real": true,
+        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_3 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm1223": {
+        "real": true,
+        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1331": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1313": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1322": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1323": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1333": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1332": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1311": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1312": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re1321": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im1321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1331": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1313": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1322": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1323": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1333": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1332": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1311": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1312": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re1321": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im1321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeRe1113": {
+        "real": true,
+        "tex": "2 (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeRe1322": {
+        "real": true,
+        "tex": "4 (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeRe1333": {
+        "real": true,
+        "tex": "2 (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeIm1113": {
+        "real": true,
+        "tex": "2 i (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeIm1322": {
+        "real": true,
+        "tex": "4 i (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeIm1333": {
+        "real": true,
+        "tex": "2 i (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1331": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1313": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1322": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1323": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1333": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1332": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1311": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1312": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe1321": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1331": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1313": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1322": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1323": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1333": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1332": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1311": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1312": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm1321": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1331": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1313": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1322": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1323": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1333": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1332": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1311": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1312": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe1321": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1331": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1313": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1322": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1323": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1333": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1332": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1311": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1312": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm1321": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1113": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1322": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1333": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1223": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1311": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe2213": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe2312": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe3313": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1113": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm2213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm2312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm3313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1331": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1313": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1322": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1323": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1333": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1332": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1311": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1312": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe1321": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm1321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1331": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1313": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1322": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1323": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1333": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1332": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1311": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1312": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe1321": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm1321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1331": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1113": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1213": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1313": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1231": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe2213": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe2313": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe2331": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe3313": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1331": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1113": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1213": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1313": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1231": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm2213": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm2313": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm2331": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm3313": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\gamma_\\mu q_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1311": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1312": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1313": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1321": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1322": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1323": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1331": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1332": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe1333": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3111": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3112": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3113": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3121": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3122": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3123": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3131": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3132": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3133": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm1333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3111": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3112": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3113": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3121": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3122": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3123": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3131": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3132": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3133": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1311": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1312": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1313": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1321": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1322": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1323": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1331": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1332": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re1333": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I e_3)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3111": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3112": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3113": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3121": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3122": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3123": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3131": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3132": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3133": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_1)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im1333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1^I e_3)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3111": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3112": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3113": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3121": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3122": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3123": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3131": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3132": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3133": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_1)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1311": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1312": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1313": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1321": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1322": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1323": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1331": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1332": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re1333": {
+        "real": true,
+        "tex": "(\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3111": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3112": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3113": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3121": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3122": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3123": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3131": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3132": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3133": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
       },
       "clequ3Im1311": {
         "real": true,
@@ -9786,77 +8674,1099 @@
         "real": true,
         "tex": "i (\\bar \\ell_1^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ3Im2111": {
+      "clequ3Im3111": {
         "real": true,
-        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ3Im2112": {
+      "clequ3Im3112": {
         "real": true,
-        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ3Im2113": {
+      "clequ3Im3113": {
         "real": true,
-        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ3Im2121": {
+      "clequ3Im3121": {
         "real": true,
-        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ3Im2122": {
+      "clequ3Im3122": {
         "real": true,
-        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ3Im2123": {
+      "clequ3Im3123": {
         "real": true,
-        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ3Im2131": {
+      "clequ3Im3131": {
         "real": true,
-        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ3Im2132": {
+      "clequ3Im3132": {
         "real": true,
-        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ3Im2133": {
+      "clequ3Im3133": {
         "real": true,
-        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      }
+    },
+    "mutau": {
+      "ceHRe23": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 H e_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ3Im2211": {
+      "ceHRe32": {
         "real": true,
-        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "(\\bar \\ell_3 H e_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ3Im2212": {
+      "ceHIm23": {
         "real": true,
-        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "i (\\bar \\ell_2 H e_3) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ3Im2213": {
+      "ceHIm32": {
         "real": true,
-        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "i (\\bar \\ell_3 H e_2) (H^\\dagger H) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ3Im2221": {
+      "ceWRe23": {
         "real": true,
-        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "(\\bar \\ell_2 \\sigma^I H \\sigma^{\\mu\\nu} e_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ3Im2222": {
+      "ceWRe32": {
         "real": true,
-        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "(\\bar \\ell_3 \\sigma^I H \\sigma^{\\mu\\nu} e_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ3Im2223": {
+      "ceWIm23": {
         "real": true,
-        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "i (\\bar \\ell_2 \\sigma^I H \\sigma^{\\mu\\nu} e_3) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ3Im2231": {
+      "ceWIm32": {
         "real": true,
-        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "i (\\bar \\ell_3 \\sigma^I H \\sigma^{\\mu\\nu} e_2) W^I_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ3Im2232": {
+      "ceBRe23": {
         "real": true,
-        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "(\\bar \\ell_2 H  \\sigma^{\\mu\\nu} e_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ3Im2233": {
+      "ceBRe32": {
         "real": true,
-        "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "(\\bar \\ell_3 H  \\sigma^{\\mu\\nu} e_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceBIm23": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 H  \\sigma^{\\mu\\nu} e_3) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceBIm32": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 H  \\sigma^{\\mu\\nu} e_2) B_{\\mu\\nu} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHl1Re23": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHl1Im23": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHl3Re23": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_2 \\gamma^\\mu \\sigma^I \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHl3Im23": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu^I H) (\\bar \\ell_2 \\gamma^\\mu \\sigma^I \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHeRe23": {
+        "real": true,
+        "tex": "(H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cHeIm23": {
+        "real": true,
+        "tex": "i (H^\\dagger i \\overleftrightarrow D_\\mu H) (\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe1123": {
+        "real": true,
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe2223": {
+        "real": true,
+        "tex": "2 (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe3323": {
+        "real": true,
+        "tex": "2 (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllRe1231": {
+        "real": true,
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm1123": {
+        "real": true,
+        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm2223": {
+        "real": true,
+        "tex": "2 i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm3323": {
+        "real": true,
+        "tex": "2 i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm1231": {
+        "real": true,
+        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re2332": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re2323": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re2311": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re2312": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re2313": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re2321": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re2322": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re2331": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Re2333": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im2332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im2323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im2311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im2312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im2313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_1 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im2321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im2322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_2 \\gamma^\\mu q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im2331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq1Im2333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar q_3 \\gamma^\\mu q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re2332": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re2323": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re2311": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re2312": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re2313": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re2321": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re2322": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re2331": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Re2333": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im2332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im2323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im2311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im2312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im2313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_1 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im2321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im2322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_2 \\gamma^\\mu \\sigma^I q_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im2331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clq3Im2333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\sigma^I \\ell_3)(\\bar q_3 \\gamma^\\mu \\sigma^I q_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeRe1123": {
+        "real": true,
+        "tex": "4 (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeRe2223": {
+        "real": true,
+        "tex": "2 (\\bar e_2 \\gamma_\\mu e_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeRe3323": {
+        "real": true,
+        "tex": "2 (\\bar e_3 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeIm1123": {
+        "real": true,
+        "tex": "4 i (\\bar e_1 \\gamma_\\mu e_1)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeIm2223": {
+        "real": true,
+        "tex": "2 i (\\bar e_2 \\gamma_\\mu e_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeIm3323": {
+        "real": true,
+        "tex": "2 i (\\bar e_3 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe2332": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe2323": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe2311": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe2312": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe2313": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe2321": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe2322": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe2331": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuRe2333": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm2332": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm2323": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm2311": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm2312": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm2313": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm2321": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm2322": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm2331": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceuIm2333": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe2332": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe2323": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe2311": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe2312": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe2313": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe2321": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe2322": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe2331": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedRe2333": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm2332": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm2323": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm2311": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm2312": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm2313": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm2321": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm2322": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm2331": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cedIm2333": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1123": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe2223": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe3323": {
+        "real": true,
+        "tex": "(\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1231": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1321": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe2311": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe2322": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe2333": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1123": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_1)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm2223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm3323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1231": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_3 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm2311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm2322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm2333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_3 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe2332": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe2323": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe2311": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe2312": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe2313": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe2321": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe2322": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe2331": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluRe2333": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm2332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm2323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm2311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm2312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm2313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_1 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm2321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm2322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_2 \\gamma^\\mu u_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm2331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cluIm2333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar u_3 \\gamma^\\mu u_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe2332": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe2323": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe2311": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe2312": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe2313": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe2321": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe2322": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe2331": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldRe2333": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm2332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm2323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm2311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm2312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm2313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_1 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm2321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm2322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_2 \\gamma^\\mu d_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm2331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cldIm2333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar d_3 \\gamma^\\mu d_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe2332": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1123": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_1)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1232": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1323": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe2223": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe2323": {
+        "real": true,
+        "tex": "(\\bar q_2 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe3323": {
+        "real": true,
+        "tex": "(\\bar q_3 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1223": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeRe1332": {
+        "real": true,
+        "tex": "(\\bar q_1 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm2332": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1123": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_1)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1232": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1323": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm2223": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm2323": {
+        "real": true,
+        "tex": "i (\\bar q_2 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm3323": {
+        "real": true,
+        "tex": "i (\\bar q_3 \\gamma_\\mu q_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1223": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_2)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cqeIm1332": {
+        "real": true,
+        "tex": "i (\\bar q_1 \\gamma_\\mu q_3)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2311": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2312": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2313": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2321": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2322": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2323": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2331": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2332": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe2333": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3211": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3212": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3213": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3221": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3222": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3223": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3231": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3232": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqRe3233": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm2333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3211": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_1 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_1 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_1 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3221": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_2 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3222": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_2 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_2 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3231": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_3 q_1^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3232": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_3 q_2^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cledqIm3233": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar d_3 q_3^I) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2311": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2312": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2313": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2321": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2322": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2323": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2331": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2332": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re2333": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I e_3)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3211": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3212": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3213": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3221": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3222": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3223": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3231": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3232": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Re3233": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I e_2)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2311": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2322": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2331": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2332": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im2333": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2^I e_3)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3211": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_1 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3212": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_1 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_1 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3221": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_2 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3222": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_2 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3223": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_2 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3231": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_3 u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3232": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_3 u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ1Im3233": {
+        "real": true,
+        "tex": "i (\\bar \\ell_3^I e_2)(\\bar q^J_3 u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2311": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2312": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2313": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2321": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2322": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2323": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2331": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2332": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re2333": {
+        "real": true,
+        "tex": "(\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3211": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3212": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3213": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3221": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3222": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3223": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3231": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3232": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "clequ3Re3233": {
+        "real": true,
+        "tex": "(\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
       },
       "clequ3Im2311": {
         "real": true,
@@ -9894,42 +9804,6 @@
         "real": true,
         "tex": "i (\\bar \\ell_2^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ3Im3111": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Im3112": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Im3113": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Im3121": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Im3122": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Im3123": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Im3131": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Im3132": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Im3133": {
-        "real": true,
-        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_1)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
       "clequ3Im3211": {
         "real": true,
         "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
@@ -9965,42 +9839,186 @@
       "clequ3Im3233": {
         "real": true,
         "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_2)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
-      },
-      "clequ3Im3311": {
+      }
+    },
+    "muemue": {
+      "cllRe1212": {
         "real": true,
-        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_1 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ3Im3312": {
+      "cllIm1212": {
         "real": true,
-        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_1 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ3Im3313": {
+      "ceeRe1212": {
         "real": true,
-        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_1 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "(\\bar e_1 \\gamma_\\mu e_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ3Im3321": {
+      "ceeIm1212": {
         "real": true,
-        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ3Im3322": {
+      "cleRe1212": {
         "real": true,
-        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ3Im3323": {
+      "cleIm1212": {
         "real": true,
-        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_2 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      }
+    },
+    "etauemu": {
+      "cllRe1213": {
+        "real": true,
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ3Im3331": {
+      "cllIm1213": {
         "real": true,
-        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_1) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ3Im3332": {
+      "ceeRe1213": {
         "real": true,
-        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_2) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
       },
-      "clequ3Im3333": {
+      "ceeIm1213": {
         "real": true,
-        "tex": "i (\\bar \\ell_3^I \\sigma_{\\mu\\nu} e_3)(\\bar q^J_3 \\sigma^{\\mu\\nu} u_3) \\varepsilon_{IJ} / \\text{TeV}^2 + \\text{h.c.}"
+        "tex": "2 i (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1213": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1312": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1213": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1312": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      }
+    },
+    "muemutau": {
+      "cllRe1232": {
+        "real": true,
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm1232": {
+        "real": true,
+        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar \\ell_3 \\gamma^\\mu \\ell_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeRe1232": {
+        "real": true,
+        "tex": "2 (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeIm1232": {
+        "real": true,
+        "tex": "2 i (\\bar e_1 \\gamma_\\mu e_2)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1232": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe2321": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1232": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_2)(\\bar e_3 \\gamma^\\mu e_2) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm2321": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_1) / \\text{TeV}^2 + \\text{h.c.}"
+      }
+    },
+    "tauetaue": {
+      "cllRe1313": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm1313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_1 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeRe1313": {
+        "real": true,
+        "tex": "(\\bar e_1 \\gamma_\\mu e_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeIm1313": {
+        "real": true,
+        "tex": "i (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1313": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      }
+    },
+    "tauetaumu": {
+      "cllRe1323": {
+        "real": true,
+        "tex": "2 (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm1323": {
+        "real": true,
+        "tex": "2 i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeRe1323": {
+        "real": true,
+        "tex": "2 (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeIm1323": {
+        "real": true,
+        "tex": "2 i (\\bar e_1 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe1323": {
+        "real": true,
+        "tex": "(\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe2313": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm1323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_1 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm2313": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_1 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      }
+    },
+    "taumutaumu": {
+      "cllRe2323": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cllIm2323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar \\ell_2 \\gamma^\\mu \\ell_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeRe2323": {
+        "real": true,
+        "tex": "(\\bar e_2 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "ceeIm2323": {
+        "real": true,
+        "tex": "i (\\bar e_2 \\gamma_\\mu e_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleRe2323": {
+        "real": true,
+        "tex": "(\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
+      },
+      "cleIm2323": {
+        "real": true,
+        "tex": "i (\\bar \\ell_2 \\gamma_\\mu \\ell_3)(\\bar e_2 \\gamma^\\mu e_3) / \\text{TeV}^2 + \\text{h.c.}"
       }
     }
   }

--- a/smeft.smeftsim-general.basis.yml
+++ b/smeft.smeftsim-general.basis.yml
@@ -3,7 +3,7 @@ basis: SMEFTsim_general
 metadata:
   description: Basis used in the `SMEFTsim_general` UFO models, version 3.0.0 or later. Implements Warsaw basis with generic flavor indices for all fermions. $q,u,d$ are the left- and right-handed quark fields. $\ell, e$ are left- and right-handed lepton fields. Quark fields are in the up-aligned basis. This basis definition corresponds to a fixed `LambdaSMEFT=1e+3` in the UFO models. Notation and conventions can vary compared to the Warsaw basis paper, see [arXiv:2012.11343](https://arxiv.org/abs/2012.11343) for all definitions.
 sectors:
-  dB=dL=0:
+  dB=de=dmu=dtau=0:
     cG:
       real: true
       tex: f^{ABC} G_\mu^{A \nu} G_\nu^{B \rho} G_\rho^{C \mu} / \text{TeV}^2
@@ -58,24 +58,6 @@ sectors:
     ceHRe33:
       real: true
       tex: (\bar \ell_3 H e_3) (H^\dagger H) / \text{TeV}^2 + \text{h.c.}
-    ceHRe12:
-      real: true
-      tex: (\bar \ell_1 H e_2) (H^\dagger H) / \text{TeV}^2 + \text{h.c.}
-    ceHRe13:
-      real: true
-      tex: (\bar \ell_1 H e_3) (H^\dagger H) / \text{TeV}^2 + \text{h.c.}
-    ceHRe21:
-      real: true
-      tex: (\bar \ell_2 H e_1) (H^\dagger H) / \text{TeV}^2 + \text{h.c.}
-    ceHRe23:
-      real: true
-      tex: (\bar \ell_2 H e_3) (H^\dagger H) / \text{TeV}^2 + \text{h.c.}
-    ceHRe31:
-      real: true
-      tex: (\bar \ell_3 H e_1) (H^\dagger H) / \text{TeV}^2 + \text{h.c.}
-    ceHRe32:
-      real: true
-      tex: (\bar \ell_3 H e_2) (H^\dagger H) / \text{TeV}^2 + \text{h.c.}
     ceHIm11:
       real: true
       tex: i (\bar \ell_1 H e_1) (H^\dagger H) / \text{TeV}^2 + \text{h.c.}
@@ -85,24 +67,6 @@ sectors:
     ceHIm33:
       real: true
       tex: i (\bar \ell_3 H e_3) (H^\dagger H) / \text{TeV}^2 + \text{h.c.}
-    ceHIm12:
-      real: true
-      tex: i (\bar \ell_1 H e_2) (H^\dagger H) / \text{TeV}^2 + \text{h.c.}
-    ceHIm13:
-      real: true
-      tex: i (\bar \ell_1 H e_3) (H^\dagger H) / \text{TeV}^2 + \text{h.c.}
-    ceHIm21:
-      real: true
-      tex: i (\bar \ell_2 H e_1) (H^\dagger H) / \text{TeV}^2 + \text{h.c.}
-    ceHIm23:
-      real: true
-      tex: i (\bar \ell_2 H e_3) (H^\dagger H) / \text{TeV}^2 + \text{h.c.}
-    ceHIm31:
-      real: true
-      tex: i (\bar \ell_3 H e_1) (H^\dagger H) / \text{TeV}^2 + \text{h.c.}
-    ceHIm32:
-      real: true
-      tex: i (\bar \ell_3 H e_2) (H^\dagger H) / \text{TeV}^2 + \text{h.c.}
     cuHRe11:
       real: true
       tex: (\bar q_1 \tilde H u_1) (H^\dagger H) / \text{TeV}^2 + \text{h.c.}
@@ -220,24 +184,6 @@ sectors:
     ceWRe33:
       real: true
       tex: (\bar \ell_3 \sigma^I H \sigma^{\mu\nu} e_3) W^I_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
-    ceWRe12:
-      real: true
-      tex: (\bar \ell_1 \sigma^I H \sigma^{\mu\nu} e_2) W^I_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
-    ceWRe13:
-      real: true
-      tex: (\bar \ell_1 \sigma^I H \sigma^{\mu\nu} e_3) W^I_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
-    ceWRe21:
-      real: true
-      tex: (\bar \ell_2 \sigma^I H \sigma^{\mu\nu} e_1) W^I_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
-    ceWRe23:
-      real: true
-      tex: (\bar \ell_2 \sigma^I H \sigma^{\mu\nu} e_3) W^I_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
-    ceWRe31:
-      real: true
-      tex: (\bar \ell_3 \sigma^I H \sigma^{\mu\nu} e_1) W^I_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
-    ceWRe32:
-      real: true
-      tex: (\bar \ell_3 \sigma^I H \sigma^{\mu\nu} e_2) W^I_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
     ceWIm11:
       real: true
       tex: i (\bar \ell_1 \sigma^I H \sigma^{\mu\nu} e_1) W^I_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
@@ -247,24 +193,6 @@ sectors:
     ceWIm33:
       real: true
       tex: i (\bar \ell_3 \sigma^I H \sigma^{\mu\nu} e_3) W^I_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
-    ceWIm12:
-      real: true
-      tex: i (\bar \ell_1 \sigma^I H \sigma^{\mu\nu} e_2) W^I_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
-    ceWIm13:
-      real: true
-      tex: i (\bar \ell_1 \sigma^I H \sigma^{\mu\nu} e_3) W^I_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
-    ceWIm21:
-      real: true
-      tex: i (\bar \ell_2 \sigma^I H \sigma^{\mu\nu} e_1) W^I_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
-    ceWIm23:
-      real: true
-      tex: i (\bar \ell_2 \sigma^I H \sigma^{\mu\nu} e_3) W^I_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
-    ceWIm31:
-      real: true
-      tex: i (\bar \ell_3 \sigma^I H \sigma^{\mu\nu} e_1) W^I_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
-    ceWIm32:
-      real: true
-      tex: i (\bar \ell_3 \sigma^I H \sigma^{\mu\nu} e_2) W^I_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
     ceBRe11:
       real: true
       tex: (\bar \ell_1 H  \sigma^{\mu\nu} e_1) B_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
@@ -274,24 +202,6 @@ sectors:
     ceBRe33:
       real: true
       tex: (\bar \ell_3 H  \sigma^{\mu\nu} e_3) B_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
-    ceBRe12:
-      real: true
-      tex: (\bar \ell_1 H  \sigma^{\mu\nu} e_2) B_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
-    ceBRe13:
-      real: true
-      tex: (\bar \ell_1 H  \sigma^{\mu\nu} e_3) B_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
-    ceBRe21:
-      real: true
-      tex: (\bar \ell_2 H  \sigma^{\mu\nu} e_1) B_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
-    ceBRe23:
-      real: true
-      tex: (\bar \ell_2 H  \sigma^{\mu\nu} e_3) B_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
-    ceBRe31:
-      real: true
-      tex: (\bar \ell_3 H  \sigma^{\mu\nu} e_1) B_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
-    ceBRe32:
-      real: true
-      tex: (\bar \ell_3 H  \sigma^{\mu\nu} e_2) B_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
     ceBIm11:
       real: true
       tex: i (\bar \ell_1 H  \sigma^{\mu\nu} e_1) B_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
@@ -301,24 +211,6 @@ sectors:
     ceBIm33:
       real: true
       tex: i (\bar \ell_3 H  \sigma^{\mu\nu} e_3) B_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
-    ceBIm12:
-      real: true
-      tex: i (\bar \ell_1 H  \sigma^{\mu\nu} e_2) B_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
-    ceBIm13:
-      real: true
-      tex: i (\bar \ell_1 H  \sigma^{\mu\nu} e_3) B_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
-    ceBIm21:
-      real: true
-      tex: i (\bar \ell_2 H  \sigma^{\mu\nu} e_1) B_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
-    ceBIm23:
-      real: true
-      tex: i (\bar \ell_2 H  \sigma^{\mu\nu} e_3) B_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
-    ceBIm31:
-      real: true
-      tex: i (\bar \ell_3 H  \sigma^{\mu\nu} e_1) B_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
-    ceBIm32:
-      real: true
-      tex: i (\bar \ell_3 H  \sigma^{\mu\nu} e_2) B_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
     cuGRe11:
       real: true
       tex: (\bar q_1 \tilde H \sigma^{\mu\nu} T^A u_1) G^A_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
@@ -652,24 +544,6 @@ sectors:
     cHl1Re33:
       real: true
       tex: (H^\dagger i \overleftrightarrow D_\mu H) (\bar \ell_3 \gamma^\mu \ell_3) / \text{TeV}^2
-    cHl1Re12:
-      real: true
-      tex: (H^\dagger i \overleftrightarrow D_\mu H) (\bar \ell_1 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
-    cHl1Re13:
-      real: true
-      tex: (H^\dagger i \overleftrightarrow D_\mu H) (\bar \ell_1 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
-    cHl1Re23:
-      real: true
-      tex: (H^\dagger i \overleftrightarrow D_\mu H) (\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
-    cHl1Im12:
-      real: true
-      tex: i (H^\dagger i \overleftrightarrow D_\mu H) (\bar \ell_1 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
-    cHl1Im13:
-      real: true
-      tex: i (H^\dagger i \overleftrightarrow D_\mu H) (\bar \ell_1 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
-    cHl1Im23:
-      real: true
-      tex: i (H^\dagger i \overleftrightarrow D_\mu H) (\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
     cHl3Re11:
       real: true
       tex: (H^\dagger i \overleftrightarrow D_\mu^I H) (\bar \ell_1 \gamma^\mu \sigma^I \ell_1) / \text{TeV}^2
@@ -679,24 +553,6 @@ sectors:
     cHl3Re33:
       real: true
       tex: (H^\dagger i \overleftrightarrow D_\mu^I H) (\bar \ell_3 \gamma^\mu \sigma^I \ell_3) / \text{TeV}^2
-    cHl3Re12:
-      real: true
-      tex: (H^\dagger i \overleftrightarrow D_\mu^I H) (\bar \ell_1 \gamma^\mu \sigma^I \ell_2) / \text{TeV}^2 + \text{h.c.}
-    cHl3Re13:
-      real: true
-      tex: (H^\dagger i \overleftrightarrow D_\mu^I H) (\bar \ell_1 \gamma^\mu \sigma^I \ell_3) / \text{TeV}^2 + \text{h.c.}
-    cHl3Re23:
-      real: true
-      tex: (H^\dagger i \overleftrightarrow D_\mu^I H) (\bar \ell_2 \gamma^\mu \sigma^I \ell_3) / \text{TeV}^2 + \text{h.c.}
-    cHl3Im12:
-      real: true
-      tex: i (H^\dagger i \overleftrightarrow D_\mu^I H) (\bar \ell_1 \gamma^\mu \sigma^I \ell_2) / \text{TeV}^2 + \text{h.c.}
-    cHl3Im13:
-      real: true
-      tex: i (H^\dagger i \overleftrightarrow D_\mu^I H) (\bar \ell_1 \gamma^\mu \sigma^I \ell_3) / \text{TeV}^2 + \text{h.c.}
-    cHl3Im23:
-      real: true
-      tex: i (H^\dagger i \overleftrightarrow D_\mu^I H) (\bar \ell_2 \gamma^\mu \sigma^I \ell_3) / \text{TeV}^2 + \text{h.c.}
     cHq1Re11:
       real: true
       tex: (H^\dagger i \overleftrightarrow D_\mu H) (\bar q_1 \gamma^\mu q_1) / \text{TeV}^2
@@ -760,24 +616,6 @@ sectors:
     cHeRe33:
       real: true
       tex: (H^\dagger i \overleftrightarrow D_\mu H) (\bar e_3 \gamma^\mu e_3) / \text{TeV}^2
-    cHeRe12:
-      real: true
-      tex: (H^\dagger i \overleftrightarrow D_\mu H) (\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cHeRe13:
-      real: true
-      tex: (H^\dagger i \overleftrightarrow D_\mu H) (\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cHeRe23:
-      real: true
-      tex: (H^\dagger i \overleftrightarrow D_\mu H) (\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cHeIm12:
-      real: true
-      tex: i (H^\dagger i \overleftrightarrow D_\mu H) (\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cHeIm13:
-      real: true
-      tex: i (H^\dagger i \overleftrightarrow D_\mu H) (\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cHeIm23:
-      real: true
-      tex: i (H^\dagger i \overleftrightarrow D_\mu H) (\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     cHuRe11:
       real: true
       tex: (H^\dagger i \overleftrightarrow D_\mu H) (\bar u_1 \gamma^\mu u_1) / \text{TeV}^2
@@ -913,114 +751,6 @@ sectors:
     cllRe2332:
       real: true
       tex: 2 (\bar \ell_2 \gamma_\mu \ell_3)(\bar \ell_3 \gamma^\mu \ell_2) / \text{TeV}^2
-    cllRe1112:
-      real: true
-      tex: 2 (\bar \ell_1 \gamma_\mu \ell_1)(\bar \ell_1 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
-    cllRe1113:
-      real: true
-      tex: 2 (\bar \ell_1 \gamma_\mu \ell_1)(\bar \ell_1 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
-    cllRe1123:
-      real: true
-      tex: 2 (\bar \ell_1 \gamma_\mu \ell_1)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
-    cllRe1212:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_1 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
-    cllRe1213:
-      real: true
-      tex: 2 (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_1 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
-    cllRe1222:
-      real: true
-      tex: 2 (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_2 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
-    cllRe1232:
-      real: true
-      tex: 2 (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_3 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
-    cllRe1233:
-      real: true
-      tex: 2 (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_3 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
-    cllRe1313:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_1 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
-    cllRe1322:
-      real: true
-      tex: 2 (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
-    cllRe1323:
-      real: true
-      tex: 2 (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
-    cllRe1333:
-      real: true
-      tex: 2 (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_3 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
-    cllRe2223:
-      real: true
-      tex: 2 (\bar \ell_2 \gamma_\mu \ell_2)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
-    cllRe2323:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
-    cllRe3323:
-      real: true
-      tex: 2 (\bar \ell_3 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
-    cllRe1231:
-      real: true
-      tex: 2 (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_3 \gamma^\mu \ell_1) / \text{TeV}^2 + \text{h.c.}
-    cllRe1223:
-      real: true
-      tex: 2 (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
-    cllRe1332:
-      real: true
-      tex: 2 (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_3 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
-    cllIm1112:
-      real: true
-      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_1)(\bar \ell_1 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
-    cllIm1113:
-      real: true
-      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_1)(\bar \ell_1 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
-    cllIm1123:
-      real: true
-      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_1)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
-    cllIm1212:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_1 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
-    cllIm1213:
-      real: true
-      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_1 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
-    cllIm1222:
-      real: true
-      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_2 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
-    cllIm1232:
-      real: true
-      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_3 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
-    cllIm1233:
-      real: true
-      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_3 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
-    cllIm1313:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_1 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
-    cllIm1322:
-      real: true
-      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
-    cllIm1323:
-      real: true
-      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
-    cllIm1333:
-      real: true
-      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_3 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
-    cllIm2223:
-      real: true
-      tex: 2 i (\bar \ell_2 \gamma_\mu \ell_2)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
-    cllIm2323:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
-    cllIm3323:
-      real: true
-      tex: 2 i (\bar \ell_3 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
-    cllIm1231:
-      real: true
-      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_3 \gamma^\mu \ell_1) / \text{TeV}^2 + \text{h.c.}
-    cllIm1223:
-      real: true
-      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
-    cllIm1332:
-      real: true
-      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_3 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
     clq1Re1111:
       real: true
       tex: (\bar \ell_1 \gamma_\mu \ell_1)(\bar q_1 \gamma^\mu q_1) / \text{TeV}^2
@@ -1039,15 +769,6 @@ sectors:
     clq1Re3333:
       real: true
       tex: (\bar \ell_3 \gamma_\mu \ell_3)(\bar q_3 \gamma^\mu q_3) / \text{TeV}^2
-    clq1Re1221:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_2 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
-    clq1Re1331:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_3 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
-    clq1Re2332:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_3 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
     clq1Re2211:
       real: true
       tex: (\bar \ell_2 \gamma_\mu \ell_2)(\bar q_1 \gamma^\mu q_1) / \text{TeV}^2
@@ -1066,105 +787,24 @@ sectors:
     clq1Re1123:
       real: true
       tex: (\bar \ell_1 \gamma_\mu \ell_1)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
-    clq1Re1212:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_1 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
-    clq1Re1213:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_1 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
-    clq1Re1222:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_2 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
-    clq1Re1232:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_3 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
-    clq1Re1233:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_3 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
-    clq1Re1313:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_1 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
-    clq1Re1322:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_2 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
-    clq1Re1323:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
-    clq1Re1333:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_3 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
     clq1Re2223:
       real: true
       tex: (\bar \ell_2 \gamma_\mu \ell_2)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
-    clq1Re2323:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
     clq1Re3323:
       real: true
       tex: (\bar \ell_3 \gamma_\mu \ell_3)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
-    clq1Re1231:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_3 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
-    clq1Re1223:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
-    clq1Re1332:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_3 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
-    clq1Re1211:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_1 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
-    clq1Re1311:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_1 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
-    clq1Re1312:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_1 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
-    clq1Re1321:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_2 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
     clq1Re2212:
       real: true
       tex: (\bar \ell_2 \gamma_\mu \ell_2)(\bar q_1 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
     clq1Re2213:
       real: true
       tex: (\bar \ell_2 \gamma_\mu \ell_2)(\bar q_1 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
-    clq1Re2311:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_1 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
-    clq1Re2312:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_1 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
-    clq1Re2313:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_1 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
-    clq1Re2321:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_2 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
-    clq1Re2322:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_2 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
-    clq1Re2331:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_3 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
-    clq1Re2333:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_3 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
     clq1Re3312:
       real: true
       tex: (\bar \ell_3 \gamma_\mu \ell_3)(\bar q_1 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
     clq1Re3313:
       real: true
       tex: (\bar \ell_3 \gamma_\mu \ell_3)(\bar q_1 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
-    clq1Im1221:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_2 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
-    clq1Im1331:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_3 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
-    clq1Im2332:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_3 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
     clq1Im1112:
       real: true
       tex: i (\bar \ell_1 \gamma_\mu \ell_1)(\bar q_1 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
@@ -1174,90 +814,18 @@ sectors:
     clq1Im1123:
       real: true
       tex: i (\bar \ell_1 \gamma_\mu \ell_1)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
-    clq1Im1212:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_1 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
-    clq1Im1213:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_1 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
-    clq1Im1222:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_2 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
-    clq1Im1232:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_3 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
-    clq1Im1233:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_3 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
-    clq1Im1313:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_1 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
-    clq1Im1322:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_2 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
-    clq1Im1323:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
-    clq1Im1333:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_3 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
     clq1Im2223:
       real: true
       tex: i (\bar \ell_2 \gamma_\mu \ell_2)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
-    clq1Im2323:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
     clq1Im3323:
       real: true
       tex: i (\bar \ell_3 \gamma_\mu \ell_3)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
-    clq1Im1231:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_3 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
-    clq1Im1223:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
-    clq1Im1332:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_3 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
-    clq1Im1211:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_1 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
-    clq1Im1311:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_1 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
-    clq1Im1312:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_1 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
-    clq1Im1321:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_2 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
     clq1Im2212:
       real: true
       tex: i (\bar \ell_2 \gamma_\mu \ell_2)(\bar q_1 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
     clq1Im2213:
       real: true
       tex: i (\bar \ell_2 \gamma_\mu \ell_2)(\bar q_1 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
-    clq1Im2311:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_1 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
-    clq1Im2312:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_1 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
-    clq1Im2313:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_1 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
-    clq1Im2321:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_2 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
-    clq1Im2322:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_2 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
-    clq1Im2331:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_3 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
-    clq1Im2333:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_3 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
     clq1Im3312:
       real: true
       tex: i (\bar \ell_3 \gamma_\mu \ell_3)(\bar q_1 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
@@ -1282,15 +850,6 @@ sectors:
     clq3Re3333:
       real: true
       tex: (\bar \ell_3 \gamma_\mu \sigma^I \ell_3)(\bar q_3 \gamma^\mu \sigma^I q_3) / \text{TeV}^2
-    clq3Re1221:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_2 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
-    clq3Re1331:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_3 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
-    clq3Re2332:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_3 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
     clq3Re2211:
       real: true
       tex: (\bar \ell_2 \gamma_\mu \sigma^I \ell_2)(\bar q_1 \gamma^\mu \sigma^I q_1) / \text{TeV}^2
@@ -1309,105 +868,24 @@ sectors:
     clq3Re1123:
       real: true
       tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_1)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
-    clq3Re1212:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_1 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
-    clq3Re1213:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_1 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
-    clq3Re1222:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_2 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
-    clq3Re1232:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_3 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
-    clq3Re1233:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_3 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
-    clq3Re1313:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_1 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
-    clq3Re1322:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_2 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
-    clq3Re1323:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
-    clq3Re1333:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_3 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
     clq3Re2223:
       real: true
       tex: (\bar \ell_2 \gamma_\mu \sigma^I \ell_2)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
-    clq3Re2323:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
     clq3Re3323:
       real: true
       tex: (\bar \ell_3 \gamma_\mu \sigma^I \ell_3)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
-    clq3Re1231:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_3 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
-    clq3Re1223:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
-    clq3Re1332:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_3 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
-    clq3Re1211:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_1 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
-    clq3Re1311:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_1 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
-    clq3Re1312:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_1 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
-    clq3Re1321:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_2 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
     clq3Re2212:
       real: true
       tex: (\bar \ell_2 \gamma_\mu \sigma^I \ell_2)(\bar q_1 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
     clq3Re2213:
       real: true
       tex: (\bar \ell_2 \gamma_\mu \sigma^I \ell_2)(\bar q_1 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
-    clq3Re2311:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_1 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
-    clq3Re2312:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_1 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
-    clq3Re2313:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_1 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
-    clq3Re2321:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_2 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
-    clq3Re2322:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_2 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
-    clq3Re2331:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_3 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
-    clq3Re2333:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_3 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
     clq3Re3312:
       real: true
       tex: (\bar \ell_3 \gamma_\mu \sigma^I \ell_3)(\bar q_1 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
     clq3Re3313:
       real: true
       tex: (\bar \ell_3 \gamma_\mu \sigma^I \ell_3)(\bar q_1 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
-    clq3Im1221:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_2 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
-    clq3Im1331:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_3 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
-    clq3Im2332:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_3 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
     clq3Im1112:
       real: true
       tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_1)(\bar q_1 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
@@ -1417,90 +895,18 @@ sectors:
     clq3Im1123:
       real: true
       tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_1)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
-    clq3Im1212:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_1 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
-    clq3Im1213:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_1 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
-    clq3Im1222:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_2 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
-    clq3Im1232:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_3 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
-    clq3Im1233:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_3 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
-    clq3Im1313:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_1 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
-    clq3Im1322:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_2 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
-    clq3Im1323:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
-    clq3Im1333:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_3 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
     clq3Im2223:
       real: true
       tex: i (\bar \ell_2 \gamma_\mu \sigma^I \ell_2)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
-    clq3Im2323:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
     clq3Im3323:
       real: true
       tex: i (\bar \ell_3 \gamma_\mu \sigma^I \ell_3)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
-    clq3Im1231:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_3 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
-    clq3Im1223:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
-    clq3Im1332:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_3 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
-    clq3Im1211:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_1 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
-    clq3Im1311:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_1 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
-    clq3Im1312:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_1 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
-    clq3Im1321:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_2 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
     clq3Im2212:
       real: true
       tex: i (\bar \ell_2 \gamma_\mu \sigma^I \ell_2)(\bar q_1 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
     clq3Im2213:
       real: true
       tex: i (\bar \ell_2 \gamma_\mu \sigma^I \ell_2)(\bar q_1 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
-    clq3Im2311:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_1 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
-    clq3Im2312:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_1 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
-    clq3Im2313:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_1 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
-    clq3Im2321:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_2 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
-    clq3Im2322:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_2 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
-    clq3Im2331:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_3 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
-    clq3Im2333:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_3 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
     clq3Im3312:
       real: true
       tex: i (\bar \ell_3 \gamma_\mu \sigma^I \ell_3)(\bar q_1 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
@@ -1795,96 +1201,6 @@ sectors:
     ceeRe2233:
       real: true
       tex: 4 (\bar e_2 \gamma_\mu e_2)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2
-    ceeRe1112:
-      real: true
-      tex: 2 (\bar e_1 \gamma_\mu e_1)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    ceeRe1113:
-      real: true
-      tex: 2 (\bar e_1 \gamma_\mu e_1)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    ceeRe1123:
-      real: true
-      tex: 4 (\bar e_1 \gamma_\mu e_1)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    ceeRe1212:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_2)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    ceeRe1213:
-      real: true
-      tex: 2 (\bar e_1 \gamma_\mu e_2)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    ceeRe1222:
-      real: true
-      tex: 2 (\bar e_1 \gamma_\mu e_2)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    ceeRe1232:
-      real: true
-      tex: 2 (\bar e_1 \gamma_\mu e_2)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    ceeRe1233:
-      real: true
-      tex: 4 (\bar e_1 \gamma_\mu e_2)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    ceeRe1313:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    ceeRe1322:
-      real: true
-      tex: 4 (\bar e_1 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    ceeRe1323:
-      real: true
-      tex: 2 (\bar e_1 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    ceeRe1333:
-      real: true
-      tex: 2 (\bar e_1 \gamma_\mu e_3)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    ceeRe2223:
-      real: true
-      tex: 2 (\bar e_2 \gamma_\mu e_2)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    ceeRe2323:
-      real: true
-      tex: (\bar e_2 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    ceeRe3323:
-      real: true
-      tex: 2 (\bar e_3 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    ceeIm1112:
-      real: true
-      tex: 2 i (\bar e_1 \gamma_\mu e_1)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    ceeIm1113:
-      real: true
-      tex: 2 i (\bar e_1 \gamma_\mu e_1)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    ceeIm1123:
-      real: true
-      tex: 4 i (\bar e_1 \gamma_\mu e_1)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    ceeIm1212:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_2)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    ceeIm1213:
-      real: true
-      tex: 2 i (\bar e_1 \gamma_\mu e_2)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    ceeIm1222:
-      real: true
-      tex: 2 i (\bar e_1 \gamma_\mu e_2)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    ceeIm1232:
-      real: true
-      tex: 2 i (\bar e_1 \gamma_\mu e_2)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    ceeIm1233:
-      real: true
-      tex: 4 i (\bar e_1 \gamma_\mu e_2)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    ceeIm1313:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    ceeIm1322:
-      real: true
-      tex: 4 i (\bar e_1 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    ceeIm1323:
-      real: true
-      tex: 2 i (\bar e_1 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    ceeIm1333:
-      real: true
-      tex: 2 i (\bar e_1 \gamma_\mu e_3)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    ceeIm2223:
-      real: true
-      tex: 2 i (\bar e_2 \gamma_\mu e_2)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    ceeIm2323:
-      real: true
-      tex: i (\bar e_2 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    ceeIm3323:
-      real: true
-      tex: 2 i (\bar e_3 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     cuuRe1111:
       real: true
       tex: (\bar u_1 \gamma_\mu u_1)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2
@@ -2173,15 +1489,6 @@ sectors:
     ceuRe3333:
       real: true
       tex: (\bar e_3 \gamma_\mu e_3)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2
-    ceuRe1221:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_2)(\bar u_2 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    ceuRe1331:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_3)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    ceuRe2332:
-      real: true
-      tex: (\bar e_2 \gamma_\mu e_3)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
     ceuRe2211:
       real: true
       tex: (\bar e_2 \gamma_\mu e_2)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2
@@ -2200,105 +1507,24 @@ sectors:
     ceuRe1123:
       real: true
       tex: (\bar e_1 \gamma_\mu e_1)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    ceuRe1212:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_2)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    ceuRe1213:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_2)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    ceuRe1222:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_2)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    ceuRe1232:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_2)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    ceuRe1233:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_2)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    ceuRe1313:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_3)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    ceuRe1322:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_3)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    ceuRe1323:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    ceuRe1333:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_3)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     ceuRe2223:
       real: true
       tex: (\bar e_2 \gamma_\mu e_2)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    ceuRe2323:
-      real: true
-      tex: (\bar e_2 \gamma_\mu e_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     ceuRe3323:
       real: true
       tex: (\bar e_3 \gamma_\mu e_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    ceuRe1231:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_2)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    ceuRe1223:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_2)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    ceuRe1332:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_3)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    ceuRe1211:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_2)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    ceuRe1311:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_3)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    ceuRe1312:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_3)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    ceuRe1321:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_3)(\bar u_2 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
     ceuRe2212:
       real: true
       tex: (\bar e_2 \gamma_\mu e_2)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
     ceuRe2213:
       real: true
       tex: (\bar e_2 \gamma_\mu e_2)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    ceuRe2311:
-      real: true
-      tex: (\bar e_2 \gamma_\mu e_3)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    ceuRe2312:
-      real: true
-      tex: (\bar e_2 \gamma_\mu e_3)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    ceuRe2313:
-      real: true
-      tex: (\bar e_2 \gamma_\mu e_3)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    ceuRe2321:
-      real: true
-      tex: (\bar e_2 \gamma_\mu e_3)(\bar u_2 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    ceuRe2322:
-      real: true
-      tex: (\bar e_2 \gamma_\mu e_3)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    ceuRe2331:
-      real: true
-      tex: (\bar e_2 \gamma_\mu e_3)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    ceuRe2333:
-      real: true
-      tex: (\bar e_2 \gamma_\mu e_3)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     ceuRe3312:
       real: true
       tex: (\bar e_3 \gamma_\mu e_3)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
     ceuRe3313:
       real: true
       tex: (\bar e_3 \gamma_\mu e_3)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    ceuIm1221:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_2)(\bar u_2 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    ceuIm1331:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_3)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    ceuIm2332:
-      real: true
-      tex: i (\bar e_2 \gamma_\mu e_3)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
     ceuIm1112:
       real: true
       tex: i (\bar e_1 \gamma_\mu e_1)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
@@ -2308,90 +1534,18 @@ sectors:
     ceuIm1123:
       real: true
       tex: i (\bar e_1 \gamma_\mu e_1)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    ceuIm1212:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_2)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    ceuIm1213:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_2)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    ceuIm1222:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_2)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    ceuIm1232:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_2)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    ceuIm1233:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_2)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    ceuIm1313:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_3)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    ceuIm1322:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_3)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    ceuIm1323:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    ceuIm1333:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_3)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     ceuIm2223:
       real: true
       tex: i (\bar e_2 \gamma_\mu e_2)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    ceuIm2323:
-      real: true
-      tex: i (\bar e_2 \gamma_\mu e_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     ceuIm3323:
       real: true
       tex: i (\bar e_3 \gamma_\mu e_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    ceuIm1231:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_2)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    ceuIm1223:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_2)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    ceuIm1332:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_3)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    ceuIm1211:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_2)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    ceuIm1311:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_3)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    ceuIm1312:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_3)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    ceuIm1321:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_3)(\bar u_2 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
     ceuIm2212:
       real: true
       tex: i (\bar e_2 \gamma_\mu e_2)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
     ceuIm2213:
       real: true
       tex: i (\bar e_2 \gamma_\mu e_2)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    ceuIm2311:
-      real: true
-      tex: i (\bar e_2 \gamma_\mu e_3)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    ceuIm2312:
-      real: true
-      tex: i (\bar e_2 \gamma_\mu e_3)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    ceuIm2313:
-      real: true
-      tex: i (\bar e_2 \gamma_\mu e_3)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    ceuIm2321:
-      real: true
-      tex: i (\bar e_2 \gamma_\mu e_3)(\bar u_2 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    ceuIm2322:
-      real: true
-      tex: i (\bar e_2 \gamma_\mu e_3)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    ceuIm2331:
-      real: true
-      tex: i (\bar e_2 \gamma_\mu e_3)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    ceuIm2333:
-      real: true
-      tex: i (\bar e_2 \gamma_\mu e_3)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     ceuIm3312:
       real: true
       tex: i (\bar e_3 \gamma_\mu e_3)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
@@ -2416,15 +1570,6 @@ sectors:
     cedRe3333:
       real: true
       tex: (\bar e_3 \gamma_\mu e_3)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2
-    cedRe1221:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_2)(\bar d_2 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cedRe1331:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_3)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cedRe2332:
-      real: true
-      tex: (\bar e_2 \gamma_\mu e_3)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
     cedRe2211:
       real: true
       tex: (\bar e_2 \gamma_\mu e_2)(\bar d_1 \gamma^\mu d_1) / \text{TeV}^2
@@ -2443,105 +1588,24 @@ sectors:
     cedRe1123:
       real: true
       tex: (\bar e_1 \gamma_\mu e_1)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cedRe1212:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_2)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cedRe1213:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_2)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cedRe1222:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_2)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cedRe1232:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_2)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cedRe1233:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_2)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cedRe1313:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_3)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cedRe1322:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_3)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cedRe1323:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cedRe1333:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_3)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cedRe2223:
       real: true
       tex: (\bar e_2 \gamma_\mu e_2)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cedRe2323:
-      real: true
-      tex: (\bar e_2 \gamma_\mu e_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cedRe3323:
       real: true
       tex: (\bar e_3 \gamma_\mu e_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cedRe1231:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_2)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cedRe1223:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_2)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cedRe1332:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_3)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cedRe1211:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_2)(\bar d_1 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cedRe1311:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_3)(\bar d_1 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cedRe1312:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_3)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cedRe1321:
-      real: true
-      tex: (\bar e_1 \gamma_\mu e_3)(\bar d_2 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
     cedRe2212:
       real: true
       tex: (\bar e_2 \gamma_\mu e_2)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
     cedRe2213:
       real: true
       tex: (\bar e_2 \gamma_\mu e_2)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cedRe2311:
-      real: true
-      tex: (\bar e_2 \gamma_\mu e_3)(\bar d_1 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cedRe2312:
-      real: true
-      tex: (\bar e_2 \gamma_\mu e_3)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cedRe2313:
-      real: true
-      tex: (\bar e_2 \gamma_\mu e_3)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cedRe2321:
-      real: true
-      tex: (\bar e_2 \gamma_\mu e_3)(\bar d_2 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cedRe2322:
-      real: true
-      tex: (\bar e_2 \gamma_\mu e_3)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cedRe2331:
-      real: true
-      tex: (\bar e_2 \gamma_\mu e_3)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cedRe2333:
-      real: true
-      tex: (\bar e_2 \gamma_\mu e_3)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cedRe3312:
       real: true
       tex: (\bar e_3 \gamma_\mu e_3)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
     cedRe3313:
       real: true
       tex: (\bar e_3 \gamma_\mu e_3)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cedIm1221:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_2)(\bar d_2 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cedIm1331:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_3)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cedIm2332:
-      real: true
-      tex: i (\bar e_2 \gamma_\mu e_3)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
     cedIm1112:
       real: true
       tex: i (\bar e_1 \gamma_\mu e_1)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
@@ -2551,90 +1615,18 @@ sectors:
     cedIm1123:
       real: true
       tex: i (\bar e_1 \gamma_\mu e_1)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cedIm1212:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_2)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cedIm1213:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_2)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cedIm1222:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_2)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cedIm1232:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_2)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cedIm1233:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_2)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cedIm1313:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_3)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cedIm1322:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_3)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cedIm1323:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cedIm1333:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_3)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cedIm2223:
       real: true
       tex: i (\bar e_2 \gamma_\mu e_2)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cedIm2323:
-      real: true
-      tex: i (\bar e_2 \gamma_\mu e_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cedIm3323:
       real: true
       tex: i (\bar e_3 \gamma_\mu e_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cedIm1231:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_2)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cedIm1223:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_2)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cedIm1332:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_3)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cedIm1211:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_2)(\bar d_1 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cedIm1311:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_3)(\bar d_1 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cedIm1312:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_3)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cedIm1321:
-      real: true
-      tex: i (\bar e_1 \gamma_\mu e_3)(\bar d_2 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
     cedIm2212:
       real: true
       tex: i (\bar e_2 \gamma_\mu e_2)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
     cedIm2213:
       real: true
       tex: i (\bar e_2 \gamma_\mu e_2)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cedIm2311:
-      real: true
-      tex: i (\bar e_2 \gamma_\mu e_3)(\bar d_1 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cedIm2312:
-      real: true
-      tex: i (\bar e_2 \gamma_\mu e_3)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cedIm2313:
-      real: true
-      tex: i (\bar e_2 \gamma_\mu e_3)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cedIm2321:
-      real: true
-      tex: i (\bar e_2 \gamma_\mu e_3)(\bar d_2 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cedIm2322:
-      real: true
-      tex: i (\bar e_2 \gamma_\mu e_3)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cedIm2331:
-      real: true
-      tex: i (\bar e_2 \gamma_\mu e_3)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cedIm2333:
-      real: true
-      tex: i (\bar e_2 \gamma_\mu e_3)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cedIm3312:
       real: true
       tex: i (\bar e_3 \gamma_\mu e_3)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
@@ -3163,105 +2155,6 @@ sectors:
     cleRe3322:
       real: true
       tex: (\bar \ell_3 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2
-    cleRe1112:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_1)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cleRe1113:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_1)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cleRe1123:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_1)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cleRe1212:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cleRe1213:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cleRe1222:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cleRe1232:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cleRe1233:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cleRe1313:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cleRe1322:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cleRe1323:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cleRe1333:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cleRe2223:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_2)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cleRe2323:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cleRe3323:
-      real: true
-      tex: (\bar \ell_3 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cleRe1231:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_3 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
-    cleRe1223:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cleRe1332:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cleRe1211:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_1 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
-    cleRe1311:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
-    cleRe1312:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cleRe1321:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
-    cleRe2212:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_2)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cleRe2213:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_2)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cleRe2311:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
-    cleRe2312:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cleRe2313:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cleRe2321:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
-    cleRe2322:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cleRe2331:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_3 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
-    cleRe2333:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cleRe3312:
-      real: true
-      tex: (\bar \ell_3 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cleRe3313:
-      real: true
-      tex: (\bar \ell_3 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     cleIm1221:
       real: true
       tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_2 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
@@ -3271,105 +2164,6 @@ sectors:
     cleIm2332:
       real: true
       tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cleIm1112:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_1)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cleIm1113:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_1)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cleIm1123:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_1)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cleIm1212:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cleIm1213:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cleIm1222:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cleIm1232:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cleIm1233:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cleIm1313:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cleIm1322:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cleIm1323:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cleIm1333:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cleIm2223:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_2)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cleIm2323:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cleIm3323:
-      real: true
-      tex: i (\bar \ell_3 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cleIm1231:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_3 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
-    cleIm1223:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cleIm1332:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cleIm1211:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_1 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
-    cleIm1311:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
-    cleIm1312:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cleIm1321:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
-    cleIm2212:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_2)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cleIm2213:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_2)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cleIm2311:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
-    cleIm2312:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cleIm2313:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cleIm2321:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
-    cleIm2322:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cleIm2331:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_3 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
-    cleIm2333:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cleIm3312:
-      real: true
-      tex: i (\bar \ell_3 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cleIm3313:
-      real: true
-      tex: i (\bar \ell_3 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     cluRe1111:
       real: true
       tex: (\bar \ell_1 \gamma_\mu \ell_1)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2
@@ -3388,15 +2182,6 @@ sectors:
     cluRe3333:
       real: true
       tex: (\bar \ell_3 \gamma_\mu \ell_3)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2
-    cluRe1221:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_2 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    cluRe1331:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    cluRe2332:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
     cluRe2211:
       real: true
       tex: (\bar \ell_2 \gamma_\mu \ell_2)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2
@@ -3415,105 +2200,24 @@ sectors:
     cluRe1123:
       real: true
       tex: (\bar \ell_1 \gamma_\mu \ell_1)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    cluRe1212:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    cluRe1213:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    cluRe1222:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    cluRe1232:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    cluRe1233:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    cluRe1313:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    cluRe1322:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    cluRe1323:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    cluRe1333:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     cluRe2223:
       real: true
       tex: (\bar \ell_2 \gamma_\mu \ell_2)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    cluRe2323:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     cluRe3323:
       real: true
       tex: (\bar \ell_3 \gamma_\mu \ell_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    cluRe1231:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    cluRe1223:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    cluRe1332:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    cluRe1211:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    cluRe1311:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    cluRe1312:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    cluRe1321:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_2 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
     cluRe2212:
       real: true
       tex: (\bar \ell_2 \gamma_\mu \ell_2)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
     cluRe2213:
       real: true
       tex: (\bar \ell_2 \gamma_\mu \ell_2)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    cluRe2311:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    cluRe2312:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    cluRe2313:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    cluRe2321:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_2 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    cluRe2322:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    cluRe2331:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    cluRe2333:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     cluRe3312:
       real: true
       tex: (\bar \ell_3 \gamma_\mu \ell_3)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
     cluRe3313:
       real: true
       tex: (\bar \ell_3 \gamma_\mu \ell_3)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    cluIm1221:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_2 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    cluIm1331:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    cluIm2332:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
     cluIm1112:
       real: true
       tex: i (\bar \ell_1 \gamma_\mu \ell_1)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
@@ -3523,90 +2227,18 @@ sectors:
     cluIm1123:
       real: true
       tex: i (\bar \ell_1 \gamma_\mu \ell_1)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    cluIm1212:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    cluIm1213:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    cluIm1222:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    cluIm1232:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    cluIm1233:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    cluIm1313:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    cluIm1322:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    cluIm1323:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    cluIm1333:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     cluIm2223:
       real: true
       tex: i (\bar \ell_2 \gamma_\mu \ell_2)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    cluIm2323:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     cluIm3323:
       real: true
       tex: i (\bar \ell_3 \gamma_\mu \ell_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    cluIm1231:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    cluIm1223:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    cluIm1332:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    cluIm1211:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    cluIm1311:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    cluIm1312:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    cluIm1321:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_2 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
     cluIm2212:
       real: true
       tex: i (\bar \ell_2 \gamma_\mu \ell_2)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
     cluIm2213:
       real: true
       tex: i (\bar \ell_2 \gamma_\mu \ell_2)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    cluIm2311:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    cluIm2312:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    cluIm2313:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
-    cluIm2321:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_2 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    cluIm2322:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
-    cluIm2331:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
-    cluIm2333:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
     cluIm3312:
       real: true
       tex: i (\bar \ell_3 \gamma_\mu \ell_3)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
@@ -3631,15 +2263,6 @@ sectors:
     cldRe3333:
       real: true
       tex: (\bar \ell_3 \gamma_\mu \ell_3)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2
-    cldRe1221:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_2 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cldRe1331:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cldRe2332:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
     cldRe2211:
       real: true
       tex: (\bar \ell_2 \gamma_\mu \ell_2)(\bar d_1 \gamma^\mu d_1) / \text{TeV}^2
@@ -3658,105 +2281,24 @@ sectors:
     cldRe1123:
       real: true
       tex: (\bar \ell_1 \gamma_\mu \ell_1)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cldRe1212:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cldRe1213:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cldRe1222:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cldRe1232:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cldRe1233:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cldRe1313:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cldRe1322:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cldRe1323:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cldRe1333:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cldRe2223:
       real: true
       tex: (\bar \ell_2 \gamma_\mu \ell_2)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cldRe2323:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cldRe3323:
       real: true
       tex: (\bar \ell_3 \gamma_\mu \ell_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cldRe1231:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cldRe1223:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cldRe1332:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cldRe1211:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_1 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cldRe1311:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_1 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cldRe1312:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cldRe1321:
-      real: true
-      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_2 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
     cldRe2212:
       real: true
       tex: (\bar \ell_2 \gamma_\mu \ell_2)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
     cldRe2213:
       real: true
       tex: (\bar \ell_2 \gamma_\mu \ell_2)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cldRe2311:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_1 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cldRe2312:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cldRe2313:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cldRe2321:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_2 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cldRe2322:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cldRe2331:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cldRe2333:
-      real: true
-      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cldRe3312:
       real: true
       tex: (\bar \ell_3 \gamma_\mu \ell_3)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
     cldRe3313:
       real: true
       tex: (\bar \ell_3 \gamma_\mu \ell_3)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cldIm1221:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_2 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cldIm1331:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cldIm2332:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
     cldIm1112:
       real: true
       tex: i (\bar \ell_1 \gamma_\mu \ell_1)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
@@ -3766,90 +2308,18 @@ sectors:
     cldIm1123:
       real: true
       tex: i (\bar \ell_1 \gamma_\mu \ell_1)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cldIm1212:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cldIm1213:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cldIm1222:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cldIm1232:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cldIm1233:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cldIm1313:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cldIm1322:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cldIm1323:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cldIm1333:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cldIm2223:
       real: true
       tex: i (\bar \ell_2 \gamma_\mu \ell_2)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cldIm2323:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cldIm3323:
       real: true
       tex: i (\bar \ell_3 \gamma_\mu \ell_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cldIm1231:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cldIm1223:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cldIm1332:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cldIm1211:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_1 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cldIm1311:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_1 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cldIm1312:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cldIm1321:
-      real: true
-      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_2 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
     cldIm2212:
       real: true
       tex: i (\bar \ell_2 \gamma_\mu \ell_2)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
     cldIm2213:
       real: true
       tex: i (\bar \ell_2 \gamma_\mu \ell_2)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cldIm2311:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_1 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cldIm2312:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cldIm2313:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
-    cldIm2321:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_2 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cldIm2322:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
-    cldIm2331:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
-    cldIm2333:
-      real: true
-      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
     cldIm3312:
       real: true
       tex: i (\bar \ell_3 \gamma_\mu \ell_3)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
@@ -3874,15 +2344,6 @@ sectors:
     cqeRe3333:
       real: true
       tex: (\bar q_3 \gamma_\mu q_3)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2
-    cqeRe1221:
-      real: true
-      tex: (\bar q_1 \gamma_\mu q_2)(\bar e_2 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
-    cqeRe1331:
-      real: true
-      tex: (\bar q_1 \gamma_\mu q_3)(\bar e_3 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
-    cqeRe2332:
-      real: true
-      tex: (\bar q_2 \gamma_\mu q_3)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
     cqeRe2211:
       real: true
       tex: (\bar q_2 \gamma_\mu q_2)(\bar e_1 \gamma^\mu e_1) / \text{TeV}^2
@@ -3892,213 +2353,60 @@ sectors:
     cqeRe3322:
       real: true
       tex: (\bar q_3 \gamma_\mu q_3)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2
-    cqeRe1112:
-      real: true
-      tex: (\bar q_1 \gamma_\mu q_1)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cqeRe1113:
-      real: true
-      tex: (\bar q_1 \gamma_\mu q_1)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cqeRe1123:
-      real: true
-      tex: (\bar q_1 \gamma_\mu q_1)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cqeRe1212:
-      real: true
-      tex: (\bar q_1 \gamma_\mu q_2)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cqeRe1213:
-      real: true
-      tex: (\bar q_1 \gamma_\mu q_2)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     cqeRe1222:
       real: true
       tex: (\bar q_1 \gamma_\mu q_2)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cqeRe1232:
-      real: true
-      tex: (\bar q_1 \gamma_\mu q_2)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
     cqeRe1233:
       real: true
       tex: (\bar q_1 \gamma_\mu q_2)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cqeRe1313:
-      real: true
-      tex: (\bar q_1 \gamma_\mu q_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     cqeRe1322:
       real: true
       tex: (\bar q_1 \gamma_\mu q_3)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cqeRe1323:
-      real: true
-      tex: (\bar q_1 \gamma_\mu q_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     cqeRe1333:
       real: true
       tex: (\bar q_1 \gamma_\mu q_3)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cqeRe2223:
-      real: true
-      tex: (\bar q_2 \gamma_\mu q_2)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cqeRe2323:
-      real: true
-      tex: (\bar q_2 \gamma_\mu q_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cqeRe3323:
-      real: true
-      tex: (\bar q_3 \gamma_\mu q_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cqeRe1231:
-      real: true
-      tex: (\bar q_1 \gamma_\mu q_2)(\bar e_3 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
-    cqeRe1223:
-      real: true
-      tex: (\bar q_1 \gamma_\mu q_2)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cqeRe1332:
-      real: true
-      tex: (\bar q_1 \gamma_\mu q_3)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
     cqeRe1211:
       real: true
       tex: (\bar q_1 \gamma_\mu q_2)(\bar e_1 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
     cqeRe1311:
       real: true
       tex: (\bar q_1 \gamma_\mu q_3)(\bar e_1 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
-    cqeRe1312:
-      real: true
-      tex: (\bar q_1 \gamma_\mu q_3)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cqeRe1321:
-      real: true
-      tex: (\bar q_1 \gamma_\mu q_3)(\bar e_2 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
-    cqeRe2212:
-      real: true
-      tex: (\bar q_2 \gamma_\mu q_2)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cqeRe2213:
-      real: true
-      tex: (\bar q_2 \gamma_\mu q_2)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     cqeRe2311:
       real: true
       tex: (\bar q_2 \gamma_\mu q_3)(\bar e_1 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
-    cqeRe2312:
-      real: true
-      tex: (\bar q_2 \gamma_\mu q_3)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cqeRe2313:
-      real: true
-      tex: (\bar q_2 \gamma_\mu q_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cqeRe2321:
-      real: true
-      tex: (\bar q_2 \gamma_\mu q_3)(\bar e_2 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
     cqeRe2322:
       real: true
       tex: (\bar q_2 \gamma_\mu q_3)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cqeRe2331:
-      real: true
-      tex: (\bar q_2 \gamma_\mu q_3)(\bar e_3 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
     cqeRe2333:
       real: true
       tex: (\bar q_2 \gamma_\mu q_3)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cqeRe3312:
-      real: true
-      tex: (\bar q_3 \gamma_\mu q_3)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cqeRe3313:
-      real: true
-      tex: (\bar q_3 \gamma_\mu q_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cqeIm1221:
-      real: true
-      tex: i (\bar q_1 \gamma_\mu q_2)(\bar e_2 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
-    cqeIm1331:
-      real: true
-      tex: i (\bar q_1 \gamma_\mu q_3)(\bar e_3 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
-    cqeIm2332:
-      real: true
-      tex: i (\bar q_2 \gamma_\mu q_3)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cqeIm1112:
-      real: true
-      tex: i (\bar q_1 \gamma_\mu q_1)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cqeIm1113:
-      real: true
-      tex: i (\bar q_1 \gamma_\mu q_1)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cqeIm1123:
-      real: true
-      tex: i (\bar q_1 \gamma_\mu q_1)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cqeIm1212:
-      real: true
-      tex: i (\bar q_1 \gamma_\mu q_2)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cqeIm1213:
-      real: true
-      tex: i (\bar q_1 \gamma_\mu q_2)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     cqeIm1222:
       real: true
       tex: i (\bar q_1 \gamma_\mu q_2)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cqeIm1232:
-      real: true
-      tex: i (\bar q_1 \gamma_\mu q_2)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
     cqeIm1233:
       real: true
       tex: i (\bar q_1 \gamma_\mu q_2)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cqeIm1313:
-      real: true
-      tex: i (\bar q_1 \gamma_\mu q_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     cqeIm1322:
       real: true
       tex: i (\bar q_1 \gamma_\mu q_3)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cqeIm1323:
-      real: true
-      tex: i (\bar q_1 \gamma_\mu q_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     cqeIm1333:
       real: true
       tex: i (\bar q_1 \gamma_\mu q_3)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cqeIm2223:
-      real: true
-      tex: i (\bar q_2 \gamma_\mu q_2)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cqeIm2323:
-      real: true
-      tex: i (\bar q_2 \gamma_\mu q_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cqeIm3323:
-      real: true
-      tex: i (\bar q_3 \gamma_\mu q_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cqeIm1231:
-      real: true
-      tex: i (\bar q_1 \gamma_\mu q_2)(\bar e_3 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
-    cqeIm1223:
-      real: true
-      tex: i (\bar q_1 \gamma_\mu q_2)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cqeIm1332:
-      real: true
-      tex: i (\bar q_1 \gamma_\mu q_3)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
     cqeIm1211:
       real: true
       tex: i (\bar q_1 \gamma_\mu q_2)(\bar e_1 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
     cqeIm1311:
       real: true
       tex: i (\bar q_1 \gamma_\mu q_3)(\bar e_1 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
-    cqeIm1312:
-      real: true
-      tex: i (\bar q_1 \gamma_\mu q_3)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cqeIm1321:
-      real: true
-      tex: i (\bar q_1 \gamma_\mu q_3)(\bar e_2 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
-    cqeIm2212:
-      real: true
-      tex: i (\bar q_2 \gamma_\mu q_2)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cqeIm2213:
-      real: true
-      tex: i (\bar q_2 \gamma_\mu q_2)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     cqeIm2311:
       real: true
       tex: i (\bar q_2 \gamma_\mu q_3)(\bar e_1 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
-    cqeIm2312:
-      real: true
-      tex: i (\bar q_2 \gamma_\mu q_3)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cqeIm2313:
-      real: true
-      tex: i (\bar q_2 \gamma_\mu q_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cqeIm2321:
-      real: true
-      tex: i (\bar q_2 \gamma_\mu q_3)(\bar e_2 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
     cqeIm2322:
       real: true
       tex: i (\bar q_2 \gamma_\mu q_3)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cqeIm2331:
-      real: true
-      tex: i (\bar q_2 \gamma_\mu q_3)(\bar e_3 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
     cqeIm2333:
       real: true
       tex: i (\bar q_2 \gamma_\mu q_3)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
-    cqeIm3312:
-      real: true
-      tex: i (\bar q_3 \gamma_\mu q_3)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
-    cqeIm3313:
-      real: true
-      tex: i (\bar q_3 \gamma_\mu q_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
     cqu1Re1111:
       real: true
       tex: (\bar q_1 \gamma_\mu q_1)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2
@@ -5098,87 +3406,6 @@ sectors:
     cledqRe1133:
       real: true
       tex: (\bar \ell_1^I e_1)(\bar d_3 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe1211:
-      real: true
-      tex: (\bar \ell_1^I e_2)(\bar d_1 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe1212:
-      real: true
-      tex: (\bar \ell_1^I e_2)(\bar d_1 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe1213:
-      real: true
-      tex: (\bar \ell_1^I e_2)(\bar d_1 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe1221:
-      real: true
-      tex: (\bar \ell_1^I e_2)(\bar d_2 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe1222:
-      real: true
-      tex: (\bar \ell_1^I e_2)(\bar d_2 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe1223:
-      real: true
-      tex: (\bar \ell_1^I e_2)(\bar d_2 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe1231:
-      real: true
-      tex: (\bar \ell_1^I e_2)(\bar d_3 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe1232:
-      real: true
-      tex: (\bar \ell_1^I e_2)(\bar d_3 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe1233:
-      real: true
-      tex: (\bar \ell_1^I e_2)(\bar d_3 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe1311:
-      real: true
-      tex: (\bar \ell_1^I e_3)(\bar d_1 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe1312:
-      real: true
-      tex: (\bar \ell_1^I e_3)(\bar d_1 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe1313:
-      real: true
-      tex: (\bar \ell_1^I e_3)(\bar d_1 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe1321:
-      real: true
-      tex: (\bar \ell_1^I e_3)(\bar d_2 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe1322:
-      real: true
-      tex: (\bar \ell_1^I e_3)(\bar d_2 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe1323:
-      real: true
-      tex: (\bar \ell_1^I e_3)(\bar d_2 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe1331:
-      real: true
-      tex: (\bar \ell_1^I e_3)(\bar d_3 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe1332:
-      real: true
-      tex: (\bar \ell_1^I e_3)(\bar d_3 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe1333:
-      real: true
-      tex: (\bar \ell_1^I e_3)(\bar d_3 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe2111:
-      real: true
-      tex: (\bar \ell_2^I e_1)(\bar d_1 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe2112:
-      real: true
-      tex: (\bar \ell_2^I e_1)(\bar d_1 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe2113:
-      real: true
-      tex: (\bar \ell_2^I e_1)(\bar d_1 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe2121:
-      real: true
-      tex: (\bar \ell_2^I e_1)(\bar d_2 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe2122:
-      real: true
-      tex: (\bar \ell_2^I e_1)(\bar d_2 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe2123:
-      real: true
-      tex: (\bar \ell_2^I e_1)(\bar d_2 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe2131:
-      real: true
-      tex: (\bar \ell_2^I e_1)(\bar d_3 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe2132:
-      real: true
-      tex: (\bar \ell_2^I e_1)(\bar d_3 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe2133:
-      real: true
-      tex: (\bar \ell_2^I e_1)(\bar d_3 q_3^I) / \text{TeV}^2 + \text{h.c.}
     cledqRe2211:
       real: true
       tex: (\bar \ell_2^I e_2)(\bar d_1 q_1^I) / \text{TeV}^2 + \text{h.c.}
@@ -5206,87 +3433,6 @@ sectors:
     cledqRe2233:
       real: true
       tex: (\bar \ell_2^I e_2)(\bar d_3 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe2311:
-      real: true
-      tex: (\bar \ell_2^I e_3)(\bar d_1 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe2312:
-      real: true
-      tex: (\bar \ell_2^I e_3)(\bar d_1 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe2313:
-      real: true
-      tex: (\bar \ell_2^I e_3)(\bar d_1 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe2321:
-      real: true
-      tex: (\bar \ell_2^I e_3)(\bar d_2 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe2322:
-      real: true
-      tex: (\bar \ell_2^I e_3)(\bar d_2 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe2323:
-      real: true
-      tex: (\bar \ell_2^I e_3)(\bar d_2 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe2331:
-      real: true
-      tex: (\bar \ell_2^I e_3)(\bar d_3 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe2332:
-      real: true
-      tex: (\bar \ell_2^I e_3)(\bar d_3 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe2333:
-      real: true
-      tex: (\bar \ell_2^I e_3)(\bar d_3 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe3111:
-      real: true
-      tex: (\bar \ell_3^I e_1)(\bar d_1 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe3112:
-      real: true
-      tex: (\bar \ell_3^I e_1)(\bar d_1 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe3113:
-      real: true
-      tex: (\bar \ell_3^I e_1)(\bar d_1 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe3121:
-      real: true
-      tex: (\bar \ell_3^I e_1)(\bar d_2 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe3122:
-      real: true
-      tex: (\bar \ell_3^I e_1)(\bar d_2 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe3123:
-      real: true
-      tex: (\bar \ell_3^I e_1)(\bar d_2 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe3131:
-      real: true
-      tex: (\bar \ell_3^I e_1)(\bar d_3 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe3132:
-      real: true
-      tex: (\bar \ell_3^I e_1)(\bar d_3 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe3133:
-      real: true
-      tex: (\bar \ell_3^I e_1)(\bar d_3 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe3211:
-      real: true
-      tex: (\bar \ell_3^I e_2)(\bar d_1 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe3212:
-      real: true
-      tex: (\bar \ell_3^I e_2)(\bar d_1 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe3213:
-      real: true
-      tex: (\bar \ell_3^I e_2)(\bar d_1 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe3221:
-      real: true
-      tex: (\bar \ell_3^I e_2)(\bar d_2 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe3222:
-      real: true
-      tex: (\bar \ell_3^I e_2)(\bar d_2 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe3223:
-      real: true
-      tex: (\bar \ell_3^I e_2)(\bar d_2 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe3231:
-      real: true
-      tex: (\bar \ell_3^I e_2)(\bar d_3 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe3232:
-      real: true
-      tex: (\bar \ell_3^I e_2)(\bar d_3 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqRe3233:
-      real: true
-      tex: (\bar \ell_3^I e_2)(\bar d_3 q_3^I) / \text{TeV}^2 + \text{h.c.}
     cledqRe3311:
       real: true
       tex: (\bar \ell_3^I e_3)(\bar d_1 q_1^I) / \text{TeV}^2 + \text{h.c.}
@@ -5341,87 +3487,6 @@ sectors:
     cledqIm1133:
       real: true
       tex: i (\bar \ell_1^I e_1)(\bar d_3 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm1211:
-      real: true
-      tex: i (\bar \ell_1^I e_2)(\bar d_1 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm1212:
-      real: true
-      tex: i (\bar \ell_1^I e_2)(\bar d_1 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm1213:
-      real: true
-      tex: i (\bar \ell_1^I e_2)(\bar d_1 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm1221:
-      real: true
-      tex: i (\bar \ell_1^I e_2)(\bar d_2 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm1222:
-      real: true
-      tex: i (\bar \ell_1^I e_2)(\bar d_2 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm1223:
-      real: true
-      tex: i (\bar \ell_1^I e_2)(\bar d_2 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm1231:
-      real: true
-      tex: i (\bar \ell_1^I e_2)(\bar d_3 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm1232:
-      real: true
-      tex: i (\bar \ell_1^I e_2)(\bar d_3 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm1233:
-      real: true
-      tex: i (\bar \ell_1^I e_2)(\bar d_3 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm1311:
-      real: true
-      tex: i (\bar \ell_1^I e_3)(\bar d_1 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm1312:
-      real: true
-      tex: i (\bar \ell_1^I e_3)(\bar d_1 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm1313:
-      real: true
-      tex: i (\bar \ell_1^I e_3)(\bar d_1 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm1321:
-      real: true
-      tex: i (\bar \ell_1^I e_3)(\bar d_2 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm1322:
-      real: true
-      tex: i (\bar \ell_1^I e_3)(\bar d_2 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm1323:
-      real: true
-      tex: i (\bar \ell_1^I e_3)(\bar d_2 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm1331:
-      real: true
-      tex: i (\bar \ell_1^I e_3)(\bar d_3 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm1332:
-      real: true
-      tex: i (\bar \ell_1^I e_3)(\bar d_3 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm1333:
-      real: true
-      tex: i (\bar \ell_1^I e_3)(\bar d_3 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm2111:
-      real: true
-      tex: i (\bar \ell_2^I e_1)(\bar d_1 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm2112:
-      real: true
-      tex: i (\bar \ell_2^I e_1)(\bar d_1 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm2113:
-      real: true
-      tex: i (\bar \ell_2^I e_1)(\bar d_1 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm2121:
-      real: true
-      tex: i (\bar \ell_2^I e_1)(\bar d_2 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm2122:
-      real: true
-      tex: i (\bar \ell_2^I e_1)(\bar d_2 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm2123:
-      real: true
-      tex: i (\bar \ell_2^I e_1)(\bar d_2 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm2131:
-      real: true
-      tex: i (\bar \ell_2^I e_1)(\bar d_3 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm2132:
-      real: true
-      tex: i (\bar \ell_2^I e_1)(\bar d_3 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm2133:
-      real: true
-      tex: i (\bar \ell_2^I e_1)(\bar d_3 q_3^I) / \text{TeV}^2 + \text{h.c.}
     cledqIm2211:
       real: true
       tex: i (\bar \ell_2^I e_2)(\bar d_1 q_1^I) / \text{TeV}^2 + \text{h.c.}
@@ -5449,87 +3514,6 @@ sectors:
     cledqIm2233:
       real: true
       tex: i (\bar \ell_2^I e_2)(\bar d_3 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm2311:
-      real: true
-      tex: i (\bar \ell_2^I e_3)(\bar d_1 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm2312:
-      real: true
-      tex: i (\bar \ell_2^I e_3)(\bar d_1 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm2313:
-      real: true
-      tex: i (\bar \ell_2^I e_3)(\bar d_1 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm2321:
-      real: true
-      tex: i (\bar \ell_2^I e_3)(\bar d_2 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm2322:
-      real: true
-      tex: i (\bar \ell_2^I e_3)(\bar d_2 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm2323:
-      real: true
-      tex: i (\bar \ell_2^I e_3)(\bar d_2 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm2331:
-      real: true
-      tex: i (\bar \ell_2^I e_3)(\bar d_3 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm2332:
-      real: true
-      tex: i (\bar \ell_2^I e_3)(\bar d_3 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm2333:
-      real: true
-      tex: i (\bar \ell_2^I e_3)(\bar d_3 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm3111:
-      real: true
-      tex: i (\bar \ell_3^I e_1)(\bar d_1 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm3112:
-      real: true
-      tex: i (\bar \ell_3^I e_1)(\bar d_1 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm3113:
-      real: true
-      tex: i (\bar \ell_3^I e_1)(\bar d_1 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm3121:
-      real: true
-      tex: i (\bar \ell_3^I e_1)(\bar d_2 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm3122:
-      real: true
-      tex: i (\bar \ell_3^I e_1)(\bar d_2 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm3123:
-      real: true
-      tex: i (\bar \ell_3^I e_1)(\bar d_2 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm3131:
-      real: true
-      tex: i (\bar \ell_3^I e_1)(\bar d_3 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm3132:
-      real: true
-      tex: i (\bar \ell_3^I e_1)(\bar d_3 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm3133:
-      real: true
-      tex: i (\bar \ell_3^I e_1)(\bar d_3 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm3211:
-      real: true
-      tex: i (\bar \ell_3^I e_2)(\bar d_1 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm3212:
-      real: true
-      tex: i (\bar \ell_3^I e_2)(\bar d_1 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm3213:
-      real: true
-      tex: i (\bar \ell_3^I e_2)(\bar d_1 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm3221:
-      real: true
-      tex: i (\bar \ell_3^I e_2)(\bar d_2 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm3222:
-      real: true
-      tex: i (\bar \ell_3^I e_2)(\bar d_2 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm3223:
-      real: true
-      tex: i (\bar \ell_3^I e_2)(\bar d_2 q_3^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm3231:
-      real: true
-      tex: i (\bar \ell_3^I e_2)(\bar d_3 q_1^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm3232:
-      real: true
-      tex: i (\bar \ell_3^I e_2)(\bar d_3 q_2^I) / \text{TeV}^2 + \text{h.c.}
-    cledqIm3233:
-      real: true
-      tex: i (\bar \ell_3^I e_2)(\bar d_3 q_3^I) / \text{TeV}^2 + \text{h.c.}
     cledqIm3311:
       real: true
       tex: i (\bar \ell_3^I e_3)(\bar d_1 q_1^I) / \text{TeV}^2 + \text{h.c.}
@@ -6556,87 +4540,6 @@ sectors:
     clequ1Re1133:
       real: true
       tex: (\bar \ell_1^I e_1)(\bar q^J_3 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re1211:
-      real: true
-      tex: (\bar \ell_1^I e_2)(\bar q^J_1 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re1212:
-      real: true
-      tex: (\bar \ell_1^I e_2)(\bar q^J_1 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re1213:
-      real: true
-      tex: (\bar \ell_1^I e_2)(\bar q^J_1 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re1221:
-      real: true
-      tex: (\bar \ell_1^I e_2)(\bar q^J_2 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re1222:
-      real: true
-      tex: (\bar \ell_1^I e_2)(\bar q^J_2 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re1223:
-      real: true
-      tex: (\bar \ell_1^I e_2)(\bar q^J_2 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re1231:
-      real: true
-      tex: (\bar \ell_1^I e_2)(\bar q^J_3 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re1232:
-      real: true
-      tex: (\bar \ell_1^I e_2)(\bar q^J_3 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re1233:
-      real: true
-      tex: (\bar \ell_1^I e_2)(\bar q^J_3 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re1311:
-      real: true
-      tex: (\bar \ell_1^I e_3)(\bar q^J_1 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re1312:
-      real: true
-      tex: (\bar \ell_1^I e_3)(\bar q^J_1 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re1313:
-      real: true
-      tex: (\bar \ell_1^I e_3)(\bar q^J_1 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re1321:
-      real: true
-      tex: (\bar \ell_1^I e_3)(\bar q^J_2 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re1322:
-      real: true
-      tex: (\bar \ell_1^I e_3)(\bar q^J_2 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re1323:
-      real: true
-      tex: (\bar \ell_1^I e_3)(\bar q^J_2 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re1331:
-      real: true
-      tex: (\bar \ell_1^I e_3)(\bar q^J_3 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re1332:
-      real: true
-      tex: (\bar \ell_1^I e_3)(\bar q^J_3 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re1333:
-      real: true
-      tex: (\bar \ell_1^I e_3)(\bar q^J_3 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re2111:
-      real: true
-      tex: (\bar \ell_2^I e_1)(\bar q^J_1 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re2112:
-      real: true
-      tex: (\bar \ell_2^I e_1)(\bar q^J_1 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re2113:
-      real: true
-      tex: (\bar \ell_2^I e_1)(\bar q^J_1 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re2121:
-      real: true
-      tex: (\bar \ell_2^I e_1)(\bar q^J_2 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re2122:
-      real: true
-      tex: (\bar \ell_2^I e_1)(\bar q^J_2 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re2123:
-      real: true
-      tex: (\bar \ell_2^I e_1)(\bar q^J_2 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re2131:
-      real: true
-      tex: (\bar \ell_2^I e_1)(\bar q^J_3 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re2132:
-      real: true
-      tex: (\bar \ell_2^I e_1)(\bar q^J_3 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re2133:
-      real: true
-      tex: (\bar \ell_2^I e_1)(\bar q^J_3 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
     clequ1Re2211:
       real: true
       tex: (\bar \ell_2^I e_2)(\bar q^J_1 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
@@ -6664,87 +4567,6 @@ sectors:
     clequ1Re2233:
       real: true
       tex: (\bar \ell_2^I e_2)(\bar q^J_3 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re2311:
-      real: true
-      tex: (\bar \ell_2^I e_3)(\bar q^J_1 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re2312:
-      real: true
-      tex: (\bar \ell_2^I e_3)(\bar q^J_1 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re2313:
-      real: true
-      tex: (\bar \ell_2^I e_3)(\bar q^J_1 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re2321:
-      real: true
-      tex: (\bar \ell_2^I e_3)(\bar q^J_2 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re2322:
-      real: true
-      tex: (\bar \ell_2^I e_3)(\bar q^J_2 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re2323:
-      real: true
-      tex: (\bar \ell_2^I e_3)(\bar q^J_2 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re2331:
-      real: true
-      tex: (\bar \ell_2^I e_3)(\bar q^J_3 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re2332:
-      real: true
-      tex: (\bar \ell_2^I e_3)(\bar q^J_3 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re2333:
-      real: true
-      tex: (\bar \ell_2^I e_3)(\bar q^J_3 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re3111:
-      real: true
-      tex: (\bar \ell_3^I e_1)(\bar q^J_1 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re3112:
-      real: true
-      tex: (\bar \ell_3^I e_1)(\bar q^J_1 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re3113:
-      real: true
-      tex: (\bar \ell_3^I e_1)(\bar q^J_1 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re3121:
-      real: true
-      tex: (\bar \ell_3^I e_1)(\bar q^J_2 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re3122:
-      real: true
-      tex: (\bar \ell_3^I e_1)(\bar q^J_2 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re3123:
-      real: true
-      tex: (\bar \ell_3^I e_1)(\bar q^J_2 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re3131:
-      real: true
-      tex: (\bar \ell_3^I e_1)(\bar q^J_3 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re3132:
-      real: true
-      tex: (\bar \ell_3^I e_1)(\bar q^J_3 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re3133:
-      real: true
-      tex: (\bar \ell_3^I e_1)(\bar q^J_3 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re3211:
-      real: true
-      tex: (\bar \ell_3^I e_2)(\bar q^J_1 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re3212:
-      real: true
-      tex: (\bar \ell_3^I e_2)(\bar q^J_1 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re3213:
-      real: true
-      tex: (\bar \ell_3^I e_2)(\bar q^J_1 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re3221:
-      real: true
-      tex: (\bar \ell_3^I e_2)(\bar q^J_2 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re3222:
-      real: true
-      tex: (\bar \ell_3^I e_2)(\bar q^J_2 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re3223:
-      real: true
-      tex: (\bar \ell_3^I e_2)(\bar q^J_2 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re3231:
-      real: true
-      tex: (\bar \ell_3^I e_2)(\bar q^J_3 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re3232:
-      real: true
-      tex: (\bar \ell_3^I e_2)(\bar q^J_3 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Re3233:
-      real: true
-      tex: (\bar \ell_3^I e_2)(\bar q^J_3 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
     clequ1Re3311:
       real: true
       tex: (\bar \ell_3^I e_3)(\bar q^J_1 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
@@ -6799,87 +4621,6 @@ sectors:
     clequ1Im1133:
       real: true
       tex: i (\bar \ell_1^I e_1)(\bar q^J_3 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im1211:
-      real: true
-      tex: i (\bar \ell_1^I e_2)(\bar q^J_1 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im1212:
-      real: true
-      tex: i (\bar \ell_1^I e_2)(\bar q^J_1 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im1213:
-      real: true
-      tex: i (\bar \ell_1^I e_2)(\bar q^J_1 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im1221:
-      real: true
-      tex: i (\bar \ell_1^I e_2)(\bar q^J_2 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im1222:
-      real: true
-      tex: i (\bar \ell_1^I e_2)(\bar q^J_2 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im1223:
-      real: true
-      tex: i (\bar \ell_1^I e_2)(\bar q^J_2 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im1231:
-      real: true
-      tex: i (\bar \ell_1^I e_2)(\bar q^J_3 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im1232:
-      real: true
-      tex: i (\bar \ell_1^I e_2)(\bar q^J_3 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im1233:
-      real: true
-      tex: i (\bar \ell_1^I e_2)(\bar q^J_3 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im1311:
-      real: true
-      tex: i (\bar \ell_1^I e_3)(\bar q^J_1 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im1312:
-      real: true
-      tex: i (\bar \ell_1^I e_3)(\bar q^J_1 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im1313:
-      real: true
-      tex: i (\bar \ell_1^I e_3)(\bar q^J_1 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im1321:
-      real: true
-      tex: i (\bar \ell_1^I e_3)(\bar q^J_2 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im1322:
-      real: true
-      tex: i (\bar \ell_1^I e_3)(\bar q^J_2 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im1323:
-      real: true
-      tex: i (\bar \ell_1^I e_3)(\bar q^J_2 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im1331:
-      real: true
-      tex: i (\bar \ell_1^I e_3)(\bar q^J_3 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im1332:
-      real: true
-      tex: i (\bar \ell_1^I e_3)(\bar q^J_3 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im1333:
-      real: true
-      tex: i (\bar \ell_1^I e_3)(\bar q^J_3 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im2111:
-      real: true
-      tex: i (\bar \ell_2^I e_1)(\bar q^J_1 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im2112:
-      real: true
-      tex: i (\bar \ell_2^I e_1)(\bar q^J_1 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im2113:
-      real: true
-      tex: i (\bar \ell_2^I e_1)(\bar q^J_1 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im2121:
-      real: true
-      tex: i (\bar \ell_2^I e_1)(\bar q^J_2 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im2122:
-      real: true
-      tex: i (\bar \ell_2^I e_1)(\bar q^J_2 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im2123:
-      real: true
-      tex: i (\bar \ell_2^I e_1)(\bar q^J_2 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im2131:
-      real: true
-      tex: i (\bar \ell_2^I e_1)(\bar q^J_3 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im2132:
-      real: true
-      tex: i (\bar \ell_2^I e_1)(\bar q^J_3 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im2133:
-      real: true
-      tex: i (\bar \ell_2^I e_1)(\bar q^J_3 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
     clequ1Im2211:
       real: true
       tex: i (\bar \ell_2^I e_2)(\bar q^J_1 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
@@ -6907,87 +4648,6 @@ sectors:
     clequ1Im2233:
       real: true
       tex: i (\bar \ell_2^I e_2)(\bar q^J_3 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im2311:
-      real: true
-      tex: i (\bar \ell_2^I e_3)(\bar q^J_1 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im2312:
-      real: true
-      tex: i (\bar \ell_2^I e_3)(\bar q^J_1 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im2313:
-      real: true
-      tex: i (\bar \ell_2^I e_3)(\bar q^J_1 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im2321:
-      real: true
-      tex: i (\bar \ell_2^I e_3)(\bar q^J_2 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im2322:
-      real: true
-      tex: i (\bar \ell_2^I e_3)(\bar q^J_2 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im2323:
-      real: true
-      tex: i (\bar \ell_2^I e_3)(\bar q^J_2 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im2331:
-      real: true
-      tex: i (\bar \ell_2^I e_3)(\bar q^J_3 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im2332:
-      real: true
-      tex: i (\bar \ell_2^I e_3)(\bar q^J_3 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im2333:
-      real: true
-      tex: i (\bar \ell_2^I e_3)(\bar q^J_3 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im3111:
-      real: true
-      tex: i (\bar \ell_3^I e_1)(\bar q^J_1 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im3112:
-      real: true
-      tex: i (\bar \ell_3^I e_1)(\bar q^J_1 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im3113:
-      real: true
-      tex: i (\bar \ell_3^I e_1)(\bar q^J_1 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im3121:
-      real: true
-      tex: i (\bar \ell_3^I e_1)(\bar q^J_2 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im3122:
-      real: true
-      tex: i (\bar \ell_3^I e_1)(\bar q^J_2 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im3123:
-      real: true
-      tex: i (\bar \ell_3^I e_1)(\bar q^J_2 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im3131:
-      real: true
-      tex: i (\bar \ell_3^I e_1)(\bar q^J_3 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im3132:
-      real: true
-      tex: i (\bar \ell_3^I e_1)(\bar q^J_3 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im3133:
-      real: true
-      tex: i (\bar \ell_3^I e_1)(\bar q^J_3 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im3211:
-      real: true
-      tex: i (\bar \ell_3^I e_2)(\bar q^J_1 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im3212:
-      real: true
-      tex: i (\bar \ell_3^I e_2)(\bar q^J_1 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im3213:
-      real: true
-      tex: i (\bar \ell_3^I e_2)(\bar q^J_1 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im3221:
-      real: true
-      tex: i (\bar \ell_3^I e_2)(\bar q^J_2 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im3222:
-      real: true
-      tex: i (\bar \ell_3^I e_2)(\bar q^J_2 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im3223:
-      real: true
-      tex: i (\bar \ell_3^I e_2)(\bar q^J_2 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im3231:
-      real: true
-      tex: i (\bar \ell_3^I e_2)(\bar q^J_3 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im3232:
-      real: true
-      tex: i (\bar \ell_3^I e_2)(\bar q^J_3 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ1Im3233:
-      real: true
-      tex: i (\bar \ell_3^I e_2)(\bar q^J_3 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
     clequ1Im3311:
       real: true
       tex: i (\bar \ell_3^I e_3)(\bar q^J_1 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
@@ -7042,87 +4702,6 @@ sectors:
     clequ3Re1133:
       real: true
       tex: (\bar \ell_1^I \sigma_{\mu\nu} e_1)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re1211:
-      real: true
-      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_1 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re1212:
-      real: true
-      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_1 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re1213:
-      real: true
-      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_1 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re1221:
-      real: true
-      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_2 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re1222:
-      real: true
-      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_2 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re1223:
-      real: true
-      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_2 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re1231:
-      real: true
-      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_3 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re1232:
-      real: true
-      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_3 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re1233:
-      real: true
-      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re1311:
-      real: true
-      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_1 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re1312:
-      real: true
-      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_1 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re1313:
-      real: true
-      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_1 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re1321:
-      real: true
-      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_2 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re1322:
-      real: true
-      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_2 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re1323:
-      real: true
-      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_2 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re1331:
-      real: true
-      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_3 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re1332:
-      real: true
-      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_3 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re1333:
-      real: true
-      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re2111:
-      real: true
-      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_1 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re2112:
-      real: true
-      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_1 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re2113:
-      real: true
-      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_1 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re2121:
-      real: true
-      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_2 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re2122:
-      real: true
-      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_2 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re2123:
-      real: true
-      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_2 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re2131:
-      real: true
-      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_3 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re2132:
-      real: true
-      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_3 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re2133:
-      real: true
-      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
     clequ3Re2211:
       real: true
       tex: (\bar \ell_2^I \sigma_{\mu\nu} e_2)(\bar q^J_1 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
@@ -7150,87 +4729,6 @@ sectors:
     clequ3Re2233:
       real: true
       tex: (\bar \ell_2^I \sigma_{\mu\nu} e_2)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re2311:
-      real: true
-      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_1 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re2312:
-      real: true
-      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_1 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re2313:
-      real: true
-      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_1 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re2321:
-      real: true
-      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_2 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re2322:
-      real: true
-      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_2 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re2323:
-      real: true
-      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_2 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re2331:
-      real: true
-      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_3 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re2332:
-      real: true
-      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_3 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re2333:
-      real: true
-      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re3111:
-      real: true
-      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_1 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re3112:
-      real: true
-      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_1 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re3113:
-      real: true
-      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_1 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re3121:
-      real: true
-      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_2 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re3122:
-      real: true
-      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_2 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re3123:
-      real: true
-      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_2 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re3131:
-      real: true
-      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_3 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re3132:
-      real: true
-      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_3 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re3133:
-      real: true
-      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re3211:
-      real: true
-      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_1 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re3212:
-      real: true
-      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_1 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re3213:
-      real: true
-      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_1 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re3221:
-      real: true
-      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_2 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re3222:
-      real: true
-      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_2 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re3223:
-      real: true
-      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_2 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re3231:
-      real: true
-      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_3 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re3232:
-      real: true
-      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_3 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Re3233:
-      real: true
-      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
     clequ3Re3311:
       real: true
       tex: (\bar \ell_3^I \sigma_{\mu\nu} e_3)(\bar q^J_1 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
@@ -7285,87 +4783,6 @@ sectors:
     clequ3Im1133:
       real: true
       tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_1)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im1211:
-      real: true
-      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_1 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im1212:
-      real: true
-      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_1 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im1213:
-      real: true
-      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_1 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im1221:
-      real: true
-      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_2 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im1222:
-      real: true
-      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_2 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im1223:
-      real: true
-      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_2 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im1231:
-      real: true
-      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_3 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im1232:
-      real: true
-      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_3 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im1233:
-      real: true
-      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im1311:
-      real: true
-      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_1 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im1312:
-      real: true
-      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_1 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im1313:
-      real: true
-      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_1 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im1321:
-      real: true
-      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_2 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im1322:
-      real: true
-      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_2 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im1323:
-      real: true
-      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_2 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im1331:
-      real: true
-      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_3 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im1332:
-      real: true
-      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_3 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im1333:
-      real: true
-      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im2111:
-      real: true
-      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_1 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im2112:
-      real: true
-      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_1 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im2113:
-      real: true
-      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_1 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im2121:
-      real: true
-      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_2 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im2122:
-      real: true
-      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_2 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im2123:
-      real: true
-      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_2 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im2131:
-      real: true
-      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_3 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im2132:
-      real: true
-      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_3 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im2133:
-      real: true
-      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
     clequ3Im2211:
       real: true
       tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_2)(\bar q^J_1 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
@@ -7393,87 +4810,6 @@ sectors:
     clequ3Im2233:
       real: true
       tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_2)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im2311:
-      real: true
-      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_1 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im2312:
-      real: true
-      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_1 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im2313:
-      real: true
-      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_1 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im2321:
-      real: true
-      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_2 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im2322:
-      real: true
-      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_2 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im2323:
-      real: true
-      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_2 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im2331:
-      real: true
-      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_3 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im2332:
-      real: true
-      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_3 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im2333:
-      real: true
-      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im3111:
-      real: true
-      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_1 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im3112:
-      real: true
-      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_1 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im3113:
-      real: true
-      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_1 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im3121:
-      real: true
-      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_2 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im3122:
-      real: true
-      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_2 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im3123:
-      real: true
-      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_2 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im3131:
-      real: true
-      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_3 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im3132:
-      real: true
-      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_3 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im3133:
-      real: true
-      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im3211:
-      real: true
-      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_1 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im3212:
-      real: true
-      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_1 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im3213:
-      real: true
-      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_1 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im3221:
-      real: true
-      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_2 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im3222:
-      real: true
-      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_2 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im3223:
-      real: true
-      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_2 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im3231:
-      real: true
-      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_3 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im3232:
-      real: true
-      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_3 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
-    clequ3Im3233:
-      real: true
-      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
     clequ3Im3311:
       real: true
       tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_3)(\bar q^J_1 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
@@ -7501,3 +4837,2676 @@ sectors:
     clequ3Im3333:
       real: true
       tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_3)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+  mue:
+    ceHRe12:
+      real: true
+      tex: (\bar \ell_1 H e_2) (H^\dagger H) / \text{TeV}^2 + \text{h.c.}
+    ceHRe21:
+      real: true
+      tex: (\bar \ell_2 H e_1) (H^\dagger H) / \text{TeV}^2 + \text{h.c.}
+    ceHIm12:
+      real: true
+      tex: i (\bar \ell_1 H e_2) (H^\dagger H) / \text{TeV}^2 + \text{h.c.}
+    ceHIm21:
+      real: true
+      tex: i (\bar \ell_2 H e_1) (H^\dagger H) / \text{TeV}^2 + \text{h.c.}
+    ceWRe12:
+      real: true
+      tex: (\bar \ell_1 \sigma^I H \sigma^{\mu\nu} e_2) W^I_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
+    ceWRe21:
+      real: true
+      tex: (\bar \ell_2 \sigma^I H \sigma^{\mu\nu} e_1) W^I_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
+    ceWIm12:
+      real: true
+      tex: i (\bar \ell_1 \sigma^I H \sigma^{\mu\nu} e_2) W^I_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
+    ceWIm21:
+      real: true
+      tex: i (\bar \ell_2 \sigma^I H \sigma^{\mu\nu} e_1) W^I_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
+    ceBRe12:
+      real: true
+      tex: (\bar \ell_1 H  \sigma^{\mu\nu} e_2) B_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
+    ceBRe21:
+      real: true
+      tex: (\bar \ell_2 H  \sigma^{\mu\nu} e_1) B_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
+    ceBIm12:
+      real: true
+      tex: i (\bar \ell_1 H  \sigma^{\mu\nu} e_2) B_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
+    ceBIm21:
+      real: true
+      tex: i (\bar \ell_2 H  \sigma^{\mu\nu} e_1) B_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
+    cHl1Re12:
+      real: true
+      tex: (H^\dagger i \overleftrightarrow D_\mu H) (\bar \ell_1 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
+    cHl1Im12:
+      real: true
+      tex: i (H^\dagger i \overleftrightarrow D_\mu H) (\bar \ell_1 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
+    cHl3Re12:
+      real: true
+      tex: (H^\dagger i \overleftrightarrow D_\mu^I H) (\bar \ell_1 \gamma^\mu \sigma^I \ell_2) / \text{TeV}^2 + \text{h.c.}
+    cHl3Im12:
+      real: true
+      tex: i (H^\dagger i \overleftrightarrow D_\mu^I H) (\bar \ell_1 \gamma^\mu \sigma^I \ell_2) / \text{TeV}^2 + \text{h.c.}
+    cHeRe12:
+      real: true
+      tex: (H^\dagger i \overleftrightarrow D_\mu H) (\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cHeIm12:
+      real: true
+      tex: i (H^\dagger i \overleftrightarrow D_\mu H) (\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cllRe1112:
+      real: true
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_1)(\bar \ell_1 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
+    cllRe1222:
+      real: true
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_2 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
+    cllRe1233:
+      real: true
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_3 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+    cllRe1332:
+      real: true
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_3 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
+    cllIm1112:
+      real: true
+      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_1)(\bar \ell_1 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
+    cllIm1222:
+      real: true
+      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_2 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
+    cllIm1233:
+      real: true
+      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_3 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+    cllIm1332:
+      real: true
+      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_3 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
+    clq1Re1221:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_2 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
+    clq1Re1212:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_1 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
+    clq1Re1213:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_1 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+    clq1Re1222:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_2 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
+    clq1Re1232:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_3 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
+    clq1Re1233:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_3 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+    clq1Re1231:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_3 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
+    clq1Re1223:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+    clq1Re1211:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_1 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
+    clq1Im1221:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_2 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
+    clq1Im1212:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_1 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
+    clq1Im1213:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_1 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+    clq1Im1222:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_2 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
+    clq1Im1232:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_3 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
+    clq1Im1233:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_3 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+    clq1Im1231:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_3 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
+    clq1Im1223:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+    clq1Im1211:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar q_1 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
+    clq3Re1221:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_2 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
+    clq3Re1212:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_1 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
+    clq3Re1213:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_1 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+    clq3Re1222:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_2 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
+    clq3Re1232:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_3 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
+    clq3Re1233:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_3 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+    clq3Re1231:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_3 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
+    clq3Re1223:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+    clq3Re1211:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_1 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
+    clq3Im1221:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_2 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
+    clq3Im1212:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_1 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
+    clq3Im1213:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_1 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+    clq3Im1222:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_2 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
+    clq3Im1232:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_3 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
+    clq3Im1233:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_3 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+    clq3Im1231:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_3 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
+    clq3Im1223:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+    clq3Im1211:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_2)(\bar q_1 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
+    ceeRe1112:
+      real: true
+      tex: 2 (\bar e_1 \gamma_\mu e_1)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    ceeRe1222:
+      real: true
+      tex: 2 (\bar e_1 \gamma_\mu e_2)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    ceeRe1233:
+      real: true
+      tex: 4 (\bar e_1 \gamma_\mu e_2)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    ceeIm1112:
+      real: true
+      tex: 2 i (\bar e_1 \gamma_\mu e_1)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    ceeIm1222:
+      real: true
+      tex: 2 i (\bar e_1 \gamma_\mu e_2)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    ceeIm1233:
+      real: true
+      tex: 4 i (\bar e_1 \gamma_\mu e_2)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    ceuRe1221:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_2)(\bar u_2 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    ceuRe1212:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_2)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    ceuRe1213:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_2)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    ceuRe1222:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_2)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    ceuRe1232:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_2)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    ceuRe1233:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_2)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    ceuRe1231:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_2)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    ceuRe1223:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_2)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    ceuRe1211:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_2)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    ceuIm1221:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_2)(\bar u_2 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    ceuIm1212:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_2)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    ceuIm1213:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_2)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    ceuIm1222:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_2)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    ceuIm1232:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_2)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    ceuIm1233:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_2)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    ceuIm1231:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_2)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    ceuIm1223:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_2)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    ceuIm1211:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_2)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    cedRe1221:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_2)(\bar d_2 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cedRe1212:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_2)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cedRe1213:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_2)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cedRe1222:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_2)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cedRe1232:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_2)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cedRe1233:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_2)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cedRe1231:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_2)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cedRe1223:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_2)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cedRe1211:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_2)(\bar d_1 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cedIm1221:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_2)(\bar d_2 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cedIm1212:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_2)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cedIm1213:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_2)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cedIm1222:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_2)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cedIm1232:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_2)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cedIm1233:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_2)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cedIm1231:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_2)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cedIm1223:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_2)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cedIm1211:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_2)(\bar d_1 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cleRe1112:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_1)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cleRe1222:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cleRe1233:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleRe1332:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cleRe1211:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_1 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
+    cleRe2212:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_2)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cleRe2331:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_3 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
+    cleRe3312:
+      real: true
+      tex: (\bar \ell_3 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cleIm1112:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_1)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cleIm1222:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cleIm1233:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleIm1332:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cleIm1211:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_1 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
+    cleIm2212:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_2)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cleIm2331:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_3 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
+    cleIm3312:
+      real: true
+      tex: i (\bar \ell_3 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cluRe1221:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_2 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    cluRe1212:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    cluRe1213:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    cluRe1222:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    cluRe1232:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    cluRe1233:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    cluRe1231:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    cluRe1223:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    cluRe1211:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    cluIm1221:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_2 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    cluIm1212:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    cluIm1213:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    cluIm1222:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    cluIm1232:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    cluIm1233:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    cluIm1231:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    cluIm1223:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    cluIm1211:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    cldRe1221:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_2 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cldRe1212:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cldRe1213:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cldRe1222:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cldRe1232:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cldRe1233:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cldRe1231:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cldRe1223:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cldRe1211:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_1 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cldIm1221:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_2 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cldIm1212:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cldIm1213:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cldIm1222:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cldIm1232:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cldIm1233:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cldIm1231:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cldIm1223:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cldIm1211:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar d_1 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cqeRe1221:
+      real: true
+      tex: (\bar q_1 \gamma_\mu q_2)(\bar e_2 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
+    cqeRe1112:
+      real: true
+      tex: (\bar q_1 \gamma_\mu q_1)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cqeRe1212:
+      real: true
+      tex: (\bar q_1 \gamma_\mu q_2)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cqeRe1312:
+      real: true
+      tex: (\bar q_1 \gamma_\mu q_3)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cqeRe1321:
+      real: true
+      tex: (\bar q_1 \gamma_\mu q_3)(\bar e_2 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
+    cqeRe2212:
+      real: true
+      tex: (\bar q_2 \gamma_\mu q_2)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cqeRe2312:
+      real: true
+      tex: (\bar q_2 \gamma_\mu q_3)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cqeRe2321:
+      real: true
+      tex: (\bar q_2 \gamma_\mu q_3)(\bar e_2 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
+    cqeRe3312:
+      real: true
+      tex: (\bar q_3 \gamma_\mu q_3)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cqeIm1221:
+      real: true
+      tex: i (\bar q_1 \gamma_\mu q_2)(\bar e_2 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
+    cqeIm1112:
+      real: true
+      tex: i (\bar q_1 \gamma_\mu q_1)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cqeIm1212:
+      real: true
+      tex: i (\bar q_1 \gamma_\mu q_2)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cqeIm1312:
+      real: true
+      tex: i (\bar q_1 \gamma_\mu q_3)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cqeIm1321:
+      real: true
+      tex: i (\bar q_1 \gamma_\mu q_3)(\bar e_2 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
+    cqeIm2212:
+      real: true
+      tex: i (\bar q_2 \gamma_\mu q_2)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cqeIm2312:
+      real: true
+      tex: i (\bar q_2 \gamma_\mu q_3)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cqeIm2321:
+      real: true
+      tex: i (\bar q_2 \gamma_\mu q_3)(\bar e_2 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
+    cqeIm3312:
+      real: true
+      tex: i (\bar q_3 \gamma_\mu q_3)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cledqRe1211:
+      real: true
+      tex: (\bar \ell_1^I e_2)(\bar d_1 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe1212:
+      real: true
+      tex: (\bar \ell_1^I e_2)(\bar d_1 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe1213:
+      real: true
+      tex: (\bar \ell_1^I e_2)(\bar d_1 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe1221:
+      real: true
+      tex: (\bar \ell_1^I e_2)(\bar d_2 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe1222:
+      real: true
+      tex: (\bar \ell_1^I e_2)(\bar d_2 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe1223:
+      real: true
+      tex: (\bar \ell_1^I e_2)(\bar d_2 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe1231:
+      real: true
+      tex: (\bar \ell_1^I e_2)(\bar d_3 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe1232:
+      real: true
+      tex: (\bar \ell_1^I e_2)(\bar d_3 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe1233:
+      real: true
+      tex: (\bar \ell_1^I e_2)(\bar d_3 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe2111:
+      real: true
+      tex: (\bar \ell_2^I e_1)(\bar d_1 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe2112:
+      real: true
+      tex: (\bar \ell_2^I e_1)(\bar d_1 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe2113:
+      real: true
+      tex: (\bar \ell_2^I e_1)(\bar d_1 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe2121:
+      real: true
+      tex: (\bar \ell_2^I e_1)(\bar d_2 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe2122:
+      real: true
+      tex: (\bar \ell_2^I e_1)(\bar d_2 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe2123:
+      real: true
+      tex: (\bar \ell_2^I e_1)(\bar d_2 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe2131:
+      real: true
+      tex: (\bar \ell_2^I e_1)(\bar d_3 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe2132:
+      real: true
+      tex: (\bar \ell_2^I e_1)(\bar d_3 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe2133:
+      real: true
+      tex: (\bar \ell_2^I e_1)(\bar d_3 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm1211:
+      real: true
+      tex: i (\bar \ell_1^I e_2)(\bar d_1 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm1212:
+      real: true
+      tex: i (\bar \ell_1^I e_2)(\bar d_1 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm1213:
+      real: true
+      tex: i (\bar \ell_1^I e_2)(\bar d_1 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm1221:
+      real: true
+      tex: i (\bar \ell_1^I e_2)(\bar d_2 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm1222:
+      real: true
+      tex: i (\bar \ell_1^I e_2)(\bar d_2 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm1223:
+      real: true
+      tex: i (\bar \ell_1^I e_2)(\bar d_2 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm1231:
+      real: true
+      tex: i (\bar \ell_1^I e_2)(\bar d_3 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm1232:
+      real: true
+      tex: i (\bar \ell_1^I e_2)(\bar d_3 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm1233:
+      real: true
+      tex: i (\bar \ell_1^I e_2)(\bar d_3 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm2111:
+      real: true
+      tex: i (\bar \ell_2^I e_1)(\bar d_1 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm2112:
+      real: true
+      tex: i (\bar \ell_2^I e_1)(\bar d_1 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm2113:
+      real: true
+      tex: i (\bar \ell_2^I e_1)(\bar d_1 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm2121:
+      real: true
+      tex: i (\bar \ell_2^I e_1)(\bar d_2 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm2122:
+      real: true
+      tex: i (\bar \ell_2^I e_1)(\bar d_2 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm2123:
+      real: true
+      tex: i (\bar \ell_2^I e_1)(\bar d_2 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm2131:
+      real: true
+      tex: i (\bar \ell_2^I e_1)(\bar d_3 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm2132:
+      real: true
+      tex: i (\bar \ell_2^I e_1)(\bar d_3 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm2133:
+      real: true
+      tex: i (\bar \ell_2^I e_1)(\bar d_3 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    clequ1Re1211:
+      real: true
+      tex: (\bar \ell_1^I e_2)(\bar q^J_1 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re1212:
+      real: true
+      tex: (\bar \ell_1^I e_2)(\bar q^J_1 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re1213:
+      real: true
+      tex: (\bar \ell_1^I e_2)(\bar q^J_1 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re1221:
+      real: true
+      tex: (\bar \ell_1^I e_2)(\bar q^J_2 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re1222:
+      real: true
+      tex: (\bar \ell_1^I e_2)(\bar q^J_2 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re1223:
+      real: true
+      tex: (\bar \ell_1^I e_2)(\bar q^J_2 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re1231:
+      real: true
+      tex: (\bar \ell_1^I e_2)(\bar q^J_3 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re1232:
+      real: true
+      tex: (\bar \ell_1^I e_2)(\bar q^J_3 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re1233:
+      real: true
+      tex: (\bar \ell_1^I e_2)(\bar q^J_3 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re2111:
+      real: true
+      tex: (\bar \ell_2^I e_1)(\bar q^J_1 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re2112:
+      real: true
+      tex: (\bar \ell_2^I e_1)(\bar q^J_1 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re2113:
+      real: true
+      tex: (\bar \ell_2^I e_1)(\bar q^J_1 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re2121:
+      real: true
+      tex: (\bar \ell_2^I e_1)(\bar q^J_2 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re2122:
+      real: true
+      tex: (\bar \ell_2^I e_1)(\bar q^J_2 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re2123:
+      real: true
+      tex: (\bar \ell_2^I e_1)(\bar q^J_2 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re2131:
+      real: true
+      tex: (\bar \ell_2^I e_1)(\bar q^J_3 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re2132:
+      real: true
+      tex: (\bar \ell_2^I e_1)(\bar q^J_3 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re2133:
+      real: true
+      tex: (\bar \ell_2^I e_1)(\bar q^J_3 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im1211:
+      real: true
+      tex: i (\bar \ell_1^I e_2)(\bar q^J_1 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im1212:
+      real: true
+      tex: i (\bar \ell_1^I e_2)(\bar q^J_1 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im1213:
+      real: true
+      tex: i (\bar \ell_1^I e_2)(\bar q^J_1 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im1221:
+      real: true
+      tex: i (\bar \ell_1^I e_2)(\bar q^J_2 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im1222:
+      real: true
+      tex: i (\bar \ell_1^I e_2)(\bar q^J_2 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im1223:
+      real: true
+      tex: i (\bar \ell_1^I e_2)(\bar q^J_2 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im1231:
+      real: true
+      tex: i (\bar \ell_1^I e_2)(\bar q^J_3 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im1232:
+      real: true
+      tex: i (\bar \ell_1^I e_2)(\bar q^J_3 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im1233:
+      real: true
+      tex: i (\bar \ell_1^I e_2)(\bar q^J_3 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im2111:
+      real: true
+      tex: i (\bar \ell_2^I e_1)(\bar q^J_1 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im2112:
+      real: true
+      tex: i (\bar \ell_2^I e_1)(\bar q^J_1 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im2113:
+      real: true
+      tex: i (\bar \ell_2^I e_1)(\bar q^J_1 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im2121:
+      real: true
+      tex: i (\bar \ell_2^I e_1)(\bar q^J_2 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im2122:
+      real: true
+      tex: i (\bar \ell_2^I e_1)(\bar q^J_2 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im2123:
+      real: true
+      tex: i (\bar \ell_2^I e_1)(\bar q^J_2 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im2131:
+      real: true
+      tex: i (\bar \ell_2^I e_1)(\bar q^J_3 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im2132:
+      real: true
+      tex: i (\bar \ell_2^I e_1)(\bar q^J_3 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im2133:
+      real: true
+      tex: i (\bar \ell_2^I e_1)(\bar q^J_3 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re1211:
+      real: true
+      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_1 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re1212:
+      real: true
+      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_1 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re1213:
+      real: true
+      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_1 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re1221:
+      real: true
+      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_2 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re1222:
+      real: true
+      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_2 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re1223:
+      real: true
+      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_2 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re1231:
+      real: true
+      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_3 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re1232:
+      real: true
+      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_3 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re1233:
+      real: true
+      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re2111:
+      real: true
+      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_1 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re2112:
+      real: true
+      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_1 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re2113:
+      real: true
+      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_1 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re2121:
+      real: true
+      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_2 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re2122:
+      real: true
+      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_2 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re2123:
+      real: true
+      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_2 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re2131:
+      real: true
+      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_3 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re2132:
+      real: true
+      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_3 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re2133:
+      real: true
+      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im1211:
+      real: true
+      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_1 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im1212:
+      real: true
+      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_1 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im1213:
+      real: true
+      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_1 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im1221:
+      real: true
+      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_2 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im1222:
+      real: true
+      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_2 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im1223:
+      real: true
+      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_2 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im1231:
+      real: true
+      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_3 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im1232:
+      real: true
+      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_3 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im1233:
+      real: true
+      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_2)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im2111:
+      real: true
+      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_1 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im2112:
+      real: true
+      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_1 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im2113:
+      real: true
+      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_1 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im2121:
+      real: true
+      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_2 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im2122:
+      real: true
+      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_2 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im2123:
+      real: true
+      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_2 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im2131:
+      real: true
+      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_3 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im2132:
+      real: true
+      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_3 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im2133:
+      real: true
+      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_1)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+  taue:
+    ceHRe13:
+      real: true
+      tex: (\bar \ell_1 H e_3) (H^\dagger H) / \text{TeV}^2 + \text{h.c.}
+    ceHRe31:
+      real: true
+      tex: (\bar \ell_3 H e_1) (H^\dagger H) / \text{TeV}^2 + \text{h.c.}
+    ceHIm13:
+      real: true
+      tex: i (\bar \ell_1 H e_3) (H^\dagger H) / \text{TeV}^2 + \text{h.c.}
+    ceHIm31:
+      real: true
+      tex: i (\bar \ell_3 H e_1) (H^\dagger H) / \text{TeV}^2 + \text{h.c.}
+    ceWRe13:
+      real: true
+      tex: (\bar \ell_1 \sigma^I H \sigma^{\mu\nu} e_3) W^I_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
+    ceWRe31:
+      real: true
+      tex: (\bar \ell_3 \sigma^I H \sigma^{\mu\nu} e_1) W^I_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
+    ceWIm13:
+      real: true
+      tex: i (\bar \ell_1 \sigma^I H \sigma^{\mu\nu} e_3) W^I_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
+    ceWIm31:
+      real: true
+      tex: i (\bar \ell_3 \sigma^I H \sigma^{\mu\nu} e_1) W^I_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
+    ceBRe13:
+      real: true
+      tex: (\bar \ell_1 H  \sigma^{\mu\nu} e_3) B_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
+    ceBRe31:
+      real: true
+      tex: (\bar \ell_3 H  \sigma^{\mu\nu} e_1) B_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
+    ceBIm13:
+      real: true
+      tex: i (\bar \ell_1 H  \sigma^{\mu\nu} e_3) B_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
+    ceBIm31:
+      real: true
+      tex: i (\bar \ell_3 H  \sigma^{\mu\nu} e_1) B_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
+    cHl1Re13:
+      real: true
+      tex: (H^\dagger i \overleftrightarrow D_\mu H) (\bar \ell_1 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+    cHl1Im13:
+      real: true
+      tex: i (H^\dagger i \overleftrightarrow D_\mu H) (\bar \ell_1 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+    cHl3Re13:
+      real: true
+      tex: (H^\dagger i \overleftrightarrow D_\mu^I H) (\bar \ell_1 \gamma^\mu \sigma^I \ell_3) / \text{TeV}^2 + \text{h.c.}
+    cHl3Im13:
+      real: true
+      tex: i (H^\dagger i \overleftrightarrow D_\mu^I H) (\bar \ell_1 \gamma^\mu \sigma^I \ell_3) / \text{TeV}^2 + \text{h.c.}
+    cHeRe13:
+      real: true
+      tex: (H^\dagger i \overleftrightarrow D_\mu H) (\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cHeIm13:
+      real: true
+      tex: i (H^\dagger i \overleftrightarrow D_\mu H) (\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cllRe1113:
+      real: true
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_1)(\bar \ell_1 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+    cllRe1322:
+      real: true
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
+    cllRe1333:
+      real: true
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_3 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+    cllRe1223:
+      real: true
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+    cllIm1113:
+      real: true
+      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_1)(\bar \ell_1 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+    cllIm1322:
+      real: true
+      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
+    cllIm1333:
+      real: true
+      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_3 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+    cllIm1223:
+      real: true
+      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+    clq1Re1331:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_3 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
+    clq1Re1313:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_1 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+    clq1Re1322:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_2 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
+    clq1Re1323:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+    clq1Re1333:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_3 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+    clq1Re1332:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_3 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
+    clq1Re1311:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_1 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
+    clq1Re1312:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_1 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
+    clq1Re1321:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_2 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
+    clq1Im1331:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_3 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
+    clq1Im1313:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_1 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+    clq1Im1322:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_2 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
+    clq1Im1323:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+    clq1Im1333:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_3 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+    clq1Im1332:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_3 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
+    clq1Im1311:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_1 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
+    clq1Im1312:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_1 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
+    clq1Im1321:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar q_2 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
+    clq3Re1331:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_3 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
+    clq3Re1313:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_1 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+    clq3Re1322:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_2 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
+    clq3Re1323:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+    clq3Re1333:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_3 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+    clq3Re1332:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_3 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
+    clq3Re1311:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_1 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
+    clq3Re1312:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_1 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
+    clq3Re1321:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_2 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
+    clq3Im1331:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_3 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
+    clq3Im1313:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_1 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+    clq3Im1322:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_2 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
+    clq3Im1323:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+    clq3Im1333:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_3 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+    clq3Im1332:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_3 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
+    clq3Im1311:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_1 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
+    clq3Im1312:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_1 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
+    clq3Im1321:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \sigma^I \ell_3)(\bar q_2 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
+    ceeRe1113:
+      real: true
+      tex: 2 (\bar e_1 \gamma_\mu e_1)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    ceeRe1322:
+      real: true
+      tex: 4 (\bar e_1 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    ceeRe1333:
+      real: true
+      tex: 2 (\bar e_1 \gamma_\mu e_3)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    ceeIm1113:
+      real: true
+      tex: 2 i (\bar e_1 \gamma_\mu e_1)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    ceeIm1322:
+      real: true
+      tex: 4 i (\bar e_1 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    ceeIm1333:
+      real: true
+      tex: 2 i (\bar e_1 \gamma_\mu e_3)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    ceuRe1331:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_3)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    ceuRe1313:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_3)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    ceuRe1322:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_3)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    ceuRe1323:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    ceuRe1333:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_3)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    ceuRe1332:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_3)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    ceuRe1311:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_3)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    ceuRe1312:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_3)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    ceuRe1321:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_3)(\bar u_2 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    ceuIm1331:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_3)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    ceuIm1313:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_3)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    ceuIm1322:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_3)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    ceuIm1323:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    ceuIm1333:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_3)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    ceuIm1332:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_3)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    ceuIm1311:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_3)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    ceuIm1312:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_3)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    ceuIm1321:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_3)(\bar u_2 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    cedRe1331:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_3)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cedRe1313:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_3)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cedRe1322:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_3)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cedRe1323:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cedRe1333:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_3)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cedRe1332:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_3)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cedRe1311:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_3)(\bar d_1 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cedRe1312:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_3)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cedRe1321:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_3)(\bar d_2 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cedIm1331:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_3)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cedIm1313:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_3)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cedIm1322:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_3)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cedIm1323:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cedIm1333:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_3)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cedIm1332:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_3)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cedIm1311:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_3)(\bar d_1 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cedIm1312:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_3)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cedIm1321:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_3)(\bar d_2 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cleRe1113:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_1)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleRe1322:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cleRe1333:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleRe1223:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleRe1311:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
+    cleRe2213:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_2)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleRe2312:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cleRe3313:
+      real: true
+      tex: (\bar \ell_3 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleIm1113:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_1)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleIm1322:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cleIm1333:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleIm1223:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleIm1311:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
+    cleIm2213:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_2)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleIm2312:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cleIm3313:
+      real: true
+      tex: i (\bar \ell_3 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cluRe1331:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    cluRe1313:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    cluRe1322:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    cluRe1323:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    cluRe1333:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    cluRe1332:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    cluRe1311:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    cluRe1312:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    cluRe1321:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_2 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    cluIm1331:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    cluIm1313:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    cluIm1322:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    cluIm1323:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    cluIm1333:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    cluIm1332:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    cluIm1311:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    cluIm1312:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    cluIm1321:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar u_2 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    cldRe1331:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cldRe1313:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cldRe1322:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cldRe1323:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cldRe1333:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cldRe1332:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cldRe1311:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_1 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cldRe1312:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cldRe1321:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_2 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cldIm1331:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cldIm1313:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cldIm1322:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cldIm1323:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cldIm1333:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cldIm1332:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cldIm1311:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_1 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cldIm1312:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cldIm1321:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar d_2 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cqeRe1331:
+      real: true
+      tex: (\bar q_1 \gamma_\mu q_3)(\bar e_3 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
+    cqeRe1113:
+      real: true
+      tex: (\bar q_1 \gamma_\mu q_1)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cqeRe1213:
+      real: true
+      tex: (\bar q_1 \gamma_\mu q_2)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cqeRe1313:
+      real: true
+      tex: (\bar q_1 \gamma_\mu q_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cqeRe1231:
+      real: true
+      tex: (\bar q_1 \gamma_\mu q_2)(\bar e_3 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
+    cqeRe2213:
+      real: true
+      tex: (\bar q_2 \gamma_\mu q_2)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cqeRe2313:
+      real: true
+      tex: (\bar q_2 \gamma_\mu q_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cqeRe2331:
+      real: true
+      tex: (\bar q_2 \gamma_\mu q_3)(\bar e_3 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
+    cqeRe3313:
+      real: true
+      tex: (\bar q_3 \gamma_\mu q_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cqeIm1331:
+      real: true
+      tex: i (\bar q_1 \gamma_\mu q_3)(\bar e_3 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
+    cqeIm1113:
+      real: true
+      tex: i (\bar q_1 \gamma_\mu q_1)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cqeIm1213:
+      real: true
+      tex: i (\bar q_1 \gamma_\mu q_2)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cqeIm1313:
+      real: true
+      tex: i (\bar q_1 \gamma_\mu q_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cqeIm1231:
+      real: true
+      tex: i (\bar q_1 \gamma_\mu q_2)(\bar e_3 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
+    cqeIm2213:
+      real: true
+      tex: i (\bar q_2 \gamma_\mu q_2)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cqeIm2313:
+      real: true
+      tex: i (\bar q_2 \gamma_\mu q_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cqeIm2331:
+      real: true
+      tex: i (\bar q_2 \gamma_\mu q_3)(\bar e_3 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
+    cqeIm3313:
+      real: true
+      tex: i (\bar q_3 \gamma_\mu q_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cledqRe1311:
+      real: true
+      tex: (\bar \ell_1^I e_3)(\bar d_1 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe1312:
+      real: true
+      tex: (\bar \ell_1^I e_3)(\bar d_1 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe1313:
+      real: true
+      tex: (\bar \ell_1^I e_3)(\bar d_1 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe1321:
+      real: true
+      tex: (\bar \ell_1^I e_3)(\bar d_2 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe1322:
+      real: true
+      tex: (\bar \ell_1^I e_3)(\bar d_2 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe1323:
+      real: true
+      tex: (\bar \ell_1^I e_3)(\bar d_2 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe1331:
+      real: true
+      tex: (\bar \ell_1^I e_3)(\bar d_3 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe1332:
+      real: true
+      tex: (\bar \ell_1^I e_3)(\bar d_3 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe1333:
+      real: true
+      tex: (\bar \ell_1^I e_3)(\bar d_3 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe3111:
+      real: true
+      tex: (\bar \ell_3^I e_1)(\bar d_1 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe3112:
+      real: true
+      tex: (\bar \ell_3^I e_1)(\bar d_1 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe3113:
+      real: true
+      tex: (\bar \ell_3^I e_1)(\bar d_1 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe3121:
+      real: true
+      tex: (\bar \ell_3^I e_1)(\bar d_2 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe3122:
+      real: true
+      tex: (\bar \ell_3^I e_1)(\bar d_2 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe3123:
+      real: true
+      tex: (\bar \ell_3^I e_1)(\bar d_2 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe3131:
+      real: true
+      tex: (\bar \ell_3^I e_1)(\bar d_3 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe3132:
+      real: true
+      tex: (\bar \ell_3^I e_1)(\bar d_3 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe3133:
+      real: true
+      tex: (\bar \ell_3^I e_1)(\bar d_3 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm1311:
+      real: true
+      tex: i (\bar \ell_1^I e_3)(\bar d_1 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm1312:
+      real: true
+      tex: i (\bar \ell_1^I e_3)(\bar d_1 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm1313:
+      real: true
+      tex: i (\bar \ell_1^I e_3)(\bar d_1 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm1321:
+      real: true
+      tex: i (\bar \ell_1^I e_3)(\bar d_2 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm1322:
+      real: true
+      tex: i (\bar \ell_1^I e_3)(\bar d_2 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm1323:
+      real: true
+      tex: i (\bar \ell_1^I e_3)(\bar d_2 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm1331:
+      real: true
+      tex: i (\bar \ell_1^I e_3)(\bar d_3 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm1332:
+      real: true
+      tex: i (\bar \ell_1^I e_3)(\bar d_3 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm1333:
+      real: true
+      tex: i (\bar \ell_1^I e_3)(\bar d_3 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm3111:
+      real: true
+      tex: i (\bar \ell_3^I e_1)(\bar d_1 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm3112:
+      real: true
+      tex: i (\bar \ell_3^I e_1)(\bar d_1 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm3113:
+      real: true
+      tex: i (\bar \ell_3^I e_1)(\bar d_1 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm3121:
+      real: true
+      tex: i (\bar \ell_3^I e_1)(\bar d_2 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm3122:
+      real: true
+      tex: i (\bar \ell_3^I e_1)(\bar d_2 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm3123:
+      real: true
+      tex: i (\bar \ell_3^I e_1)(\bar d_2 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm3131:
+      real: true
+      tex: i (\bar \ell_3^I e_1)(\bar d_3 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm3132:
+      real: true
+      tex: i (\bar \ell_3^I e_1)(\bar d_3 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm3133:
+      real: true
+      tex: i (\bar \ell_3^I e_1)(\bar d_3 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    clequ1Re1311:
+      real: true
+      tex: (\bar \ell_1^I e_3)(\bar q^J_1 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re1312:
+      real: true
+      tex: (\bar \ell_1^I e_3)(\bar q^J_1 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re1313:
+      real: true
+      tex: (\bar \ell_1^I e_3)(\bar q^J_1 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re1321:
+      real: true
+      tex: (\bar \ell_1^I e_3)(\bar q^J_2 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re1322:
+      real: true
+      tex: (\bar \ell_1^I e_3)(\bar q^J_2 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re1323:
+      real: true
+      tex: (\bar \ell_1^I e_3)(\bar q^J_2 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re1331:
+      real: true
+      tex: (\bar \ell_1^I e_3)(\bar q^J_3 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re1332:
+      real: true
+      tex: (\bar \ell_1^I e_3)(\bar q^J_3 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re1333:
+      real: true
+      tex: (\bar \ell_1^I e_3)(\bar q^J_3 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re3111:
+      real: true
+      tex: (\bar \ell_3^I e_1)(\bar q^J_1 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re3112:
+      real: true
+      tex: (\bar \ell_3^I e_1)(\bar q^J_1 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re3113:
+      real: true
+      tex: (\bar \ell_3^I e_1)(\bar q^J_1 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re3121:
+      real: true
+      tex: (\bar \ell_3^I e_1)(\bar q^J_2 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re3122:
+      real: true
+      tex: (\bar \ell_3^I e_1)(\bar q^J_2 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re3123:
+      real: true
+      tex: (\bar \ell_3^I e_1)(\bar q^J_2 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re3131:
+      real: true
+      tex: (\bar \ell_3^I e_1)(\bar q^J_3 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re3132:
+      real: true
+      tex: (\bar \ell_3^I e_1)(\bar q^J_3 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re3133:
+      real: true
+      tex: (\bar \ell_3^I e_1)(\bar q^J_3 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im1311:
+      real: true
+      tex: i (\bar \ell_1^I e_3)(\bar q^J_1 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im1312:
+      real: true
+      tex: i (\bar \ell_1^I e_3)(\bar q^J_1 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im1313:
+      real: true
+      tex: i (\bar \ell_1^I e_3)(\bar q^J_1 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im1321:
+      real: true
+      tex: i (\bar \ell_1^I e_3)(\bar q^J_2 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im1322:
+      real: true
+      tex: i (\bar \ell_1^I e_3)(\bar q^J_2 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im1323:
+      real: true
+      tex: i (\bar \ell_1^I e_3)(\bar q^J_2 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im1331:
+      real: true
+      tex: i (\bar \ell_1^I e_3)(\bar q^J_3 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im1332:
+      real: true
+      tex: i (\bar \ell_1^I e_3)(\bar q^J_3 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im1333:
+      real: true
+      tex: i (\bar \ell_1^I e_3)(\bar q^J_3 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im3111:
+      real: true
+      tex: i (\bar \ell_3^I e_1)(\bar q^J_1 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im3112:
+      real: true
+      tex: i (\bar \ell_3^I e_1)(\bar q^J_1 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im3113:
+      real: true
+      tex: i (\bar \ell_3^I e_1)(\bar q^J_1 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im3121:
+      real: true
+      tex: i (\bar \ell_3^I e_1)(\bar q^J_2 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im3122:
+      real: true
+      tex: i (\bar \ell_3^I e_1)(\bar q^J_2 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im3123:
+      real: true
+      tex: i (\bar \ell_3^I e_1)(\bar q^J_2 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im3131:
+      real: true
+      tex: i (\bar \ell_3^I e_1)(\bar q^J_3 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im3132:
+      real: true
+      tex: i (\bar \ell_3^I e_1)(\bar q^J_3 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im3133:
+      real: true
+      tex: i (\bar \ell_3^I e_1)(\bar q^J_3 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re1311:
+      real: true
+      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_1 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re1312:
+      real: true
+      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_1 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re1313:
+      real: true
+      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_1 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re1321:
+      real: true
+      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_2 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re1322:
+      real: true
+      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_2 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re1323:
+      real: true
+      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_2 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re1331:
+      real: true
+      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_3 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re1332:
+      real: true
+      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_3 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re1333:
+      real: true
+      tex: (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re3111:
+      real: true
+      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_1 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re3112:
+      real: true
+      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_1 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re3113:
+      real: true
+      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_1 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re3121:
+      real: true
+      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_2 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re3122:
+      real: true
+      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_2 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re3123:
+      real: true
+      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_2 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re3131:
+      real: true
+      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_3 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re3132:
+      real: true
+      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_3 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re3133:
+      real: true
+      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im1311:
+      real: true
+      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_1 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im1312:
+      real: true
+      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_1 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im1313:
+      real: true
+      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_1 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im1321:
+      real: true
+      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_2 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im1322:
+      real: true
+      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_2 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im1323:
+      real: true
+      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_2 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im1331:
+      real: true
+      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_3 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im1332:
+      real: true
+      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_3 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im1333:
+      real: true
+      tex: i (\bar \ell_1^I \sigma_{\mu\nu} e_3)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im3111:
+      real: true
+      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_1 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im3112:
+      real: true
+      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_1 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im3113:
+      real: true
+      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_1 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im3121:
+      real: true
+      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_2 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im3122:
+      real: true
+      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_2 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im3123:
+      real: true
+      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_2 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im3131:
+      real: true
+      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_3 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im3132:
+      real: true
+      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_3 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im3133:
+      real: true
+      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_1)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+  mutau:
+    ceHRe23:
+      real: true
+      tex: (\bar \ell_2 H e_3) (H^\dagger H) / \text{TeV}^2 + \text{h.c.}
+    ceHRe32:
+      real: true
+      tex: (\bar \ell_3 H e_2) (H^\dagger H) / \text{TeV}^2 + \text{h.c.}
+    ceHIm23:
+      real: true
+      tex: i (\bar \ell_2 H e_3) (H^\dagger H) / \text{TeV}^2 + \text{h.c.}
+    ceHIm32:
+      real: true
+      tex: i (\bar \ell_3 H e_2) (H^\dagger H) / \text{TeV}^2 + \text{h.c.}
+    ceWRe23:
+      real: true
+      tex: (\bar \ell_2 \sigma^I H \sigma^{\mu\nu} e_3) W^I_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
+    ceWRe32:
+      real: true
+      tex: (\bar \ell_3 \sigma^I H \sigma^{\mu\nu} e_2) W^I_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
+    ceWIm23:
+      real: true
+      tex: i (\bar \ell_2 \sigma^I H \sigma^{\mu\nu} e_3) W^I_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
+    ceWIm32:
+      real: true
+      tex: i (\bar \ell_3 \sigma^I H \sigma^{\mu\nu} e_2) W^I_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
+    ceBRe23:
+      real: true
+      tex: (\bar \ell_2 H  \sigma^{\mu\nu} e_3) B_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
+    ceBRe32:
+      real: true
+      tex: (\bar \ell_3 H  \sigma^{\mu\nu} e_2) B_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
+    ceBIm23:
+      real: true
+      tex: i (\bar \ell_2 H  \sigma^{\mu\nu} e_3) B_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
+    ceBIm32:
+      real: true
+      tex: i (\bar \ell_3 H  \sigma^{\mu\nu} e_2) B_{\mu\nu} / \text{TeV}^2 + \text{h.c.}
+    cHl1Re23:
+      real: true
+      tex: (H^\dagger i \overleftrightarrow D_\mu H) (\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+    cHl1Im23:
+      real: true
+      tex: i (H^\dagger i \overleftrightarrow D_\mu H) (\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+    cHl3Re23:
+      real: true
+      tex: (H^\dagger i \overleftrightarrow D_\mu^I H) (\bar \ell_2 \gamma^\mu \sigma^I \ell_3) / \text{TeV}^2 + \text{h.c.}
+    cHl3Im23:
+      real: true
+      tex: i (H^\dagger i \overleftrightarrow D_\mu^I H) (\bar \ell_2 \gamma^\mu \sigma^I \ell_3) / \text{TeV}^2 + \text{h.c.}
+    cHeRe23:
+      real: true
+      tex: (H^\dagger i \overleftrightarrow D_\mu H) (\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cHeIm23:
+      real: true
+      tex: i (H^\dagger i \overleftrightarrow D_\mu H) (\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cllRe1123:
+      real: true
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_1)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+    cllRe2223:
+      real: true
+      tex: 2 (\bar \ell_2 \gamma_\mu \ell_2)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+    cllRe3323:
+      real: true
+      tex: 2 (\bar \ell_3 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+    cllRe1231:
+      real: true
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_3 \gamma^\mu \ell_1) / \text{TeV}^2 + \text{h.c.}
+    cllIm1123:
+      real: true
+      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_1)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+    cllIm2223:
+      real: true
+      tex: 2 i (\bar \ell_2 \gamma_\mu \ell_2)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+    cllIm3323:
+      real: true
+      tex: 2 i (\bar \ell_3 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+    cllIm1231:
+      real: true
+      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_3 \gamma^\mu \ell_1) / \text{TeV}^2 + \text{h.c.}
+    clq1Re2332:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_3 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
+    clq1Re2323:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+    clq1Re2311:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_1 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
+    clq1Re2312:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_1 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
+    clq1Re2313:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_1 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+    clq1Re2321:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_2 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
+    clq1Re2322:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_2 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
+    clq1Re2331:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_3 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
+    clq1Re2333:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_3 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+    clq1Im2332:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_3 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
+    clq1Im2323:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_2 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+    clq1Im2311:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_1 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
+    clq1Im2312:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_1 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
+    clq1Im2313:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_1 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+    clq1Im2321:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_2 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
+    clq1Im2322:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_2 \gamma^\mu q_2) / \text{TeV}^2 + \text{h.c.}
+    clq1Im2331:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_3 \gamma^\mu q_1) / \text{TeV}^2 + \text{h.c.}
+    clq1Im2333:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar q_3 \gamma^\mu q_3) / \text{TeV}^2 + \text{h.c.}
+    clq3Re2332:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_3 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
+    clq3Re2323:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+    clq3Re2311:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_1 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
+    clq3Re2312:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_1 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
+    clq3Re2313:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_1 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+    clq3Re2321:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_2 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
+    clq3Re2322:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_2 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
+    clq3Re2331:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_3 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
+    clq3Re2333:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_3 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+    clq3Im2332:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_3 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
+    clq3Im2323:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_2 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+    clq3Im2311:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_1 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
+    clq3Im2312:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_1 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
+    clq3Im2313:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_1 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+    clq3Im2321:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_2 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
+    clq3Im2322:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_2 \gamma^\mu \sigma^I q_2) / \text{TeV}^2 + \text{h.c.}
+    clq3Im2331:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_3 \gamma^\mu \sigma^I q_1) / \text{TeV}^2 + \text{h.c.}
+    clq3Im2333:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \sigma^I \ell_3)(\bar q_3 \gamma^\mu \sigma^I q_3) / \text{TeV}^2 + \text{h.c.}
+    ceeRe1123:
+      real: true
+      tex: 4 (\bar e_1 \gamma_\mu e_1)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    ceeRe2223:
+      real: true
+      tex: 2 (\bar e_2 \gamma_\mu e_2)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    ceeRe3323:
+      real: true
+      tex: 2 (\bar e_3 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    ceeIm1123:
+      real: true
+      tex: 4 i (\bar e_1 \gamma_\mu e_1)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    ceeIm2223:
+      real: true
+      tex: 2 i (\bar e_2 \gamma_\mu e_2)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    ceeIm3323:
+      real: true
+      tex: 2 i (\bar e_3 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    ceuRe2332:
+      real: true
+      tex: (\bar e_2 \gamma_\mu e_3)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    ceuRe2323:
+      real: true
+      tex: (\bar e_2 \gamma_\mu e_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    ceuRe2311:
+      real: true
+      tex: (\bar e_2 \gamma_\mu e_3)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    ceuRe2312:
+      real: true
+      tex: (\bar e_2 \gamma_\mu e_3)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    ceuRe2313:
+      real: true
+      tex: (\bar e_2 \gamma_\mu e_3)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    ceuRe2321:
+      real: true
+      tex: (\bar e_2 \gamma_\mu e_3)(\bar u_2 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    ceuRe2322:
+      real: true
+      tex: (\bar e_2 \gamma_\mu e_3)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    ceuRe2331:
+      real: true
+      tex: (\bar e_2 \gamma_\mu e_3)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    ceuRe2333:
+      real: true
+      tex: (\bar e_2 \gamma_\mu e_3)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    ceuIm2332:
+      real: true
+      tex: i (\bar e_2 \gamma_\mu e_3)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    ceuIm2323:
+      real: true
+      tex: i (\bar e_2 \gamma_\mu e_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    ceuIm2311:
+      real: true
+      tex: i (\bar e_2 \gamma_\mu e_3)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    ceuIm2312:
+      real: true
+      tex: i (\bar e_2 \gamma_\mu e_3)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    ceuIm2313:
+      real: true
+      tex: i (\bar e_2 \gamma_\mu e_3)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    ceuIm2321:
+      real: true
+      tex: i (\bar e_2 \gamma_\mu e_3)(\bar u_2 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    ceuIm2322:
+      real: true
+      tex: i (\bar e_2 \gamma_\mu e_3)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    ceuIm2331:
+      real: true
+      tex: i (\bar e_2 \gamma_\mu e_3)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    ceuIm2333:
+      real: true
+      tex: i (\bar e_2 \gamma_\mu e_3)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    cedRe2332:
+      real: true
+      tex: (\bar e_2 \gamma_\mu e_3)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cedRe2323:
+      real: true
+      tex: (\bar e_2 \gamma_\mu e_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cedRe2311:
+      real: true
+      tex: (\bar e_2 \gamma_\mu e_3)(\bar d_1 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cedRe2312:
+      real: true
+      tex: (\bar e_2 \gamma_\mu e_3)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cedRe2313:
+      real: true
+      tex: (\bar e_2 \gamma_\mu e_3)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cedRe2321:
+      real: true
+      tex: (\bar e_2 \gamma_\mu e_3)(\bar d_2 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cedRe2322:
+      real: true
+      tex: (\bar e_2 \gamma_\mu e_3)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cedRe2331:
+      real: true
+      tex: (\bar e_2 \gamma_\mu e_3)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cedRe2333:
+      real: true
+      tex: (\bar e_2 \gamma_\mu e_3)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cedIm2332:
+      real: true
+      tex: i (\bar e_2 \gamma_\mu e_3)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cedIm2323:
+      real: true
+      tex: i (\bar e_2 \gamma_\mu e_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cedIm2311:
+      real: true
+      tex: i (\bar e_2 \gamma_\mu e_3)(\bar d_1 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cedIm2312:
+      real: true
+      tex: i (\bar e_2 \gamma_\mu e_3)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cedIm2313:
+      real: true
+      tex: i (\bar e_2 \gamma_\mu e_3)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cedIm2321:
+      real: true
+      tex: i (\bar e_2 \gamma_\mu e_3)(\bar d_2 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cedIm2322:
+      real: true
+      tex: i (\bar e_2 \gamma_\mu e_3)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cedIm2331:
+      real: true
+      tex: i (\bar e_2 \gamma_\mu e_3)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cedIm2333:
+      real: true
+      tex: i (\bar e_2 \gamma_\mu e_3)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cleRe1123:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_1)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleRe2223:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_2)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleRe3323:
+      real: true
+      tex: (\bar \ell_3 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleRe1231:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_3 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
+    cleRe1321:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
+    cleRe2311:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
+    cleRe2322:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cleRe2333:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleIm1123:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_1)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleIm2223:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_2)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleIm3323:
+      real: true
+      tex: i (\bar \ell_3 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleIm1231:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_3 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
+    cleIm1321:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
+    cleIm2311:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
+    cleIm2322:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cleIm2333:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_3 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cluRe2332:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    cluRe2323:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    cluRe2311:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    cluRe2312:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    cluRe2313:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    cluRe2321:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_2 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    cluRe2322:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    cluRe2331:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    cluRe2333:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    cluIm2332:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_3 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    cluIm2323:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_2 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    cluIm2311:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_1 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    cluIm2312:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_1 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    cluIm2313:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_1 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    cluIm2321:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_2 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    cluIm2322:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_2 \gamma^\mu u_2) / \text{TeV}^2 + \text{h.c.}
+    cluIm2331:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_3 \gamma^\mu u_1) / \text{TeV}^2 + \text{h.c.}
+    cluIm2333:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar u_3 \gamma^\mu u_3) / \text{TeV}^2 + \text{h.c.}
+    cldRe2332:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cldRe2323:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cldRe2311:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_1 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cldRe2312:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cldRe2313:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cldRe2321:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_2 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cldRe2322:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cldRe2331:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cldRe2333:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cldIm2332:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_3 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cldIm2323:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_2 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cldIm2311:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_1 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cldIm2312:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_1 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cldIm2313:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_1 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cldIm2321:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_2 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cldIm2322:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_2 \gamma^\mu d_2) / \text{TeV}^2 + \text{h.c.}
+    cldIm2331:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_3 \gamma^\mu d_1) / \text{TeV}^2 + \text{h.c.}
+    cldIm2333:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar d_3 \gamma^\mu d_3) / \text{TeV}^2 + \text{h.c.}
+    cqeRe2332:
+      real: true
+      tex: (\bar q_2 \gamma_\mu q_3)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cqeRe1123:
+      real: true
+      tex: (\bar q_1 \gamma_\mu q_1)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cqeRe1232:
+      real: true
+      tex: (\bar q_1 \gamma_\mu q_2)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cqeRe1323:
+      real: true
+      tex: (\bar q_1 \gamma_\mu q_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cqeRe2223:
+      real: true
+      tex: (\bar q_2 \gamma_\mu q_2)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cqeRe2323:
+      real: true
+      tex: (\bar q_2 \gamma_\mu q_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cqeRe3323:
+      real: true
+      tex: (\bar q_3 \gamma_\mu q_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cqeRe1223:
+      real: true
+      tex: (\bar q_1 \gamma_\mu q_2)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cqeRe1332:
+      real: true
+      tex: (\bar q_1 \gamma_\mu q_3)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cqeIm2332:
+      real: true
+      tex: i (\bar q_2 \gamma_\mu q_3)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cqeIm1123:
+      real: true
+      tex: i (\bar q_1 \gamma_\mu q_1)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cqeIm1232:
+      real: true
+      tex: i (\bar q_1 \gamma_\mu q_2)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cqeIm1323:
+      real: true
+      tex: i (\bar q_1 \gamma_\mu q_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cqeIm2223:
+      real: true
+      tex: i (\bar q_2 \gamma_\mu q_2)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cqeIm2323:
+      real: true
+      tex: i (\bar q_2 \gamma_\mu q_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cqeIm3323:
+      real: true
+      tex: i (\bar q_3 \gamma_\mu q_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cqeIm1223:
+      real: true
+      tex: i (\bar q_1 \gamma_\mu q_2)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cqeIm1332:
+      real: true
+      tex: i (\bar q_1 \gamma_\mu q_3)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cledqRe2311:
+      real: true
+      tex: (\bar \ell_2^I e_3)(\bar d_1 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe2312:
+      real: true
+      tex: (\bar \ell_2^I e_3)(\bar d_1 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe2313:
+      real: true
+      tex: (\bar \ell_2^I e_3)(\bar d_1 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe2321:
+      real: true
+      tex: (\bar \ell_2^I e_3)(\bar d_2 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe2322:
+      real: true
+      tex: (\bar \ell_2^I e_3)(\bar d_2 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe2323:
+      real: true
+      tex: (\bar \ell_2^I e_3)(\bar d_2 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe2331:
+      real: true
+      tex: (\bar \ell_2^I e_3)(\bar d_3 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe2332:
+      real: true
+      tex: (\bar \ell_2^I e_3)(\bar d_3 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe2333:
+      real: true
+      tex: (\bar \ell_2^I e_3)(\bar d_3 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe3211:
+      real: true
+      tex: (\bar \ell_3^I e_2)(\bar d_1 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe3212:
+      real: true
+      tex: (\bar \ell_3^I e_2)(\bar d_1 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe3213:
+      real: true
+      tex: (\bar \ell_3^I e_2)(\bar d_1 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe3221:
+      real: true
+      tex: (\bar \ell_3^I e_2)(\bar d_2 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe3222:
+      real: true
+      tex: (\bar \ell_3^I e_2)(\bar d_2 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe3223:
+      real: true
+      tex: (\bar \ell_3^I e_2)(\bar d_2 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe3231:
+      real: true
+      tex: (\bar \ell_3^I e_2)(\bar d_3 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe3232:
+      real: true
+      tex: (\bar \ell_3^I e_2)(\bar d_3 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqRe3233:
+      real: true
+      tex: (\bar \ell_3^I e_2)(\bar d_3 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm2311:
+      real: true
+      tex: i (\bar \ell_2^I e_3)(\bar d_1 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm2312:
+      real: true
+      tex: i (\bar \ell_2^I e_3)(\bar d_1 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm2313:
+      real: true
+      tex: i (\bar \ell_2^I e_3)(\bar d_1 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm2321:
+      real: true
+      tex: i (\bar \ell_2^I e_3)(\bar d_2 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm2322:
+      real: true
+      tex: i (\bar \ell_2^I e_3)(\bar d_2 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm2323:
+      real: true
+      tex: i (\bar \ell_2^I e_3)(\bar d_2 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm2331:
+      real: true
+      tex: i (\bar \ell_2^I e_3)(\bar d_3 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm2332:
+      real: true
+      tex: i (\bar \ell_2^I e_3)(\bar d_3 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm2333:
+      real: true
+      tex: i (\bar \ell_2^I e_3)(\bar d_3 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm3211:
+      real: true
+      tex: i (\bar \ell_3^I e_2)(\bar d_1 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm3212:
+      real: true
+      tex: i (\bar \ell_3^I e_2)(\bar d_1 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm3213:
+      real: true
+      tex: i (\bar \ell_3^I e_2)(\bar d_1 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm3221:
+      real: true
+      tex: i (\bar \ell_3^I e_2)(\bar d_2 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm3222:
+      real: true
+      tex: i (\bar \ell_3^I e_2)(\bar d_2 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm3223:
+      real: true
+      tex: i (\bar \ell_3^I e_2)(\bar d_2 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm3231:
+      real: true
+      tex: i (\bar \ell_3^I e_2)(\bar d_3 q_1^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm3232:
+      real: true
+      tex: i (\bar \ell_3^I e_2)(\bar d_3 q_2^I) / \text{TeV}^2 + \text{h.c.}
+    cledqIm3233:
+      real: true
+      tex: i (\bar \ell_3^I e_2)(\bar d_3 q_3^I) / \text{TeV}^2 + \text{h.c.}
+    clequ1Re2311:
+      real: true
+      tex: (\bar \ell_2^I e_3)(\bar q^J_1 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re2312:
+      real: true
+      tex: (\bar \ell_2^I e_3)(\bar q^J_1 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re2313:
+      real: true
+      tex: (\bar \ell_2^I e_3)(\bar q^J_1 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re2321:
+      real: true
+      tex: (\bar \ell_2^I e_3)(\bar q^J_2 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re2322:
+      real: true
+      tex: (\bar \ell_2^I e_3)(\bar q^J_2 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re2323:
+      real: true
+      tex: (\bar \ell_2^I e_3)(\bar q^J_2 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re2331:
+      real: true
+      tex: (\bar \ell_2^I e_3)(\bar q^J_3 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re2332:
+      real: true
+      tex: (\bar \ell_2^I e_3)(\bar q^J_3 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re2333:
+      real: true
+      tex: (\bar \ell_2^I e_3)(\bar q^J_3 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re3211:
+      real: true
+      tex: (\bar \ell_3^I e_2)(\bar q^J_1 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re3212:
+      real: true
+      tex: (\bar \ell_3^I e_2)(\bar q^J_1 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re3213:
+      real: true
+      tex: (\bar \ell_3^I e_2)(\bar q^J_1 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re3221:
+      real: true
+      tex: (\bar \ell_3^I e_2)(\bar q^J_2 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re3222:
+      real: true
+      tex: (\bar \ell_3^I e_2)(\bar q^J_2 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re3223:
+      real: true
+      tex: (\bar \ell_3^I e_2)(\bar q^J_2 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re3231:
+      real: true
+      tex: (\bar \ell_3^I e_2)(\bar q^J_3 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re3232:
+      real: true
+      tex: (\bar \ell_3^I e_2)(\bar q^J_3 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Re3233:
+      real: true
+      tex: (\bar \ell_3^I e_2)(\bar q^J_3 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im2311:
+      real: true
+      tex: i (\bar \ell_2^I e_3)(\bar q^J_1 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im2312:
+      real: true
+      tex: i (\bar \ell_2^I e_3)(\bar q^J_1 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im2313:
+      real: true
+      tex: i (\bar \ell_2^I e_3)(\bar q^J_1 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im2321:
+      real: true
+      tex: i (\bar \ell_2^I e_3)(\bar q^J_2 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im2322:
+      real: true
+      tex: i (\bar \ell_2^I e_3)(\bar q^J_2 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im2323:
+      real: true
+      tex: i (\bar \ell_2^I e_3)(\bar q^J_2 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im2331:
+      real: true
+      tex: i (\bar \ell_2^I e_3)(\bar q^J_3 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im2332:
+      real: true
+      tex: i (\bar \ell_2^I e_3)(\bar q^J_3 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im2333:
+      real: true
+      tex: i (\bar \ell_2^I e_3)(\bar q^J_3 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im3211:
+      real: true
+      tex: i (\bar \ell_3^I e_2)(\bar q^J_1 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im3212:
+      real: true
+      tex: i (\bar \ell_3^I e_2)(\bar q^J_1 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im3213:
+      real: true
+      tex: i (\bar \ell_3^I e_2)(\bar q^J_1 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im3221:
+      real: true
+      tex: i (\bar \ell_3^I e_2)(\bar q^J_2 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im3222:
+      real: true
+      tex: i (\bar \ell_3^I e_2)(\bar q^J_2 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im3223:
+      real: true
+      tex: i (\bar \ell_3^I e_2)(\bar q^J_2 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im3231:
+      real: true
+      tex: i (\bar \ell_3^I e_2)(\bar q^J_3 u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im3232:
+      real: true
+      tex: i (\bar \ell_3^I e_2)(\bar q^J_3 u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ1Im3233:
+      real: true
+      tex: i (\bar \ell_3^I e_2)(\bar q^J_3 u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re2311:
+      real: true
+      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_1 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re2312:
+      real: true
+      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_1 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re2313:
+      real: true
+      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_1 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re2321:
+      real: true
+      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_2 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re2322:
+      real: true
+      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_2 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re2323:
+      real: true
+      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_2 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re2331:
+      real: true
+      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_3 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re2332:
+      real: true
+      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_3 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re2333:
+      real: true
+      tex: (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re3211:
+      real: true
+      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_1 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re3212:
+      real: true
+      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_1 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re3213:
+      real: true
+      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_1 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re3221:
+      real: true
+      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_2 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re3222:
+      real: true
+      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_2 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re3223:
+      real: true
+      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_2 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re3231:
+      real: true
+      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_3 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re3232:
+      real: true
+      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_3 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Re3233:
+      real: true
+      tex: (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im2311:
+      real: true
+      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_1 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im2312:
+      real: true
+      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_1 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im2313:
+      real: true
+      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_1 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im2321:
+      real: true
+      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_2 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im2322:
+      real: true
+      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_2 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im2323:
+      real: true
+      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_2 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im2331:
+      real: true
+      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_3 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im2332:
+      real: true
+      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_3 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im2333:
+      real: true
+      tex: i (\bar \ell_2^I \sigma_{\mu\nu} e_3)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im3211:
+      real: true
+      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_1 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im3212:
+      real: true
+      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_1 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im3213:
+      real: true
+      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_1 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im3221:
+      real: true
+      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_2 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im3222:
+      real: true
+      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_2 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im3223:
+      real: true
+      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_2 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im3231:
+      real: true
+      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_3 \sigma^{\mu\nu} u_1) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im3232:
+      real: true
+      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_3 \sigma^{\mu\nu} u_2) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+    clequ3Im3233:
+      real: true
+      tex: i (\bar \ell_3^I \sigma_{\mu\nu} e_2)(\bar q^J_3 \sigma^{\mu\nu} u_3) \varepsilon_{IJ} / \text{TeV}^2 + \text{h.c.}
+  muemue:
+    cllRe1212:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_1 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
+    cllIm1212:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_1 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
+    ceeRe1212:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_2)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    ceeIm1212:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_2)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cleRe1212:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cleIm1212:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+  etauemu:
+    cllRe1213:
+      real: true
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_1 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+    cllIm1213:
+      real: true
+      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_1 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+    ceeRe1213:
+      real: true
+      tex: 2 (\bar e_1 \gamma_\mu e_2)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    ceeIm1213:
+      real: true
+      tex: 2 i (\bar e_1 \gamma_\mu e_2)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleRe1213:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleRe1312:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cleIm1213:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleIm1312:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+  muemutau:
+    cllRe1232:
+      real: true
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_3 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
+    cllIm1232:
+      real: true
+      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_2)(\bar \ell_3 \gamma^\mu \ell_2) / \text{TeV}^2 + \text{h.c.}
+    ceeRe1232:
+      real: true
+      tex: 2 (\bar e_1 \gamma_\mu e_2)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    ceeIm1232:
+      real: true
+      tex: 2 i (\bar e_1 \gamma_\mu e_2)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cleRe1232:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cleRe2321:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
+    cleIm1232:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_2)(\bar e_3 \gamma^\mu e_2) / \text{TeV}^2 + \text{h.c.}
+    cleIm2321:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_1) / \text{TeV}^2 + \text{h.c.}
+  tauetaue:
+    cllRe1313:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_1 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+    cllIm1313:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_1 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+    ceeRe1313:
+      real: true
+      tex: (\bar e_1 \gamma_\mu e_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    ceeIm1313:
+      real: true
+      tex: i (\bar e_1 \gamma_\mu e_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleRe1313:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleIm1313:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+  tauetaumu:
+    cllRe1323:
+      real: true
+      tex: 2 (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+    cllIm1323:
+      real: true
+      tex: 2 i (\bar \ell_1 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+    ceeRe1323:
+      real: true
+      tex: 2 (\bar e_1 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    ceeIm1323:
+      real: true
+      tex: 2 i (\bar e_1 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleRe1323:
+      real: true
+      tex: (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleRe2313:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleIm1323:
+      real: true
+      tex: i (\bar \ell_1 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleIm2313:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_1 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+  taumutaumu:
+    cllRe2323:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+    cllIm2323:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar \ell_2 \gamma^\mu \ell_3) / \text{TeV}^2 + \text{h.c.}
+    ceeRe2323:
+      real: true
+      tex: (\bar e_2 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    ceeIm2323:
+      real: true
+      tex: i (\bar e_2 \gamma_\mu e_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleRe2323:
+      real: true
+      tex: (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}
+    cleIm2323:
+      real: true
+      tex: i (\bar \ell_2 \gamma_\mu \ell_3)(\bar e_2 \gamma^\mu e_3) / \text{TeV}^2 + \text{h.c.}

--- a/smeft.smeftsim-mfv.basis.json
+++ b/smeft.smeftsim-mfv.basis.json
@@ -5,7 +5,7 @@
     "description": "Basis used in the `SMEFTsim_MFV` UFO models, version 3.0.0 or later. Implements Warsaw basis with $U(3)$ flavor symmetry for all fermions and includes up to 1 lepton Yukawa and 3 quark Yukawa insertions. BSM CP violation is forbidden. $q,u,d$ are the left- and right-handed quark fields. $\\ell, e$ are left- and right-handed lepton fields. $Y_l,Y_u,Y_d$ are the 3x3 yukawa matrices for leptons, up- and down-quarks, defined by $L_{SM} \\supset \\bar d Y_d H^\\dagger q$ and analogously for the others. Quark fields are in the up-aligned basis: $Y_l,Y_u$ are assumed diagonal at the scale of evaluation, while $Y_d = Y_d^{diag} V_{CKM}^\\dagger$. Flavor indices are indicated with $p,r,s,t$ with Einstein conventions on repeated indices. They run over 1,2,3 for all fields. This basis definition corresponds to a fixed `LambdaSMEFT=1e+3` in the UFO models. Notation and conventions can vary compared to the Warsaw basis paper, see [arXiv:2012.11343](https://arxiv.org/abs/2012.11343) for all definitions."
   },
   "sectors": {
-     "dB=dL=0": {
+     "dB=de=dmu=dtau=0": {
        "cG": {
           "real": true,
           "tex": "f^{ABC} G_\\mu^{A \\nu} G_\\nu^{B \\rho} G_\\rho^{C \\mu} / \\text{TeV}^2"

--- a/smeft.smeftsim-mfv.basis.yml
+++ b/smeft.smeftsim-mfv.basis.yml
@@ -3,7 +3,7 @@ basis: SMEFTsim_MFV
 metadata:
   description: 'Basis used in the `SMEFTsim_MFV` UFO models, version 3.0.0 or later. Implements Warsaw basis with $U(3)$ flavor symmetry for all fermions and includes up to 1 lepton Yukawa and 3 quark Yukawa insertions. BSM CP violation is forbidden. $q,u,d$ are the left- and right-handed quark fields. $\ell, e$ are left- and right-handed lepton fields. $Y_l,Y_u,Y_d$ are the 3x3 yukawa matrices for leptons, up- and down-quarks, defined by $L_{SM} \supset \bar d Y_d H^\dagger q$ and analogously for the others. Quark fields are in the up-aligned basis: $Y_l,Y_u$ are assumed diagonal at the scale of evaluation, while $Y_d = Y_d^{diag} V_{CKM}^\dagger$. Flavor indices are indicated with $p,r,s,t$ with Einstein conventions on repeated indices. They run over 1,2,3 for all fields. This basis definition corresponds to a fixed `LambdaSMEFT=1e+3` in the UFO models. Notation and conventions can vary compared to the Warsaw basis paper, see [arXiv:2012.11343](https://arxiv.org/abs/2012.11343) for all definitions.'
 sectors:
-  dB=dL=0:
+  dB=de=dmu=dtau=0:
     cG:
       real: true
       tex: f^{ABC} G_\mu^{A \nu} G_\nu^{B \rho} G_\rho^{C \mu} / \text{TeV}^2

--- a/smeft.smeftsim-top.basis.json
+++ b/smeft.smeftsim-top.basis.json
@@ -5,7 +5,7 @@
     "description": "Basis used in the `SMEFTsim_top` UFO models, version 3.0.0 or later. Implements Warsaw basis with $U(2)^3$ flavor symmetry in the quarks sector and $U(1)^3$ in the leptons sector. $Q,t,b$ are left- and right-handed 3rd gen quarks, $q,u,d$ are the left- and right-handed quark fields containing only the first two generations, and transforming as $U(2)$-flavor doublets. $\\ell, e$ are left- and right-handed lepton fields. $Y_u,Y_d$ are the 2x2 Yukawas of up and down quarks in the first two generations, defined by $L_{SM} \\supset \\bar d Y_d H^\\dagger  q$ and analogously for the others. Spurions connecting the first two generations with the 3rd are absent. In the UFO models, both $Y_u$ and $Y_d$ are assumed diagonal at the scale of evaluation, and the CKM is taken to be the unit matrix. Flavor indices are indicated with $p,r,s,t$ with Einstein conventions on repeated indices. They run over 1,2 for quarks. This basis definition corresponds to a fixed `LambdaSMEFT=1e+3` in the UFO models. Notation and conventions can vary compared to the Warsaw basis paper, see [arXiv:2012.11343](https://arxiv.org/abs/2012.11343) for all definitions."
   },
   "sectors": {
-     "dB=dL=0": {
+     "dB=de=dmu=dtau=0": {
        "cG": {
           "real": true,
           "tex": "f^{ABC} G_\\mu^{A \\nu} G_\\nu^{B \\rho} G_\\rho^{C \\mu} / \\text{TeV}^2"

--- a/smeft.smeftsim-top.basis.yml
+++ b/smeft.smeftsim-top.basis.yml
@@ -1,22 +1,9 @@
 eft: SMEFT
 basis: SMEFTsim_top
 metadata:
-  description: Basis used in the `SMEFTsim_top` UFO models, version 3.0.0 or later.
-    Implements Warsaw basis with $U(2)^3$ flavor symmetry in the quarks sector and
-    $U(1)^3$ in the leptons sector. $Q,t,b$ are left- and right-handed 3rd gen quarks,
-    $q,u,d$ are the left- and right-handed quark fields containing only the first
-    two generations, and transforming as $U(2)$-flavor doublets. $\ell, e$ are left-
-    and right-handed lepton fields. $Y_u,Y_d$ are the 2x2 Yukawas of up and down quarks
-    in the first two generations, defined by $L_{SM} \supset \bar d Y_d H^\dagger  q$
-    and analogously for the others. Spurions connecting the first two generations
-    with the 3rd are absent. In the UFO models, both $Y_u$ and $Y_d$ are assumed diagonal at the
-    scale of evaluation, and the CKM is taken to be the unit matrix. Flavor indices are
-    indicated with $p,r,s,t$ with Einstein conventions on repeated indices. They run
-    over 1,2 for quarks. This basis definition corresponds to a fixed `LambdaSMEFT=1e+3`
-    in the UFO models. Notation and conventions can vary compared to the Warsaw basis
-    paper, see [arXiv:2012.11343](https://arxiv.org/abs/2012.11343) for all definitions.
+  description: Basis used in the `SMEFTsim_top` UFO models, version 3.0.0 or later. Implements Warsaw basis with $U(2)^3$ flavor symmetry in the quarks sector and $U(1)^3$ in the leptons sector. $Q,t,b$ are left- and right-handed 3rd gen quarks, $q,u,d$ are the left- and right-handed quark fields containing only the first two generations, and transforming as $U(2)$-flavor doublets. $\ell, e$ are left- and right-handed lepton fields. $Y_u,Y_d$ are the 2x2 Yukawas of up and down quarks in the first two generations, defined by $L_{SM} \supset \bar d Y_d H^\dagger  q$ and analogously for the others. Spurions connecting the first two generations with the 3rd are absent. In the UFO models, both $Y_u$ and $Y_d$ are assumed diagonal at the scale of evaluation, and the CKM is taken to be the unit matrix. Flavor indices are indicated with $p,r,s,t$ with Einstein conventions on repeated indices. They run over 1,2 for quarks. This basis definition corresponds to a fixed `LambdaSMEFT=1e+3` in the UFO models. Notation and conventions can vary compared to the Warsaw basis paper, see [arXiv:2012.11343](https://arxiv.org/abs/2012.11343) for all definitions.
 sectors:
-  dB=dL=0:
+  dB=de=dmu=dtau=0:
     cG:
       real: true
       tex: f^{ABC} G_\mu^{A \nu} G_\nu^{B \rho} G_\rho^{C \mu} / \text{TeV}^2

--- a/smeft.smeftsim-topu3l.basis.json
+++ b/smeft.smeftsim-topu3l.basis.json
@@ -5,7 +5,7 @@
     "description": "Basis used in the `SMEFTsim_topU3l` UFO models, version 3.0.0 or later. Implements Warsaw basis with $U(2)^3$ flavor symmetry in the quarks sector and $U(3)^2$ in the leptons sector. $Q,t,b$ are left- and right-handed 3rd gen quarks, $q,u,d$ are the left- and right-handed quark fields containing only the first two generations, and transforming as $U(2)$-flavor doublets. $\\ell, e$ are left- and right-handed lepton fields. $Y_u,Y_d$ are the 2x2 Yukawas of up and down quarks in the first two generations. $Y_l$ is the 3x3 lepton Yukawa. Yukawas defined by $L_{SM} \\supset \\bar d Y_d H^\\dagger q$ and analogously for the others. Spurions connecting the first two generations with the 3rd are absent. In the UFO models, both $Y_u$ and $Y_d$ are assumed diagonal at the scale of evaluation, and the CKM is taken to be the unit matrix. Flavor indices are indicated with $p,r,s,t$ with Einstein conventions on repeated indices. They run over 1,2 for quarks and 1,2,3 for leptons. This basis definition corresponds to a fixed `LambdaSMEFT=1e+3` in the UFO models. Notation and conventions can vary compared to the Warsaw basis paper, see [arXiv:2012.11343](https://arxiv.org/abs/2012.11343) for all definitions."
   },
   "sectors": {
-     "dB=dL=0": {
+     "dB=de=dmu=dtau=0": {
        "cG": {
           "real": true,
           "tex": "f^{ABC} G_\\mu^{A \\nu} G_\\nu^{B \\rho} G_\\rho^{C \\mu} / \\text{TeV}^2"

--- a/smeft.smeftsim-topu3l.basis.yml
+++ b/smeft.smeftsim-topu3l.basis.yml
@@ -1,23 +1,9 @@
 eft: SMEFT
 basis: SMEFTsim_topU3l
 metadata:
-  description: Basis used in the `SMEFTsim_topU3l` UFO models, version 3.0.0 or later.
-    Implements Warsaw basis with $U(2)^3$ flavor symmetry in the quarks sector and
-    $U(3)^2$ in the leptons sector. $Q,t,b$ are left- and right-handed 3rd gen quarks,
-    $q,u,d$ are the left- and right-handed quark fields containing only the first
-    two generations, and transforming as $U(2)$-flavor doublets. $\ell, e$ are left-
-    and right-handed lepton fields. $Y_u,Y_d$ are the 2x2 Yukawas of up and down quarks
-    in the first two generations. $Y_l$ is the 3x3 lepton Yukawa. Yukawas defined
-    by $L_{SM} \supset \bar d Y_d H^\dagger q$ and analogously for the others. Spurions
-    connecting the first two generations with the 3rd are absent. In the UFO models,
-    both $Y_u$ and $Y_d$ are assumed diagonal at the scale of evaluation, and the CKM
-    is taken to be the unit matrix. Flavor indices are indicated with $p,r,s,t$
-    with Einstein conventions on repeated indices. They run over 1,2 for quarks and
-    1,2,3 for leptons. This basis definition corresponds to a fixed `LambdaSMEFT=1e+3`
-    in the UFO models. Notation and conventions can vary compared to the Warsaw basis
-    paper, see [arXiv:2012.11343](https://arxiv.org/abs/2012.11343) for all definitions.
+  description: Basis used in the `SMEFTsim_topU3l` UFO models, version 3.0.0 or later. Implements Warsaw basis with $U(2)^3$ flavor symmetry in the quarks sector and $U(3)^2$ in the leptons sector. $Q,t,b$ are left- and right-handed 3rd gen quarks, $q,u,d$ are the left- and right-handed quark fields containing only the first two generations, and transforming as $U(2)$-flavor doublets. $\ell, e$ are left- and right-handed lepton fields. $Y_u,Y_d$ are the 2x2 Yukawas of up and down quarks in the first two generations. $Y_l$ is the 3x3 lepton Yukawa. Yukawas defined by $L_{SM} \supset \bar d Y_d H^\dagger q$ and analogously for the others. Spurions connecting the first two generations with the 3rd are absent. In the UFO models, both $Y_u$ and $Y_d$ are assumed diagonal at the scale of evaluation, and the CKM is taken to be the unit matrix. Flavor indices are indicated with $p,r,s,t$ with Einstein conventions on repeated indices. They run over 1,2 for quarks and 1,2,3 for leptons. This basis definition corresponds to a fixed `LambdaSMEFT=1e+3` in the UFO models. Notation and conventions can vary compared to the Warsaw basis paper, see [arXiv:2012.11343](https://arxiv.org/abs/2012.11343) for all definitions.
 sectors:
-  dB=dL=0:
+  dB=de=dmu=dtau=0:
     cG:
       real: true
       tex: f^{ABC} G_\mu^{A \nu} G_\nu^{B \rho} G_\rho^{C \mu} / \text{TeV}^2

--- a/smeft.smeftsim-u35.basis.json
+++ b/smeft.smeftsim-u35.basis.json
@@ -5,7 +5,7 @@
     "description": "Basis used in the `SMEFTsim_U35` UFO models, version 3.0.0 or later. Implements Warsaw basis with $U(3)$ flavor symmetry for all fermions. For each operator, only the lowest-order flavor structure is kept. $q,u,d$ are the left- and right-handed quark fields. $\\ell, e$ are left- and right-handed lepton fields. $Y_l,Y_u,Y_d$ are the 3x3 yukawa matrices for leptons, up- and down-quarks, defined by $L_{SM} \\supset \\bar d Y_d H^\\dagger q$ and analogously for the others. Quark fields are in the up-aligned basis: $Y_l,Y_u$ are assumed diagonal at the scale of evaluation, while $Y_d = Y_d^{diag} V_{CKM}^\\dagger$. Flavor indices are indicated with $p,r,s,t$ with Einstein conventions on repeated indices. They run over 1,2,3 for all fields. This basis definition corresponds to a fixed `LambdaSMEFT=1e+3` in the UFO models. Notation and conventions can vary compared to the Warsaw basis paper, see [arXiv:2012.11343](https://arxiv.org/abs/2012.11343) for all definitions."
   },
   "sectors": {
-     "dB=dL=0": {
+     "dB=de=dmu=dtau=0": {
        "cG": {
           "real": true,
           "tex": "f^{ABC} G_\\mu^{A \\nu} G_\\nu^{B \\rho} G_\\rho^{C \\mu} / \\text{TeV}^2"

--- a/smeft.smeftsim-u35.basis.yml
+++ b/smeft.smeftsim-u35.basis.yml
@@ -1,21 +1,9 @@
 eft: SMEFT
 basis: SMEFTsim_U35
 metadata:
-  description: 'Basis used in the `SMEFTsim_U35` UFO models, version 3.0.0 or later.
-    Implements Warsaw basis with $U(3)$ flavor symmetry for all fermions. For
-    each operator, only the lowest-order flavor structure is kept. $q,u,d$ are
-    the left- and right-handed quark fields. $\ell, e$ are left- and
-    right-handed lepton fields. $Y_l,Y_u,Y_d$ are the 3x3 yukawa matrices for
-    leptons, up- and down-quarks, defined by $L_{SM} \supset \bar d Y_d
-    H^\dagger q$ and analogously for the others. Quark fields are in the up-aligned
-    basis: $Y_l,Y_u$ are assumed diagonal at the scale of evaluation, while
-    $Y_d = Y_d^{diag} V_{CKM}^\dagger$. Flavor indices are indicated
-    with $p,r,s,t$ with Einstein conventions on repeated indices. They run over
-    1,2,3 for all fields. This basis definition corresponds to a fixed
-    `LambdaSMEFT=1e+3` in the UFO models. Notation and conventions can vary
-    compared to the Warsaw basis paper, see [arXiv:2012.11343](https://arxiv.org/abs/2012.11343) for all definitions.'
+  description: 'Basis used in the `SMEFTsim_U35` UFO models, version 3.0.0 or later. Implements Warsaw basis with $U(3)$ flavor symmetry for all fermions. For each operator, only the lowest-order flavor structure is kept. $q,u,d$ are the left- and right-handed quark fields. $\ell, e$ are left- and right-handed lepton fields. $Y_l,Y_u,Y_d$ are the 3x3 yukawa matrices for leptons, up- and down-quarks, defined by $L_{SM} \supset \bar d Y_d H^\dagger q$ and analogously for the others. Quark fields are in the up-aligned basis: $Y_l,Y_u$ are assumed diagonal at the scale of evaluation, while $Y_d = Y_d^{diag} V_{CKM}^\dagger$. Flavor indices are indicated with $p,r,s,t$ with Einstein conventions on repeated indices. They run over 1,2,3 for all fields. This basis definition corresponds to a fixed `LambdaSMEFT=1e+3` in the UFO models. Notation and conventions can vary compared to the Warsaw basis paper, see [arXiv:2012.11343](https://arxiv.org/abs/2012.11343) for all definitions.'
 sectors:
-  dB=dL=0:
+  dB=de=dmu=dtau=0:
     cG:
       real: true
       tex: f^{ABC} G_\mu^{A \nu} G_\nu^{B \rho} G_\rho^{C \mu} / \text{TeV}^2

--- a/smeft.warsaw.basis.json
+++ b/smeft.warsaw.basis.json
@@ -4306,822 +4306,826 @@
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
       }
     },
-    "dB=dL=1": {
+    "dB=de=1": {
       "duql_1111": {
         "tex": "\\left( d_1 C u_1 \\right) \\left( q_1 C \\ell_1 \\right)"
-      },
-      "duql_1112": {
-        "tex": "\\left( d_1 C u_1 \\right) \\left( q_1 C \\ell_2 \\right)"
-      },
-      "duql_1113": {
-        "tex": "\\left( d_1 C u_1 \\right) \\left( q_1 C \\ell_3 \\right)"
       },
       "duql_1121": {
         "tex": "\\left( d_1 C u_1 \\right) \\left( q_2 C \\ell_1 \\right)"
       },
-      "duql_1122": {
-        "tex": "\\left( d_1 C u_1 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "duql_1123": {
-        "tex": "\\left( d_1 C u_1 \\right) \\left( q_2 C \\ell_3 \\right)"
-      },
       "duql_1131": {
         "tex": "\\left( d_1 C u_1 \\right) \\left( q_3 C \\ell_1 \\right)"
-      },
-      "duql_1132": {
-        "tex": "\\left( d_1 C u_1 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "duql_1133": {
-        "tex": "\\left( d_1 C u_1 \\right) \\left( q_3 C \\ell_3 \\right)"
       },
       "duql_1211": {
         "tex": "\\left( d_1 C u_2 \\right) \\left( q_1 C \\ell_1 \\right)"
       },
-      "duql_1212": {
-        "tex": "\\left( d_1 C u_2 \\right) \\left( q_1 C \\ell_2 \\right)"
-      },
-      "duql_1213": {
-        "tex": "\\left( d_1 C u_2 \\right) \\left( q_1 C \\ell_3 \\right)"
-      },
       "duql_1221": {
         "tex": "\\left( d_1 C u_2 \\right) \\left( q_2 C \\ell_1 \\right)"
-      },
-      "duql_1222": {
-        "tex": "\\left( d_1 C u_2 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "duql_1223": {
-        "tex": "\\left( d_1 C u_2 \\right) \\left( q_2 C \\ell_3 \\right)"
       },
       "duql_1231": {
         "tex": "\\left( d_1 C u_2 \\right) \\left( q_3 C \\ell_1 \\right)"
       },
-      "duql_1232": {
-        "tex": "\\left( d_1 C u_2 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "duql_1233": {
-        "tex": "\\left( d_1 C u_2 \\right) \\left( q_3 C \\ell_3 \\right)"
-      },
       "duql_1311": {
         "tex": "\\left( d_1 C u_3 \\right) \\left( q_1 C \\ell_1 \\right)"
-      },
-      "duql_1312": {
-        "tex": "\\left( d_1 C u_3 \\right) \\left( q_1 C \\ell_2 \\right)"
-      },
-      "duql_1313": {
-        "tex": "\\left( d_1 C u_3 \\right) \\left( q_1 C \\ell_3 \\right)"
       },
       "duql_1321": {
         "tex": "\\left( d_1 C u_3 \\right) \\left( q_2 C \\ell_1 \\right)"
       },
-      "duql_1322": {
-        "tex": "\\left( d_1 C u_3 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "duql_1323": {
-        "tex": "\\left( d_1 C u_3 \\right) \\left( q_2 C \\ell_3 \\right)"
-      },
       "duql_1331": {
         "tex": "\\left( d_1 C u_3 \\right) \\left( q_3 C \\ell_1 \\right)"
-      },
-      "duql_1332": {
-        "tex": "\\left( d_1 C u_3 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "duql_1333": {
-        "tex": "\\left( d_1 C u_3 \\right) \\left( q_3 C \\ell_3 \\right)"
       },
       "duql_2111": {
         "tex": "\\left( d_2 C u_1 \\right) \\left( q_1 C \\ell_1 \\right)"
       },
-      "duql_2112": {
-        "tex": "\\left( d_2 C u_1 \\right) \\left( q_1 C \\ell_2 \\right)"
-      },
-      "duql_2113": {
-        "tex": "\\left( d_2 C u_1 \\right) \\left( q_1 C \\ell_3 \\right)"
-      },
       "duql_2121": {
         "tex": "\\left( d_2 C u_1 \\right) \\left( q_2 C \\ell_1 \\right)"
-      },
-      "duql_2122": {
-        "tex": "\\left( d_2 C u_1 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "duql_2123": {
-        "tex": "\\left( d_2 C u_1 \\right) \\left( q_2 C \\ell_3 \\right)"
       },
       "duql_2131": {
         "tex": "\\left( d_2 C u_1 \\right) \\left( q_3 C \\ell_1 \\right)"
       },
-      "duql_2132": {
-        "tex": "\\left( d_2 C u_1 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "duql_2133": {
-        "tex": "\\left( d_2 C u_1 \\right) \\left( q_3 C \\ell_3 \\right)"
-      },
       "duql_2211": {
         "tex": "\\left( d_2 C u_2 \\right) \\left( q_1 C \\ell_1 \\right)"
-      },
-      "duql_2212": {
-        "tex": "\\left( d_2 C u_2 \\right) \\left( q_1 C \\ell_2 \\right)"
-      },
-      "duql_2213": {
-        "tex": "\\left( d_2 C u_2 \\right) \\left( q_1 C \\ell_3 \\right)"
       },
       "duql_2221": {
         "tex": "\\left( d_2 C u_2 \\right) \\left( q_2 C \\ell_1 \\right)"
       },
-      "duql_2222": {
-        "tex": "\\left( d_2 C u_2 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "duql_2223": {
-        "tex": "\\left( d_2 C u_2 \\right) \\left( q_2 C \\ell_3 \\right)"
-      },
       "duql_2231": {
         "tex": "\\left( d_2 C u_2 \\right) \\left( q_3 C \\ell_1 \\right)"
-      },
-      "duql_2232": {
-        "tex": "\\left( d_2 C u_2 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "duql_2233": {
-        "tex": "\\left( d_2 C u_2 \\right) \\left( q_3 C \\ell_3 \\right)"
       },
       "duql_2311": {
         "tex": "\\left( d_2 C u_3 \\right) \\left( q_1 C \\ell_1 \\right)"
       },
-      "duql_2312": {
-        "tex": "\\left( d_2 C u_3 \\right) \\left( q_1 C \\ell_2 \\right)"
-      },
-      "duql_2313": {
-        "tex": "\\left( d_2 C u_3 \\right) \\left( q_1 C \\ell_3 \\right)"
-      },
       "duql_2321": {
         "tex": "\\left( d_2 C u_3 \\right) \\left( q_2 C \\ell_1 \\right)"
-      },
-      "duql_2322": {
-        "tex": "\\left( d_2 C u_3 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "duql_2323": {
-        "tex": "\\left( d_2 C u_3 \\right) \\left( q_2 C \\ell_3 \\right)"
       },
       "duql_2331": {
         "tex": "\\left( d_2 C u_3 \\right) \\left( q_3 C \\ell_1 \\right)"
       },
-      "duql_2332": {
-        "tex": "\\left( d_2 C u_3 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "duql_2333": {
-        "tex": "\\left( d_2 C u_3 \\right) \\left( q_3 C \\ell_3 \\right)"
-      },
       "duql_3111": {
         "tex": "\\left( d_3 C u_1 \\right) \\left( q_1 C \\ell_1 \\right)"
-      },
-      "duql_3112": {
-        "tex": "\\left( d_3 C u_1 \\right) \\left( q_1 C \\ell_2 \\right)"
-      },
-      "duql_3113": {
-        "tex": "\\left( d_3 C u_1 \\right) \\left( q_1 C \\ell_3 \\right)"
       },
       "duql_3121": {
         "tex": "\\left( d_3 C u_1 \\right) \\left( q_2 C \\ell_1 \\right)"
       },
-      "duql_3122": {
-        "tex": "\\left( d_3 C u_1 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "duql_3123": {
-        "tex": "\\left( d_3 C u_1 \\right) \\left( q_2 C \\ell_3 \\right)"
-      },
       "duql_3131": {
         "tex": "\\left( d_3 C u_1 \\right) \\left( q_3 C \\ell_1 \\right)"
-      },
-      "duql_3132": {
-        "tex": "\\left( d_3 C u_1 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "duql_3133": {
-        "tex": "\\left( d_3 C u_1 \\right) \\left( q_3 C \\ell_3 \\right)"
       },
       "duql_3211": {
         "tex": "\\left( d_3 C u_2 \\right) \\left( q_1 C \\ell_1 \\right)"
       },
-      "duql_3212": {
-        "tex": "\\left( d_3 C u_2 \\right) \\left( q_1 C \\ell_2 \\right)"
-      },
-      "duql_3213": {
-        "tex": "\\left( d_3 C u_2 \\right) \\left( q_1 C \\ell_3 \\right)"
-      },
       "duql_3221": {
         "tex": "\\left( d_3 C u_2 \\right) \\left( q_2 C \\ell_1 \\right)"
-      },
-      "duql_3222": {
-        "tex": "\\left( d_3 C u_2 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "duql_3223": {
-        "tex": "\\left( d_3 C u_2 \\right) \\left( q_2 C \\ell_3 \\right)"
       },
       "duql_3231": {
         "tex": "\\left( d_3 C u_2 \\right) \\left( q_3 C \\ell_1 \\right)"
       },
-      "duql_3232": {
-        "tex": "\\left( d_3 C u_2 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "duql_3233": {
-        "tex": "\\left( d_3 C u_2 \\right) \\left( q_3 C \\ell_3 \\right)"
-      },
       "duql_3311": {
         "tex": "\\left( d_3 C u_3 \\right) \\left( q_1 C \\ell_1 \\right)"
-      },
-      "duql_3312": {
-        "tex": "\\left( d_3 C u_3 \\right) \\left( q_1 C \\ell_2 \\right)"
-      },
-      "duql_3313": {
-        "tex": "\\left( d_3 C u_3 \\right) \\left( q_1 C \\ell_3 \\right)"
       },
       "duql_3321": {
         "tex": "\\left( d_3 C u_3 \\right) \\left( q_2 C \\ell_1 \\right)"
       },
-      "duql_3322": {
-        "tex": "\\left( d_3 C u_3 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "duql_3323": {
-        "tex": "\\left( d_3 C u_3 \\right) \\left( q_2 C \\ell_3 \\right)"
-      },
       "duql_3331": {
         "tex": "\\left( d_3 C u_3 \\right) \\left( q_3 C \\ell_1 \\right)"
-      },
-      "duql_3332": {
-        "tex": "\\left( d_3 C u_3 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "duql_3333": {
-        "tex": "\\left( d_3 C u_3 \\right) \\left( q_3 C \\ell_3 \\right)"
       },
       "qque_1111": {
         "tex": "\\left( q_1 C q_1 \\right) \\left( u_1 C e_1 \\right)"
       },
-      "qque_1112": {
-        "tex": "\\left( q_1 C q_1 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "qque_1113": {
-        "tex": "\\left( q_1 C q_1 \\right) \\left( u_1 C e_3 \\right)"
-      },
       "qque_1121": {
         "tex": "\\left( q_1 C q_1 \\right) \\left( u_2 C e_1 \\right)"
-      },
-      "qque_1122": {
-        "tex": "\\left( q_1 C q_1 \\right) \\left( u_2 C e_2 \\right)"
-      },
-      "qque_1123": {
-        "tex": "\\left( q_1 C q_1 \\right) \\left( u_2 C e_3 \\right)"
       },
       "qque_1131": {
         "tex": "\\left( q_1 C q_1 \\right) \\left( u_3 C e_1 \\right)"
       },
-      "qque_1132": {
-        "tex": "\\left( q_1 C q_1 \\right) \\left( u_3 C e_2 \\right)"
-      },
-      "qque_1133": {
-        "tex": "\\left( q_1 C q_1 \\right) \\left( u_3 C e_3 \\right)"
-      },
       "qque_1211": {
         "tex": "\\left( q_1 C q_2 \\right) \\left( u_1 C e_1 \\right)"
-      },
-      "qque_1212": {
-        "tex": "\\left( q_1 C q_2 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "qque_1213": {
-        "tex": "\\left( q_1 C q_2 \\right) \\left( u_1 C e_3 \\right)"
       },
       "qque_1221": {
         "tex": "\\left( q_1 C q_2 \\right) \\left( u_2 C e_1 \\right)"
       },
-      "qque_1222": {
-        "tex": "\\left( q_1 C q_2 \\right) \\left( u_2 C e_2 \\right)"
-      },
-      "qque_1223": {
-        "tex": "\\left( q_1 C q_2 \\right) \\left( u_2 C e_3 \\right)"
-      },
       "qque_1231": {
         "tex": "\\left( q_1 C q_2 \\right) \\left( u_3 C e_1 \\right)"
-      },
-      "qque_1232": {
-        "tex": "\\left( q_1 C q_2 \\right) \\left( u_3 C e_2 \\right)"
-      },
-      "qque_1233": {
-        "tex": "\\left( q_1 C q_2 \\right) \\left( u_3 C e_3 \\right)"
       },
       "qque_1311": {
         "tex": "\\left( q_1 C q_3 \\right) \\left( u_1 C e_1 \\right)"
       },
-      "qque_1312": {
-        "tex": "\\left( q_1 C q_3 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "qque_1313": {
-        "tex": "\\left( q_1 C q_3 \\right) \\left( u_1 C e_3 \\right)"
-      },
       "qque_1321": {
         "tex": "\\left( q_1 C q_3 \\right) \\left( u_2 C e_1 \\right)"
-      },
-      "qque_1322": {
-        "tex": "\\left( q_1 C q_3 \\right) \\left( u_2 C e_2 \\right)"
-      },
-      "qque_1323": {
-        "tex": "\\left( q_1 C q_3 \\right) \\left( u_2 C e_3 \\right)"
       },
       "qque_1331": {
         "tex": "\\left( q_1 C q_3 \\right) \\left( u_3 C e_1 \\right)"
       },
-      "qque_1332": {
-        "tex": "\\left( q_1 C q_3 \\right) \\left( u_3 C e_2 \\right)"
-      },
-      "qque_1333": {
-        "tex": "\\left( q_1 C q_3 \\right) \\left( u_3 C e_3 \\right)"
-      },
       "qque_2211": {
         "tex": "\\left( q_2 C q_2 \\right) \\left( u_1 C e_1 \\right)"
-      },
-      "qque_2212": {
-        "tex": "\\left( q_2 C q_2 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "qque_2213": {
-        "tex": "\\left( q_2 C q_2 \\right) \\left( u_1 C e_3 \\right)"
       },
       "qque_2221": {
         "tex": "\\left( q_2 C q_2 \\right) \\left( u_2 C e_1 \\right)"
       },
-      "qque_2222": {
-        "tex": "\\left( q_2 C q_2 \\right) \\left( u_2 C e_2 \\right)"
-      },
-      "qque_2223": {
-        "tex": "\\left( q_2 C q_2 \\right) \\left( u_2 C e_3 \\right)"
-      },
       "qque_2231": {
         "tex": "\\left( q_2 C q_2 \\right) \\left( u_3 C e_1 \\right)"
-      },
-      "qque_2232": {
-        "tex": "\\left( q_2 C q_2 \\right) \\left( u_3 C e_2 \\right)"
-      },
-      "qque_2233": {
-        "tex": "\\left( q_2 C q_2 \\right) \\left( u_3 C e_3 \\right)"
       },
       "qque_2311": {
         "tex": "\\left( q_2 C q_3 \\right) \\left( u_1 C e_1 \\right)"
       },
-      "qque_2312": {
-        "tex": "\\left( q_2 C q_3 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "qque_2313": {
-        "tex": "\\left( q_2 C q_3 \\right) \\left( u_1 C e_3 \\right)"
-      },
       "qque_2321": {
         "tex": "\\left( q_2 C q_3 \\right) \\left( u_2 C e_1 \\right)"
-      },
-      "qque_2322": {
-        "tex": "\\left( q_2 C q_3 \\right) \\left( u_2 C e_2 \\right)"
-      },
-      "qque_2323": {
-        "tex": "\\left( q_2 C q_3 \\right) \\left( u_2 C e_3 \\right)"
       },
       "qque_2331": {
         "tex": "\\left( q_2 C q_3 \\right) \\left( u_3 C e_1 \\right)"
       },
-      "qque_2332": {
-        "tex": "\\left( q_2 C q_3 \\right) \\left( u_3 C e_2 \\right)"
-      },
-      "qque_2333": {
-        "tex": "\\left( q_2 C q_3 \\right) \\left( u_3 C e_3 \\right)"
-      },
       "qque_3311": {
         "tex": "\\left( q_3 C q_3 \\right) \\left( u_1 C e_1 \\right)"
-      },
-      "qque_3312": {
-        "tex": "\\left( q_3 C q_3 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "qque_3313": {
-        "tex": "\\left( q_3 C q_3 \\right) \\left( u_1 C e_3 \\right)"
       },
       "qque_3321": {
         "tex": "\\left( q_3 C q_3 \\right) \\left( u_2 C e_1 \\right)"
       },
-      "qque_3322": {
-        "tex": "\\left( q_3 C q_3 \\right) \\left( u_2 C e_2 \\right)"
-      },
-      "qque_3323": {
-        "tex": "\\left( q_3 C q_3 \\right) \\left( u_2 C e_3 \\right)"
-      },
       "qque_3331": {
         "tex": "\\left( q_3 C q_3 \\right) \\left( u_3 C e_1 \\right)"
-      },
-      "qque_3332": {
-        "tex": "\\left( q_3 C q_3 \\right) \\left( u_3 C e_2 \\right)"
-      },
-      "qque_3333": {
-        "tex": "\\left( q_3 C q_3 \\right) \\left( u_3 C e_3 \\right)"
       },
       "qqql_1111": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_1 C \\ell_1 \\right)"
       },
-      "qqql_1112": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_1 C \\ell_2 \\right)"
-      },
-      "qqql_1113": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_1 C \\ell_3 \\right)"
-      },
       "qqql_1121": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_2 C \\ell_1 \\right)"
-      },
-      "qqql_1122": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "qqql_1123": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_2 C \\ell_3 \\right)"
       },
       "qqql_1131": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_3 C \\ell_1 \\right)"
       },
-      "qqql_1132": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "qqql_1133": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_3 C \\ell_3 \\right)"
-      },
       "qqql_1211": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_1 C \\ell_1 \\right)"
-      },
-      "qqql_1212": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_1 C \\ell_2 \\right)"
-      },
-      "qqql_1213": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_1 C \\ell_3 \\right)"
       },
       "qqql_1221": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_2 C \\ell_1 \\right)"
       },
-      "qqql_1222": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "qqql_1223": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_2 C \\ell_3 \\right)"
-      },
       "qqql_1231": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_3 C \\ell_1 \\right)"
-      },
-      "qqql_1232": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "qqql_1233": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_3 C \\ell_3 \\right)"
       },
       "qqql_1311": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_1 C \\ell_1 \\right)"
       },
-      "qqql_1312": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_1 C \\ell_2 \\right)"
-      },
-      "qqql_1313": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_1 C \\ell_3 \\right)"
-      },
       "qqql_1321": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_2 C \\ell_1 \\right)"
-      },
-      "qqql_1322": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "qqql_1323": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_2 C \\ell_3 \\right)"
       },
       "qqql_1331": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_3 C \\ell_1 \\right)"
       },
-      "qqql_1332": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "qqql_1333": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_3 C \\ell_3 \\right)"
-      },
       "qqql_2121": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_1 \\right) \\left( q_2 C \\ell_1 \\right)"
-      },
-      "qqql_2122": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_1 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "qqql_2123": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_1 \\right) \\left( q_2 C \\ell_3 \\right)"
       },
       "qqql_2131": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_1 \\right) \\left( q_3 C \\ell_1 \\right)"
       },
-      "qqql_2132": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_1 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "qqql_2133": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_1 \\right) \\left( q_3 C \\ell_3 \\right)"
-      },
       "qqql_2221": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_2 \\right) \\left( q_2 C \\ell_1 \\right)"
-      },
-      "qqql_2222": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_2 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "qqql_2223": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_2 \\right) \\left( q_2 C \\ell_3 \\right)"
       },
       "qqql_2231": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_2 \\right) \\left( q_3 C \\ell_1 \\right)"
       },
-      "qqql_2232": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_2 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "qqql_2233": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_2 \\right) \\left( q_3 C \\ell_3 \\right)"
-      },
       "qqql_2311": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_1 C \\ell_1 \\right)"
-      },
-      "qqql_2312": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_1 C \\ell_2 \\right)"
-      },
-      "qqql_2313": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_1 C \\ell_3 \\right)"
       },
       "qqql_2321": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_2 C \\ell_1 \\right)"
       },
-      "qqql_2322": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_2 C \\ell_2 \\right)"
-      },
-      "qqql_2323": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_2 C \\ell_3 \\right)"
-      },
       "qqql_2331": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_3 C \\ell_1 \\right)"
-      },
-      "qqql_2332": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "qqql_2333": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_3 C \\ell_3 \\right)"
       },
       "qqql_3131": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_1 \\right) \\left( q_3 C \\ell_1 \\right)"
       },
-      "qqql_3132": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_1 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "qqql_3133": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_1 \\right) \\left( q_3 C \\ell_3 \\right)"
-      },
       "qqql_3231": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_2 \\right) \\left( q_3 C \\ell_1 \\right)"
-      },
-      "qqql_3232": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_2 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "qqql_3233": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_2 \\right) \\left( q_3 C \\ell_3 \\right)"
       },
       "qqql_3331": {
         "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_3 \\right) \\left( q_3 C \\ell_1 \\right)"
       },
-      "qqql_3332": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_3 \\right) \\left( q_3 C \\ell_2 \\right)"
-      },
-      "qqql_3333": {
-        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_3 \\right) \\left( q_3 C \\ell_3 \\right)"
-      },
       "duue_1111": {
         "tex": "\\left( d_1 C u_1 \\right) \\left( u_1 C e_1 \\right)"
-      },
-      "duue_1112": {
-        "tex": "\\left( d_1 C u_1 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "duue_1113": {
-        "tex": "\\left( d_1 C u_1 \\right) \\left( u_1 C e_3 \\right)"
       },
       "duue_1121": {
         "tex": "\\left( d_1 C u_1 \\right) \\left( u_2 C e_1 \\right)"
       },
-      "duue_1122": {
-        "tex": "\\left( d_1 C u_1 \\right) \\left( u_2 C e_2 \\right)"
-      },
-      "duue_1123": {
-        "tex": "\\left( d_1 C u_1 \\right) \\left( u_2 C e_3 \\right)"
-      },
       "duue_1131": {
         "tex": "\\left( d_1 C u_1 \\right) \\left( u_3 C e_1 \\right)"
-      },
-      "duue_1132": {
-        "tex": "\\left( d_1 C u_1 \\right) \\left( u_3 C e_2 \\right)"
-      },
-      "duue_1133": {
-        "tex": "\\left( d_1 C u_1 \\right) \\left( u_3 C e_3 \\right)"
       },
       "duue_1211": {
         "tex": "\\left( d_1 C u_2 \\right) \\left( u_1 C e_1 \\right)"
       },
-      "duue_1212": {
-        "tex": "\\left( d_1 C u_2 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "duue_1213": {
-        "tex": "\\left( d_1 C u_2 \\right) \\left( u_1 C e_3 \\right)"
-      },
       "duue_1221": {
         "tex": "\\left( d_1 C u_2 \\right) \\left( u_2 C e_1 \\right)"
-      },
-      "duue_1222": {
-        "tex": "\\left( d_1 C u_2 \\right) \\left( u_2 C e_2 \\right)"
-      },
-      "duue_1223": {
-        "tex": "\\left( d_1 C u_2 \\right) \\left( u_2 C e_3 \\right)"
       },
       "duue_1231": {
         "tex": "\\left( d_1 C u_2 \\right) \\left( u_3 C e_1 \\right)"
       },
-      "duue_1232": {
-        "tex": "\\left( d_1 C u_2 \\right) \\left( u_3 C e_2 \\right)"
-      },
-      "duue_1233": {
-        "tex": "\\left( d_1 C u_2 \\right) \\left( u_3 C e_3 \\right)"
-      },
       "duue_1311": {
         "tex": "\\left( d_1 C u_3 \\right) \\left( u_1 C e_1 \\right)"
-      },
-      "duue_1312": {
-        "tex": "\\left( d_1 C u_3 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "duue_1313": {
-        "tex": "\\left( d_1 C u_3 \\right) \\left( u_1 C e_3 \\right)"
       },
       "duue_1321": {
         "tex": "\\left( d_1 C u_3 \\right) \\left( u_2 C e_1 \\right)"
       },
-      "duue_1322": {
-        "tex": "\\left( d_1 C u_3 \\right) \\left( u_2 C e_2 \\right)"
-      },
-      "duue_1323": {
-        "tex": "\\left( d_1 C u_3 \\right) \\left( u_2 C e_3 \\right)"
-      },
       "duue_1331": {
         "tex": "\\left( d_1 C u_3 \\right) \\left( u_3 C e_1 \\right)"
-      },
-      "duue_1332": {
-        "tex": "\\left( d_1 C u_3 \\right) \\left( u_3 C e_2 \\right)"
-      },
-      "duue_1333": {
-        "tex": "\\left( d_1 C u_3 \\right) \\left( u_3 C e_3 \\right)"
       },
       "duue_2111": {
         "tex": "\\left( d_2 C u_1 \\right) \\left( u_1 C e_1 \\right)"
       },
-      "duue_2112": {
-        "tex": "\\left( d_2 C u_1 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "duue_2113": {
-        "tex": "\\left( d_2 C u_1 \\right) \\left( u_1 C e_3 \\right)"
-      },
       "duue_2121": {
         "tex": "\\left( d_2 C u_1 \\right) \\left( u_2 C e_1 \\right)"
-      },
-      "duue_2122": {
-        "tex": "\\left( d_2 C u_1 \\right) \\left( u_2 C e_2 \\right)"
-      },
-      "duue_2123": {
-        "tex": "\\left( d_2 C u_1 \\right) \\left( u_2 C e_3 \\right)"
       },
       "duue_2131": {
         "tex": "\\left( d_2 C u_1 \\right) \\left( u_3 C e_1 \\right)"
       },
-      "duue_2132": {
-        "tex": "\\left( d_2 C u_1 \\right) \\left( u_3 C e_2 \\right)"
-      },
-      "duue_2133": {
-        "tex": "\\left( d_2 C u_1 \\right) \\left( u_3 C e_3 \\right)"
-      },
       "duue_2211": {
         "tex": "\\left( d_2 C u_2 \\right) \\left( u_1 C e_1 \\right)"
-      },
-      "duue_2212": {
-        "tex": "\\left( d_2 C u_2 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "duue_2213": {
-        "tex": "\\left( d_2 C u_2 \\right) \\left( u_1 C e_3 \\right)"
       },
       "duue_2221": {
         "tex": "\\left( d_2 C u_2 \\right) \\left( u_2 C e_1 \\right)"
       },
-      "duue_2222": {
-        "tex": "\\left( d_2 C u_2 \\right) \\left( u_2 C e_2 \\right)"
-      },
-      "duue_2223": {
-        "tex": "\\left( d_2 C u_2 \\right) \\left( u_2 C e_3 \\right)"
-      },
       "duue_2231": {
         "tex": "\\left( d_2 C u_2 \\right) \\left( u_3 C e_1 \\right)"
-      },
-      "duue_2232": {
-        "tex": "\\left( d_2 C u_2 \\right) \\left( u_3 C e_2 \\right)"
-      },
-      "duue_2233": {
-        "tex": "\\left( d_2 C u_2 \\right) \\left( u_3 C e_3 \\right)"
       },
       "duue_2311": {
         "tex": "\\left( d_2 C u_3 \\right) \\left( u_1 C e_1 \\right)"
       },
-      "duue_2312": {
-        "tex": "\\left( d_2 C u_3 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "duue_2313": {
-        "tex": "\\left( d_2 C u_3 \\right) \\left( u_1 C e_3 \\right)"
-      },
       "duue_2321": {
         "tex": "\\left( d_2 C u_3 \\right) \\left( u_2 C e_1 \\right)"
-      },
-      "duue_2322": {
-        "tex": "\\left( d_2 C u_3 \\right) \\left( u_2 C e_2 \\right)"
-      },
-      "duue_2323": {
-        "tex": "\\left( d_2 C u_3 \\right) \\left( u_2 C e_3 \\right)"
       },
       "duue_2331": {
         "tex": "\\left( d_2 C u_3 \\right) \\left( u_3 C e_1 \\right)"
       },
-      "duue_2332": {
-        "tex": "\\left( d_2 C u_3 \\right) \\left( u_3 C e_2 \\right)"
-      },
-      "duue_2333": {
-        "tex": "\\left( d_2 C u_3 \\right) \\left( u_3 C e_3 \\right)"
-      },
       "duue_3111": {
         "tex": "\\left( d_3 C u_1 \\right) \\left( u_1 C e_1 \\right)"
-      },
-      "duue_3112": {
-        "tex": "\\left( d_3 C u_1 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "duue_3113": {
-        "tex": "\\left( d_3 C u_1 \\right) \\left( u_1 C e_3 \\right)"
       },
       "duue_3121": {
         "tex": "\\left( d_3 C u_1 \\right) \\left( u_2 C e_1 \\right)"
       },
-      "duue_3122": {
-        "tex": "\\left( d_3 C u_1 \\right) \\left( u_2 C e_2 \\right)"
-      },
-      "duue_3123": {
-        "tex": "\\left( d_3 C u_1 \\right) \\left( u_2 C e_3 \\right)"
-      },
       "duue_3131": {
         "tex": "\\left( d_3 C u_1 \\right) \\left( u_3 C e_1 \\right)"
-      },
-      "duue_3132": {
-        "tex": "\\left( d_3 C u_1 \\right) \\left( u_3 C e_2 \\right)"
-      },
-      "duue_3133": {
-        "tex": "\\left( d_3 C u_1 \\right) \\left( u_3 C e_3 \\right)"
       },
       "duue_3211": {
         "tex": "\\left( d_3 C u_2 \\right) \\left( u_1 C e_1 \\right)"
       },
-      "duue_3212": {
-        "tex": "\\left( d_3 C u_2 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "duue_3213": {
-        "tex": "\\left( d_3 C u_2 \\right) \\left( u_1 C e_3 \\right)"
-      },
       "duue_3221": {
         "tex": "\\left( d_3 C u_2 \\right) \\left( u_2 C e_1 \\right)"
-      },
-      "duue_3222": {
-        "tex": "\\left( d_3 C u_2 \\right) \\left( u_2 C e_2 \\right)"
-      },
-      "duue_3223": {
-        "tex": "\\left( d_3 C u_2 \\right) \\left( u_2 C e_3 \\right)"
       },
       "duue_3231": {
         "tex": "\\left( d_3 C u_2 \\right) \\left( u_3 C e_1 \\right)"
       },
-      "duue_3232": {
-        "tex": "\\left( d_3 C u_2 \\right) \\left( u_3 C e_2 \\right)"
-      },
-      "duue_3233": {
-        "tex": "\\left( d_3 C u_2 \\right) \\left( u_3 C e_3 \\right)"
-      },
       "duue_3311": {
         "tex": "\\left( d_3 C u_3 \\right) \\left( u_1 C e_1 \\right)"
-      },
-      "duue_3312": {
-        "tex": "\\left( d_3 C u_3 \\right) \\left( u_1 C e_2 \\right)"
-      },
-      "duue_3313": {
-        "tex": "\\left( d_3 C u_3 \\right) \\left( u_1 C e_3 \\right)"
       },
       "duue_3321": {
         "tex": "\\left( d_3 C u_3 \\right) \\left( u_2 C e_1 \\right)"
       },
+      "duue_3331": {
+        "tex": "\\left( d_3 C u_3 \\right) \\left( u_3 C e_1 \\right)"
+      }
+    },
+    "dB=dmu=1": {
+      "duql_1112": {
+        "tex": "\\left( d_1 C u_1 \\right) \\left( q_1 C \\ell_2 \\right)"
+      },
+      "duql_1122": {
+        "tex": "\\left( d_1 C u_1 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "duql_1132": {
+        "tex": "\\left( d_1 C u_1 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "duql_1212": {
+        "tex": "\\left( d_1 C u_2 \\right) \\left( q_1 C \\ell_2 \\right)"
+      },
+      "duql_1222": {
+        "tex": "\\left( d_1 C u_2 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "duql_1232": {
+        "tex": "\\left( d_1 C u_2 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "duql_1312": {
+        "tex": "\\left( d_1 C u_3 \\right) \\left( q_1 C \\ell_2 \\right)"
+      },
+      "duql_1322": {
+        "tex": "\\left( d_1 C u_3 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "duql_1332": {
+        "tex": "\\left( d_1 C u_3 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "duql_2112": {
+        "tex": "\\left( d_2 C u_1 \\right) \\left( q_1 C \\ell_2 \\right)"
+      },
+      "duql_2122": {
+        "tex": "\\left( d_2 C u_1 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "duql_2132": {
+        "tex": "\\left( d_2 C u_1 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "duql_2212": {
+        "tex": "\\left( d_2 C u_2 \\right) \\left( q_1 C \\ell_2 \\right)"
+      },
+      "duql_2222": {
+        "tex": "\\left( d_2 C u_2 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "duql_2232": {
+        "tex": "\\left( d_2 C u_2 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "duql_2312": {
+        "tex": "\\left( d_2 C u_3 \\right) \\left( q_1 C \\ell_2 \\right)"
+      },
+      "duql_2322": {
+        "tex": "\\left( d_2 C u_3 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "duql_2332": {
+        "tex": "\\left( d_2 C u_3 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "duql_3112": {
+        "tex": "\\left( d_3 C u_1 \\right) \\left( q_1 C \\ell_2 \\right)"
+      },
+      "duql_3122": {
+        "tex": "\\left( d_3 C u_1 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "duql_3132": {
+        "tex": "\\left( d_3 C u_1 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "duql_3212": {
+        "tex": "\\left( d_3 C u_2 \\right) \\left( q_1 C \\ell_2 \\right)"
+      },
+      "duql_3222": {
+        "tex": "\\left( d_3 C u_2 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "duql_3232": {
+        "tex": "\\left( d_3 C u_2 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "duql_3312": {
+        "tex": "\\left( d_3 C u_3 \\right) \\left( q_1 C \\ell_2 \\right)"
+      },
+      "duql_3322": {
+        "tex": "\\left( d_3 C u_3 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "duql_3332": {
+        "tex": "\\left( d_3 C u_3 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "qque_1112": {
+        "tex": "\\left( q_1 C q_1 \\right) \\left( u_1 C e_2 \\right)"
+      },
+      "qque_1122": {
+        "tex": "\\left( q_1 C q_1 \\right) \\left( u_2 C e_2 \\right)"
+      },
+      "qque_1132": {
+        "tex": "\\left( q_1 C q_1 \\right) \\left( u_3 C e_2 \\right)"
+      },
+      "qque_1212": {
+        "tex": "\\left( q_1 C q_2 \\right) \\left( u_1 C e_2 \\right)"
+      },
+      "qque_1222": {
+        "tex": "\\left( q_1 C q_2 \\right) \\left( u_2 C e_2 \\right)"
+      },
+      "qque_1232": {
+        "tex": "\\left( q_1 C q_2 \\right) \\left( u_3 C e_2 \\right)"
+      },
+      "qque_1312": {
+        "tex": "\\left( q_1 C q_3 \\right) \\left( u_1 C e_2 \\right)"
+      },
+      "qque_1322": {
+        "tex": "\\left( q_1 C q_3 \\right) \\left( u_2 C e_2 \\right)"
+      },
+      "qque_1332": {
+        "tex": "\\left( q_1 C q_3 \\right) \\left( u_3 C e_2 \\right)"
+      },
+      "qque_2212": {
+        "tex": "\\left( q_2 C q_2 \\right) \\left( u_1 C e_2 \\right)"
+      },
+      "qque_2222": {
+        "tex": "\\left( q_2 C q_2 \\right) \\left( u_2 C e_2 \\right)"
+      },
+      "qque_2232": {
+        "tex": "\\left( q_2 C q_2 \\right) \\left( u_3 C e_2 \\right)"
+      },
+      "qque_2312": {
+        "tex": "\\left( q_2 C q_3 \\right) \\left( u_1 C e_2 \\right)"
+      },
+      "qque_2322": {
+        "tex": "\\left( q_2 C q_3 \\right) \\left( u_2 C e_2 \\right)"
+      },
+      "qque_2332": {
+        "tex": "\\left( q_2 C q_3 \\right) \\left( u_3 C e_2 \\right)"
+      },
+      "qque_3312": {
+        "tex": "\\left( q_3 C q_3 \\right) \\left( u_1 C e_2 \\right)"
+      },
+      "qque_3322": {
+        "tex": "\\left( q_3 C q_3 \\right) \\left( u_2 C e_2 \\right)"
+      },
+      "qque_3332": {
+        "tex": "\\left( q_3 C q_3 \\right) \\left( u_3 C e_2 \\right)"
+      },
+      "qqql_1112": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_1 C \\ell_2 \\right)"
+      },
+      "qqql_1122": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "qqql_1132": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "qqql_1212": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_1 C \\ell_2 \\right)"
+      },
+      "qqql_1222": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "qqql_1232": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "qqql_1312": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_1 C \\ell_2 \\right)"
+      },
+      "qqql_1322": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "qqql_1332": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "qqql_2122": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_1 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "qqql_2132": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_1 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "qqql_2222": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_2 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "qqql_2232": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_2 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "qqql_2312": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_1 C \\ell_2 \\right)"
+      },
+      "qqql_2322": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_2 C \\ell_2 \\right)"
+      },
+      "qqql_2332": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "qqql_3132": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_1 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "qqql_3232": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_2 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "qqql_3332": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_3 \\right) \\left( q_3 C \\ell_2 \\right)"
+      },
+      "duue_1112": {
+        "tex": "\\left( d_1 C u_1 \\right) \\left( u_1 C e_2 \\right)"
+      },
+      "duue_1122": {
+        "tex": "\\left( d_1 C u_1 \\right) \\left( u_2 C e_2 \\right)"
+      },
+      "duue_1132": {
+        "tex": "\\left( d_1 C u_1 \\right) \\left( u_3 C e_2 \\right)"
+      },
+      "duue_1212": {
+        "tex": "\\left( d_1 C u_2 \\right) \\left( u_1 C e_2 \\right)"
+      },
+      "duue_1222": {
+        "tex": "\\left( d_1 C u_2 \\right) \\left( u_2 C e_2 \\right)"
+      },
+      "duue_1232": {
+        "tex": "\\left( d_1 C u_2 \\right) \\left( u_3 C e_2 \\right)"
+      },
+      "duue_1312": {
+        "tex": "\\left( d_1 C u_3 \\right) \\left( u_1 C e_2 \\right)"
+      },
+      "duue_1322": {
+        "tex": "\\left( d_1 C u_3 \\right) \\left( u_2 C e_2 \\right)"
+      },
+      "duue_1332": {
+        "tex": "\\left( d_1 C u_3 \\right) \\left( u_3 C e_2 \\right)"
+      },
+      "duue_2112": {
+        "tex": "\\left( d_2 C u_1 \\right) \\left( u_1 C e_2 \\right)"
+      },
+      "duue_2122": {
+        "tex": "\\left( d_2 C u_1 \\right) \\left( u_2 C e_2 \\right)"
+      },
+      "duue_2132": {
+        "tex": "\\left( d_2 C u_1 \\right) \\left( u_3 C e_2 \\right)"
+      },
+      "duue_2212": {
+        "tex": "\\left( d_2 C u_2 \\right) \\left( u_1 C e_2 \\right)"
+      },
+      "duue_2222": {
+        "tex": "\\left( d_2 C u_2 \\right) \\left( u_2 C e_2 \\right)"
+      },
+      "duue_2232": {
+        "tex": "\\left( d_2 C u_2 \\right) \\left( u_3 C e_2 \\right)"
+      },
+      "duue_2312": {
+        "tex": "\\left( d_2 C u_3 \\right) \\left( u_1 C e_2 \\right)"
+      },
+      "duue_2322": {
+        "tex": "\\left( d_2 C u_3 \\right) \\left( u_2 C e_2 \\right)"
+      },
+      "duue_2332": {
+        "tex": "\\left( d_2 C u_3 \\right) \\left( u_3 C e_2 \\right)"
+      },
+      "duue_3112": {
+        "tex": "\\left( d_3 C u_1 \\right) \\left( u_1 C e_2 \\right)"
+      },
+      "duue_3122": {
+        "tex": "\\left( d_3 C u_1 \\right) \\left( u_2 C e_2 \\right)"
+      },
+      "duue_3132": {
+        "tex": "\\left( d_3 C u_1 \\right) \\left( u_3 C e_2 \\right)"
+      },
+      "duue_3212": {
+        "tex": "\\left( d_3 C u_2 \\right) \\left( u_1 C e_2 \\right)"
+      },
+      "duue_3222": {
+        "tex": "\\left( d_3 C u_2 \\right) \\left( u_2 C e_2 \\right)"
+      },
+      "duue_3232": {
+        "tex": "\\left( d_3 C u_2 \\right) \\left( u_3 C e_2 \\right)"
+      },
+      "duue_3312": {
+        "tex": "\\left( d_3 C u_3 \\right) \\left( u_1 C e_2 \\right)"
+      },
       "duue_3322": {
         "tex": "\\left( d_3 C u_3 \\right) \\left( u_2 C e_2 \\right)"
       },
-      "duue_3323": {
-        "tex": "\\left( d_3 C u_3 \\right) \\left( u_2 C e_3 \\right)"
-      },
-      "duue_3331": {
-        "tex": "\\left( d_3 C u_3 \\right) \\left( u_3 C e_1 \\right)"
-      },
       "duue_3332": {
         "tex": "\\left( d_3 C u_3 \\right) \\left( u_3 C e_2 \\right)"
+      }
+    },
+    "dB=dtau=1": {
+      "duql_1113": {
+        "tex": "\\left( d_1 C u_1 \\right) \\left( q_1 C \\ell_3 \\right)"
+      },
+      "duql_1123": {
+        "tex": "\\left( d_1 C u_1 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "duql_1133": {
+        "tex": "\\left( d_1 C u_1 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "duql_1213": {
+        "tex": "\\left( d_1 C u_2 \\right) \\left( q_1 C \\ell_3 \\right)"
+      },
+      "duql_1223": {
+        "tex": "\\left( d_1 C u_2 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "duql_1233": {
+        "tex": "\\left( d_1 C u_2 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "duql_1313": {
+        "tex": "\\left( d_1 C u_3 \\right) \\left( q_1 C \\ell_3 \\right)"
+      },
+      "duql_1323": {
+        "tex": "\\left( d_1 C u_3 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "duql_1333": {
+        "tex": "\\left( d_1 C u_3 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "duql_2113": {
+        "tex": "\\left( d_2 C u_1 \\right) \\left( q_1 C \\ell_3 \\right)"
+      },
+      "duql_2123": {
+        "tex": "\\left( d_2 C u_1 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "duql_2133": {
+        "tex": "\\left( d_2 C u_1 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "duql_2213": {
+        "tex": "\\left( d_2 C u_2 \\right) \\left( q_1 C \\ell_3 \\right)"
+      },
+      "duql_2223": {
+        "tex": "\\left( d_2 C u_2 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "duql_2233": {
+        "tex": "\\left( d_2 C u_2 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "duql_2313": {
+        "tex": "\\left( d_2 C u_3 \\right) \\left( q_1 C \\ell_3 \\right)"
+      },
+      "duql_2323": {
+        "tex": "\\left( d_2 C u_3 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "duql_2333": {
+        "tex": "\\left( d_2 C u_3 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "duql_3113": {
+        "tex": "\\left( d_3 C u_1 \\right) \\left( q_1 C \\ell_3 \\right)"
+      },
+      "duql_3123": {
+        "tex": "\\left( d_3 C u_1 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "duql_3133": {
+        "tex": "\\left( d_3 C u_1 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "duql_3213": {
+        "tex": "\\left( d_3 C u_2 \\right) \\left( q_1 C \\ell_3 \\right)"
+      },
+      "duql_3223": {
+        "tex": "\\left( d_3 C u_2 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "duql_3233": {
+        "tex": "\\left( d_3 C u_2 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "duql_3313": {
+        "tex": "\\left( d_3 C u_3 \\right) \\left( q_1 C \\ell_3 \\right)"
+      },
+      "duql_3323": {
+        "tex": "\\left( d_3 C u_3 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "duql_3333": {
+        "tex": "\\left( d_3 C u_3 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "qque_1113": {
+        "tex": "\\left( q_1 C q_1 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "qque_1123": {
+        "tex": "\\left( q_1 C q_1 \\right) \\left( u_2 C e_3 \\right)"
+      },
+      "qque_1133": {
+        "tex": "\\left( q_1 C q_1 \\right) \\left( u_3 C e_3 \\right)"
+      },
+      "qque_1213": {
+        "tex": "\\left( q_1 C q_2 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "qque_1223": {
+        "tex": "\\left( q_1 C q_2 \\right) \\left( u_2 C e_3 \\right)"
+      },
+      "qque_1233": {
+        "tex": "\\left( q_1 C q_2 \\right) \\left( u_3 C e_3 \\right)"
+      },
+      "qque_1313": {
+        "tex": "\\left( q_1 C q_3 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "qque_1323": {
+        "tex": "\\left( q_1 C q_3 \\right) \\left( u_2 C e_3 \\right)"
+      },
+      "qque_1333": {
+        "tex": "\\left( q_1 C q_3 \\right) \\left( u_3 C e_3 \\right)"
+      },
+      "qque_2213": {
+        "tex": "\\left( q_2 C q_2 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "qque_2223": {
+        "tex": "\\left( q_2 C q_2 \\right) \\left( u_2 C e_3 \\right)"
+      },
+      "qque_2233": {
+        "tex": "\\left( q_2 C q_2 \\right) \\left( u_3 C e_3 \\right)"
+      },
+      "qque_2313": {
+        "tex": "\\left( q_2 C q_3 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "qque_2323": {
+        "tex": "\\left( q_2 C q_3 \\right) \\left( u_2 C e_3 \\right)"
+      },
+      "qque_2333": {
+        "tex": "\\left( q_2 C q_3 \\right) \\left( u_3 C e_3 \\right)"
+      },
+      "qque_3313": {
+        "tex": "\\left( q_3 C q_3 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "qque_3323": {
+        "tex": "\\left( q_3 C q_3 \\right) \\left( u_2 C e_3 \\right)"
+      },
+      "qque_3333": {
+        "tex": "\\left( q_3 C q_3 \\right) \\left( u_3 C e_3 \\right)"
+      },
+      "qqql_1113": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_1 C \\ell_3 \\right)"
+      },
+      "qqql_1123": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "qqql_1133": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_1 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "qqql_1213": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_1 C \\ell_3 \\right)"
+      },
+      "qqql_1223": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "qqql_1233": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_2 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "qqql_1313": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_1 C \\ell_3 \\right)"
+      },
+      "qqql_1323": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "qqql_1333": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_1 C q_3 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "qqql_2123": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_1 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "qqql_2133": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_1 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "qqql_2223": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_2 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "qqql_2233": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_2 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "qqql_2313": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_1 C \\ell_3 \\right)"
+      },
+      "qqql_2323": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_2 C \\ell_3 \\right)"
+      },
+      "qqql_2333": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_2 C q_3 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "qqql_3133": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_1 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "qqql_3233": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_2 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "qqql_3333": {
+        "tex": "\\epsilon_{il} \\epsilon_{jk} \\left( q_3 C q_3 \\right) \\left( q_3 C \\ell_3 \\right)"
+      },
+      "duue_1113": {
+        "tex": "\\left( d_1 C u_1 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "duue_1123": {
+        "tex": "\\left( d_1 C u_1 \\right) \\left( u_2 C e_3 \\right)"
+      },
+      "duue_1133": {
+        "tex": "\\left( d_1 C u_1 \\right) \\left( u_3 C e_3 \\right)"
+      },
+      "duue_1213": {
+        "tex": "\\left( d_1 C u_2 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "duue_1223": {
+        "tex": "\\left( d_1 C u_2 \\right) \\left( u_2 C e_3 \\right)"
+      },
+      "duue_1233": {
+        "tex": "\\left( d_1 C u_2 \\right) \\left( u_3 C e_3 \\right)"
+      },
+      "duue_1313": {
+        "tex": "\\left( d_1 C u_3 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "duue_1323": {
+        "tex": "\\left( d_1 C u_3 \\right) \\left( u_2 C e_3 \\right)"
+      },
+      "duue_1333": {
+        "tex": "\\left( d_1 C u_3 \\right) \\left( u_3 C e_3 \\right)"
+      },
+      "duue_2113": {
+        "tex": "\\left( d_2 C u_1 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "duue_2123": {
+        "tex": "\\left( d_2 C u_1 \\right) \\left( u_2 C e_3 \\right)"
+      },
+      "duue_2133": {
+        "tex": "\\left( d_2 C u_1 \\right) \\left( u_3 C e_3 \\right)"
+      },
+      "duue_2213": {
+        "tex": "\\left( d_2 C u_2 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "duue_2223": {
+        "tex": "\\left( d_2 C u_2 \\right) \\left( u_2 C e_3 \\right)"
+      },
+      "duue_2233": {
+        "tex": "\\left( d_2 C u_2 \\right) \\left( u_3 C e_3 \\right)"
+      },
+      "duue_2313": {
+        "tex": "\\left( d_2 C u_3 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "duue_2323": {
+        "tex": "\\left( d_2 C u_3 \\right) \\left( u_2 C e_3 \\right)"
+      },
+      "duue_2333": {
+        "tex": "\\left( d_2 C u_3 \\right) \\left( u_3 C e_3 \\right)"
+      },
+      "duue_3113": {
+        "tex": "\\left( d_3 C u_1 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "duue_3123": {
+        "tex": "\\left( d_3 C u_1 \\right) \\left( u_2 C e_3 \\right)"
+      },
+      "duue_3133": {
+        "tex": "\\left( d_3 C u_1 \\right) \\left( u_3 C e_3 \\right)"
+      },
+      "duue_3213": {
+        "tex": "\\left( d_3 C u_2 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "duue_3223": {
+        "tex": "\\left( d_3 C u_2 \\right) \\left( u_2 C e_3 \\right)"
+      },
+      "duue_3233": {
+        "tex": "\\left( d_3 C u_2 \\right) \\left( u_3 C e_3 \\right)"
+      },
+      "duue_3313": {
+        "tex": "\\left( d_3 C u_3 \\right) \\left( u_1 C e_3 \\right)"
+      },
+      "duue_3323": {
+        "tex": "\\left( d_3 C u_3 \\right) \\left( u_2 C e_3 \\right)"
       },
       "duue_3333": {
         "tex": "\\left( d_3 C u_3 \\right) \\left( u_3 C e_3 \\right)"

--- a/smeft.warsaw.basis.json
+++ b/smeft.warsaw.basis.json
@@ -5,7 +5,7 @@
     "description": "Basis suggested by Grzadkowski, Iskrzy\u0144ski, Misiak, and Rosiek (arXiv:1008.4884v3). At variance with their definition, the Wilson coefficients are defined to be dimensionful, such that $\\mathcal L=\\sum _i C_i O_i$. The set of redundant operators coincides with the choice of DSixTools (arXiv:1704.04504). The weak basis for the fermion fields is chosen such that the running dimension-6 mass matrices of charged leptons and down-type quarks are diagonal at the scale where the coefficient values are specified, while up-type quark singlet field is rotated to diagonalise the running dimension-6 up-type quark mass matrix \"from the right\".\n"
   },
   "sectors": {
-    "dB=dL=0": {
+    "dB=de=dmu=dtau=0": {
       "G": {
         "real": true,
         "tex": "f^{ABC} G_\\mu^{A \\nu} G_\\nu^{B \\rho} G_\\rho^{C \\mu}"
@@ -123,26 +123,8 @@
       "ephi_11": {
         "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_1 e_1 \\varphi \\right)"
       },
-      "ephi_12": {
-        "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_1 e_2 \\varphi \\right)"
-      },
-      "ephi_13": {
-        "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_1 e_3 \\varphi \\right)"
-      },
-      "ephi_21": {
-        "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_2 e_1 \\varphi \\right)"
-      },
       "ephi_22": {
         "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_2 e_2 \\varphi \\right)"
-      },
-      "ephi_23": {
-        "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_2 e_3 \\varphi \\right)"
-      },
-      "ephi_31": {
-        "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_3 e_1 \\varphi \\right)"
-      },
-      "ephi_32": {
-        "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_3 e_2 \\varphi \\right)"
       },
       "ephi_33": {
         "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_3 e_3 \\varphi \\right)"
@@ -150,26 +132,8 @@
       "eW_11": {
         "tex": "\\left( \\bar \\ell_1 \\sigma^{\\mu \\nu} e_1 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
       },
-      "eW_12": {
-        "tex": "\\left( \\bar \\ell_1 \\sigma^{\\mu \\nu} e_2 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
-      },
-      "eW_13": {
-        "tex": "\\left( \\bar \\ell_1 \\sigma^{\\mu \\nu} e_3 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
-      },
-      "eW_21": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma^{\\mu \\nu} e_1 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
-      },
       "eW_22": {
         "tex": "\\left( \\bar \\ell_2 \\sigma^{\\mu \\nu} e_2 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
-      },
-      "eW_23": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma^{\\mu \\nu} e_3 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
-      },
-      "eW_31": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma^{\\mu \\nu} e_1 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
-      },
-      "eW_32": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma^{\\mu \\nu} e_2 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
       },
       "eW_33": {
         "tex": "\\left( \\bar \\ell_3 \\sigma^{\\mu \\nu} e_3 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
@@ -177,26 +141,8 @@
       "eB_11": {
         "tex": "\\left( \\bar \\ell_1 \\sigma^{\\mu \\nu} e_1 \\right) \\varphi B_{\\mu \\nu}"
       },
-      "eB_12": {
-        "tex": "\\left( \\bar \\ell_1 \\sigma^{\\mu \\nu} e_2 \\right) \\varphi B_{\\mu \\nu}"
-      },
-      "eB_13": {
-        "tex": "\\left( \\bar \\ell_1 \\sigma^{\\mu \\nu} e_3 \\right) \\varphi B_{\\mu \\nu}"
-      },
-      "eB_21": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma^{\\mu \\nu} e_1 \\right) \\varphi B_{\\mu \\nu}"
-      },
       "eB_22": {
         "tex": "\\left( \\bar \\ell_2 \\sigma^{\\mu \\nu} e_2 \\right) \\varphi B_{\\mu \\nu}"
-      },
-      "eB_23": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma^{\\mu \\nu} e_3 \\right) \\varphi B_{\\mu \\nu}"
-      },
-      "eB_31": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma^{\\mu \\nu} e_1 \\right) \\varphi B_{\\mu \\nu}"
-      },
-      "eB_32": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma^{\\mu \\nu} e_2 \\right) \\varphi B_{\\mu \\nu}"
       },
       "eB_33": {
         "tex": "\\left( \\bar \\ell_3 \\sigma^{\\mu \\nu} e_3 \\right) \\varphi B_{\\mu \\nu}"
@@ -367,18 +313,9 @@
         "real": true,
         "tex": "\\left( \\varphi^\\dagger i \\overset\\leftrightarrow{D}_\\mu \\varphi \\right) \\left( \\bar \\ell_1 \\gamma^\\mu \\ell_1 \\right)"
       },
-      "phil1_12": {
-        "tex": "\\left( \\varphi^\\dagger i \\overset\\leftrightarrow{D}_\\mu \\varphi \\right) \\left( \\bar \\ell_1 \\gamma^\\mu \\ell_2 \\right)"
-      },
-      "phil1_13": {
-        "tex": "\\left( \\varphi^\\dagger i \\overset\\leftrightarrow{D}_\\mu \\varphi \\right) \\left( \\bar \\ell_1 \\gamma^\\mu \\ell_3 \\right)"
-      },
       "phil1_22": {
         "real": true,
         "tex": "\\left( \\varphi^\\dagger i \\overset\\leftrightarrow{D}_\\mu \\varphi \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_2 \\right)"
-      },
-      "phil1_23": {
-        "tex": "\\left( \\varphi^\\dagger i \\overset\\leftrightarrow{D}_\\mu \\varphi \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_3 \\right)"
       },
       "phil1_33": {
         "real": true,
@@ -388,18 +325,9 @@
         "real": true,
         "tex": "\\left( \\varphi^\\dagger i \\overset\\leftrightarrow{D}^I_\\mu \\varphi \\right) \\left( \\bar \\ell_1 \\tau^I \\gamma^\\mu \\ell_1 \\right)"
       },
-      "phil3_12": {
-        "tex": "\\left( \\varphi^\\dagger i \\overset\\leftrightarrow{D}^I_\\mu \\varphi \\right) \\left( \\bar \\ell_1 \\tau^I \\gamma^\\mu \\ell_2 \\right)"
-      },
-      "phil3_13": {
-        "tex": "\\left( \\varphi^\\dagger i \\overset\\leftrightarrow{D}^I_\\mu \\varphi \\right) \\left( \\bar \\ell_1 \\tau^I \\gamma^\\mu \\ell_3 \\right)"
-      },
       "phil3_22": {
         "real": true,
         "tex": "\\left( \\varphi^\\dagger i \\overset\\leftrightarrow{D}^I_\\mu \\varphi \\right) \\left( \\bar \\ell_2 \\tau^I \\gamma^\\mu \\ell_2 \\right)"
-      },
-      "phil3_23": {
-        "tex": "\\left( \\varphi^\\dagger i \\overset\\leftrightarrow{D}^I_\\mu \\varphi \\right) \\left( \\bar \\ell_2 \\tau^I \\gamma^\\mu \\ell_3 \\right)"
       },
       "phil3_33": {
         "real": true,
@@ -409,18 +337,9 @@
         "real": true,
         "tex": "\\left( \\varphi^\\dagger i \\overset\\leftrightarrow{D}_\\mu \\varphi \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
       },
-      "phie_12": {
-        "tex": "\\left( \\varphi^\\dagger i \\overset\\leftrightarrow{D}_\\mu \\varphi \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "phie_13": {
-        "tex": "\\left( \\varphi^\\dagger i \\overset\\leftrightarrow{D}_\\mu \\varphi \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
       "phie_22": {
         "real": true,
         "tex": "\\left( \\varphi^\\dagger i \\overset\\leftrightarrow{D}_\\mu \\varphi \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "phie_23": {
-        "tex": "\\left( \\varphi^\\dagger i \\overset\\leftrightarrow{D}_\\mu \\varphi \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
       },
       "phie_33": {
         "real": true,
@@ -541,87 +460,33 @@
         "real": true,
         "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar \\ell_1 \\gamma^\\mu \\ell_1 \\right)"
       },
-      "ll_1112": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar \\ell_1 \\gamma^\\mu \\ell_2 \\right)"
-      },
-      "ll_1113": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar \\ell_1 \\gamma^\\mu \\ell_3 \\right)"
-      },
       "ll_1122": {
         "real": true,
         "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_2 \\right)"
-      },
-      "ll_1123": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_3 \\right)"
       },
       "ll_1133": {
         "real": true,
         "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_3 \\right)"
       },
-      "ll_1212": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_1 \\gamma^\\mu \\ell_2 \\right)"
-      },
-      "ll_1213": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_1 \\gamma^\\mu \\ell_3 \\right)"
-      },
       "ll_1221": {
         "real": true,
         "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_1 \\right)"
-      },
-      "ll_1222": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_2 \\right)"
-      },
-      "ll_1223": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_3 \\right)"
-      },
-      "ll_1231": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_1 \\right)"
-      },
-      "ll_1232": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_2 \\right)"
-      },
-      "ll_1233": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_3 \\right)"
-      },
-      "ll_1313": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_1 \\gamma^\\mu \\ell_3 \\right)"
-      },
-      "ll_1322": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_2 \\right)"
-      },
-      "ll_1323": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_3 \\right)"
       },
       "ll_1331": {
         "real": true,
         "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_1 \\right)"
       },
-      "ll_1332": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_2 \\right)"
-      },
-      "ll_1333": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_3 \\right)"
-      },
       "ll_2222": {
         "real": true,
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_2 \\right)"
-      },
-      "ll_2223": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_3 \\right)"
       },
       "ll_2233": {
         "real": true,
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_3 \\right)"
       },
-      "ll_2323": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_3 \\right)"
-      },
       "ll_2332": {
         "real": true,
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_2 \\right)"
-      },
-      "ll_2333": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_3 \\right)"
       },
       "ll_3333": {
         "real": true,
@@ -828,60 +693,6 @@
         "real": true,
         "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar q_3 \\gamma^\\mu q_3 \\right)"
       },
-      "lq1_1211": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_1 \\gamma^\\mu q_1 \\right)"
-      },
-      "lq1_1212": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_1 \\gamma^\\mu q_2 \\right)"
-      },
-      "lq1_1213": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_1 \\gamma^\\mu q_3 \\right)"
-      },
-      "lq1_1221": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_2 \\gamma^\\mu q_1 \\right)"
-      },
-      "lq1_1222": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_2 \\gamma^\\mu q_2 \\right)"
-      },
-      "lq1_1223": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_2 \\gamma^\\mu q_3 \\right)"
-      },
-      "lq1_1231": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_3 \\gamma^\\mu q_1 \\right)"
-      },
-      "lq1_1232": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_3 \\gamma^\\mu q_2 \\right)"
-      },
-      "lq1_1233": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_3 \\gamma^\\mu q_3 \\right)"
-      },
-      "lq1_1311": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu q_1 \\right)"
-      },
-      "lq1_1312": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu q_2 \\right)"
-      },
-      "lq1_1313": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu q_3 \\right)"
-      },
-      "lq1_1321": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu q_1 \\right)"
-      },
-      "lq1_1322": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu q_2 \\right)"
-      },
-      "lq1_1323": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu q_3 \\right)"
-      },
-      "lq1_1331": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu q_1 \\right)"
-      },
-      "lq1_1332": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu q_2 \\right)"
-      },
-      "lq1_1333": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu q_3 \\right)"
-      },
       "lq1_2211": {
         "real": true,
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_1 \\gamma^\\mu q_1 \\right)"
@@ -902,33 +713,6 @@
       "lq1_2233": {
         "real": true,
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_3 \\gamma^\\mu q_3 \\right)"
-      },
-      "lq1_2311": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu q_1 \\right)"
-      },
-      "lq1_2312": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu q_2 \\right)"
-      },
-      "lq1_2313": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu q_3 \\right)"
-      },
-      "lq1_2321": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu q_1 \\right)"
-      },
-      "lq1_2322": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu q_2 \\right)"
-      },
-      "lq1_2323": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu q_3 \\right)"
-      },
-      "lq1_2331": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu q_1 \\right)"
-      },
-      "lq1_2332": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu q_2 \\right)"
-      },
-      "lq1_2333": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu q_3 \\right)"
       },
       "lq1_3311": {
         "real": true,
@@ -972,60 +756,6 @@
         "real": true,
         "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_1 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_3 \\right)"
       },
-      "lq3_1211": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_1 \\right)"
-      },
-      "lq3_1212": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_2 \\right)"
-      },
-      "lq3_1213": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_3 \\right)"
-      },
-      "lq3_1221": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_1 \\right)"
-      },
-      "lq3_1222": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_2 \\right)"
-      },
-      "lq3_1223": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_3 \\right)"
-      },
-      "lq3_1231": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_1 \\right)"
-      },
-      "lq3_1232": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_2 \\right)"
-      },
-      "lq3_1233": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_3 \\right)"
-      },
-      "lq3_1311": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_1 \\right)"
-      },
-      "lq3_1312": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_2 \\right)"
-      },
-      "lq3_1313": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_3 \\right)"
-      },
-      "lq3_1321": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_1 \\right)"
-      },
-      "lq3_1322": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_2 \\right)"
-      },
-      "lq3_1323": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_3 \\right)"
-      },
-      "lq3_1331": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_1 \\right)"
-      },
-      "lq3_1332": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_2 \\right)"
-      },
-      "lq3_1333": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_3 \\right)"
-      },
       "lq3_2211": {
         "real": true,
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_1 \\right)"
@@ -1046,33 +776,6 @@
       "lq3_2233": {
         "real": true,
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_3 \\right)"
-      },
-      "lq3_2311": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_1 \\right)"
-      },
-      "lq3_2312": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_2 \\right)"
-      },
-      "lq3_2313": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_3 \\right)"
-      },
-      "lq3_2321": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_1 \\right)"
-      },
-      "lq3_2322": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_2 \\right)"
-      },
-      "lq3_2323": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_3 \\right)"
-      },
-      "lq3_2331": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_1 \\right)"
-      },
-      "lq3_2332": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_2 \\right)"
-      },
-      "lq3_2333": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_3 \\right)"
       },
       "lq3_3311": {
         "real": true,
@@ -1099,66 +802,21 @@
         "real": true,
         "tex": "\\left( \\bar e_1 \\gamma_\\mu e_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
       },
-      "ee_1112": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "ee_1113": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
       "ee_1122": {
         "real": true,
         "tex": "\\left( \\bar e_1 \\gamma_\\mu e_1 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "ee_1123": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_1 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
       },
       "ee_1133": {
         "real": true,
         "tex": "\\left( \\bar e_1 \\gamma_\\mu e_1 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
       },
-      "ee_1212": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "ee_1213": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
-      "ee_1222": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "ee_1223": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
-      },
-      "ee_1232": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_2 \\right)"
-      },
-      "ee_1233": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
-      },
-      "ee_1313": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
-      "ee_1323": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
-      },
-      "ee_1333": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
-      },
       "ee_2222": {
         "real": true,
         "tex": "\\left( \\bar e_2 \\gamma_\\mu e_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
       },
-      "ee_2223": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
-      },
       "ee_2233": {
         "real": true,
         "tex": "\\left( \\bar e_2 \\gamma_\\mu e_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
-      },
-      "ee_2323": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
-      },
-      "ee_2333": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
       },
       "ee_3333": {
         "real": true,
@@ -1365,60 +1023,6 @@
         "real": true,
         "tex": "\\left( \\bar e_1 \\gamma_\\mu e_1 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
       },
-      "eu_1211": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_1 \\gamma^\\mu u_1 \\right)"
-      },
-      "eu_1212": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_1 \\gamma^\\mu u_2 \\right)"
-      },
-      "eu_1213": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_1 \\gamma^\\mu u_3 \\right)"
-      },
-      "eu_1221": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_2 \\gamma^\\mu u_1 \\right)"
-      },
-      "eu_1222": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_2 \\gamma^\\mu u_2 \\right)"
-      },
-      "eu_1223": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_2 \\gamma^\\mu u_3 \\right)"
-      },
-      "eu_1231": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_3 \\gamma^\\mu u_1 \\right)"
-      },
-      "eu_1232": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_3 \\gamma^\\mu u_2 \\right)"
-      },
-      "eu_1233": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
-      },
-      "eu_1311": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_1 \\right)"
-      },
-      "eu_1312": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_2 \\right)"
-      },
-      "eu_1313": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_3 \\right)"
-      },
-      "eu_1321": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_1 \\right)"
-      },
-      "eu_1322": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_2 \\right)"
-      },
-      "eu_1323": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_3 \\right)"
-      },
-      "eu_1331": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_1 \\right)"
-      },
-      "eu_1332": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_2 \\right)"
-      },
-      "eu_1333": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
-      },
       "eu_2211": {
         "real": true,
         "tex": "\\left( \\bar e_2 \\gamma_\\mu e_2 \\right) \\left( \\bar u_1 \\gamma^\\mu u_1 \\right)"
@@ -1439,33 +1043,6 @@
       "eu_2233": {
         "real": true,
         "tex": "\\left( \\bar e_2 \\gamma_\\mu e_2 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
-      },
-      "eu_2311": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_1 \\right)"
-      },
-      "eu_2312": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_2 \\right)"
-      },
-      "eu_2313": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_3 \\right)"
-      },
-      "eu_2321": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_1 \\right)"
-      },
-      "eu_2322": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_2 \\right)"
-      },
-      "eu_2323": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_3 \\right)"
-      },
-      "eu_2331": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_1 \\right)"
-      },
-      "eu_2332": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_2 \\right)"
-      },
-      "eu_2333": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
       },
       "eu_3311": {
         "real": true,
@@ -1509,60 +1086,6 @@
         "real": true,
         "tex": "\\left( \\bar e_1 \\gamma_\\mu e_1 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
       },
-      "ed_1211": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_1 \\gamma^\\mu d_1 \\right)"
-      },
-      "ed_1212": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_1 \\gamma^\\mu d_2 \\right)"
-      },
-      "ed_1213": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_1 \\gamma^\\mu d_3 \\right)"
-      },
-      "ed_1221": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_2 \\gamma^\\mu d_1 \\right)"
-      },
-      "ed_1222": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_2 \\gamma^\\mu d_2 \\right)"
-      },
-      "ed_1223": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_2 \\gamma^\\mu d_3 \\right)"
-      },
-      "ed_1231": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_3 \\gamma^\\mu d_1 \\right)"
-      },
-      "ed_1232": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_3 \\gamma^\\mu d_2 \\right)"
-      },
-      "ed_1233": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
-      },
-      "ed_1311": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_1 \\right)"
-      },
-      "ed_1312": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_2 \\right)"
-      },
-      "ed_1313": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_3 \\right)"
-      },
-      "ed_1321": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_1 \\right)"
-      },
-      "ed_1322": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_2 \\right)"
-      },
-      "ed_1323": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_3 \\right)"
-      },
-      "ed_1331": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_1 \\right)"
-      },
-      "ed_1332": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_2 \\right)"
-      },
-      "ed_1333": {
-        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
-      },
       "ed_2211": {
         "real": true,
         "tex": "\\left( \\bar e_2 \\gamma_\\mu e_2 \\right) \\left( \\bar d_1 \\gamma^\\mu d_1 \\right)"
@@ -1583,33 +1106,6 @@
       "ed_2233": {
         "real": true,
         "tex": "\\left( \\bar e_2 \\gamma_\\mu e_2 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
-      },
-      "ed_2311": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_1 \\right)"
-      },
-      "ed_2312": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_2 \\right)"
-      },
-      "ed_2313": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_3 \\right)"
-      },
-      "ed_2321": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_1 \\right)"
-      },
-      "ed_2322": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_2 \\right)"
-      },
-      "ed_2323": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_3 \\right)"
-      },
-      "ed_2331": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_1 \\right)"
-      },
-      "ed_2332": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_2 \\right)"
-      },
-      "ed_2333": {
-        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
       },
       "ed_3311": {
         "real": true,
@@ -1924,141 +1420,42 @@
         "real": true,
         "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
       },
-      "le_1112": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_1113": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
       "le_1122": {
         "real": true,
         "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_1123": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
       },
       "le_1133": {
         "real": true,
         "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
       },
-      "le_1211": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
-      },
-      "le_1212": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_1213": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
       "le_1221": {
         "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_1 \\right)"
       },
-      "le_1222": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_1223": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
-      },
-      "le_1231": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_1 \\right)"
-      },
-      "le_1232": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_1233": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
-      },
-      "le_1311": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
-      },
-      "le_1312": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_1313": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
-      "le_1321": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_1 \\right)"
-      },
-      "le_1322": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_1323": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
-      },
       "le_1331": {
         "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_1 \\right)"
-      },
-      "le_1332": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_1333": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
       },
       "le_2211": {
         "real": true,
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
       },
-      "le_2212": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_2213": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
       "le_2222": {
         "real": true,
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_2223": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
       },
       "le_2233": {
         "real": true,
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
       },
-      "le_2311": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
-      },
-      "le_2312": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_2313": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
-      "le_2321": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_1 \\right)"
-      },
-      "le_2322": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_2323": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
-      },
-      "le_2331": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_1 \\right)"
-      },
       "le_2332": {
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_2333": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
       },
       "le_3311": {
         "real": true,
         "tex": "\\left( \\bar \\ell_3 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
       },
-      "le_3312": {
-        "tex": "\\left( \\bar \\ell_3 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_3313": {
-        "tex": "\\left( \\bar \\ell_3 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
       "le_3322": {
         "real": true,
         "tex": "\\left( \\bar \\ell_3 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "le_3323": {
-        "tex": "\\left( \\bar \\ell_3 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
       },
       "le_3333": {
         "real": true,
@@ -2085,60 +1482,6 @@
         "real": true,
         "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
       },
-      "lu_1211": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_1 \\gamma^\\mu u_1 \\right)"
-      },
-      "lu_1212": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_1 \\gamma^\\mu u_2 \\right)"
-      },
-      "lu_1213": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_1 \\gamma^\\mu u_3 \\right)"
-      },
-      "lu_1221": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_2 \\gamma^\\mu u_1 \\right)"
-      },
-      "lu_1222": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_2 \\gamma^\\mu u_2 \\right)"
-      },
-      "lu_1223": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_2 \\gamma^\\mu u_3 \\right)"
-      },
-      "lu_1231": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_3 \\gamma^\\mu u_1 \\right)"
-      },
-      "lu_1232": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_3 \\gamma^\\mu u_2 \\right)"
-      },
-      "lu_1233": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
-      },
-      "lu_1311": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_1 \\right)"
-      },
-      "lu_1312": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_2 \\right)"
-      },
-      "lu_1313": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_3 \\right)"
-      },
-      "lu_1321": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_1 \\right)"
-      },
-      "lu_1322": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_2 \\right)"
-      },
-      "lu_1323": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_3 \\right)"
-      },
-      "lu_1331": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_1 \\right)"
-      },
-      "lu_1332": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_2 \\right)"
-      },
-      "lu_1333": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
-      },
       "lu_2211": {
         "real": true,
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_1 \\gamma^\\mu u_1 \\right)"
@@ -2159,33 +1502,6 @@
       "lu_2233": {
         "real": true,
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
-      },
-      "lu_2311": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_1 \\right)"
-      },
-      "lu_2312": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_2 \\right)"
-      },
-      "lu_2313": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_3 \\right)"
-      },
-      "lu_2321": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_1 \\right)"
-      },
-      "lu_2322": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_2 \\right)"
-      },
-      "lu_2323": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_3 \\right)"
-      },
-      "lu_2331": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_1 \\right)"
-      },
-      "lu_2332": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_2 \\right)"
-      },
-      "lu_2333": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
       },
       "lu_3311": {
         "real": true,
@@ -2229,60 +1545,6 @@
         "real": true,
         "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
       },
-      "ld_1211": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_1 \\gamma^\\mu d_1 \\right)"
-      },
-      "ld_1212": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_1 \\gamma^\\mu d_2 \\right)"
-      },
-      "ld_1213": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_1 \\gamma^\\mu d_3 \\right)"
-      },
-      "ld_1221": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_2 \\gamma^\\mu d_1 \\right)"
-      },
-      "ld_1222": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_2 \\gamma^\\mu d_2 \\right)"
-      },
-      "ld_1223": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_2 \\gamma^\\mu d_3 \\right)"
-      },
-      "ld_1231": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_3 \\gamma^\\mu d_1 \\right)"
-      },
-      "ld_1232": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_3 \\gamma^\\mu d_2 \\right)"
-      },
-      "ld_1233": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
-      },
-      "ld_1311": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_1 \\right)"
-      },
-      "ld_1312": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_2 \\right)"
-      },
-      "ld_1313": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_3 \\right)"
-      },
-      "ld_1321": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_1 \\right)"
-      },
-      "ld_1322": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_2 \\right)"
-      },
-      "ld_1323": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_3 \\right)"
-      },
-      "ld_1331": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_1 \\right)"
-      },
-      "ld_1332": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_2 \\right)"
-      },
-      "ld_1333": {
-        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
-      },
       "ld_2211": {
         "real": true,
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_1 \\gamma^\\mu d_1 \\right)"
@@ -2303,33 +1565,6 @@
       "ld_2233": {
         "real": true,
         "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
-      },
-      "ld_2311": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_1 \\right)"
-      },
-      "ld_2312": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_2 \\right)"
-      },
-      "ld_2313": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_3 \\right)"
-      },
-      "ld_2321": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_1 \\right)"
-      },
-      "ld_2322": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_2 \\right)"
-      },
-      "ld_2323": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_3 \\right)"
-      },
-      "ld_2331": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_1 \\right)"
-      },
-      "ld_2332": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_2 \\right)"
-      },
-      "ld_2333": {
-        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
       },
       "ld_3311": {
         "real": true,
@@ -2356,18 +1591,9 @@
         "real": true,
         "tex": "\\left( \\bar q_1 \\gamma_\\mu q_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
       },
-      "qe_1112": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "qe_1113": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
       "qe_1122": {
         "real": true,
         "tex": "\\left( \\bar q_1 \\gamma_\\mu q_1 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "qe_1123": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_1 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
       },
       "qe_1133": {
         "real": true,
@@ -2376,26 +1602,8 @@
       "qe_1211": {
         "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
       },
-      "qe_1212": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "qe_1213": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
-      "qe_1221": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_1 \\right)"
-      },
       "qe_1222": {
         "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "qe_1223": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
-      },
-      "qe_1231": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_1 \\right)"
-      },
-      "qe_1232": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_2 \\right)"
       },
       "qe_1233": {
         "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
@@ -2403,26 +1611,8 @@
       "qe_1311": {
         "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
       },
-      "qe_1312": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "qe_1313": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
-      "qe_1321": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_1 \\right)"
-      },
       "qe_1322": {
         "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "qe_1323": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
-      },
-      "qe_1331": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_1 \\right)"
-      },
-      "qe_1332": {
-        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_2 \\right)"
       },
       "qe_1333": {
         "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
@@ -2431,18 +1621,9 @@
         "real": true,
         "tex": "\\left( \\bar q_2 \\gamma_\\mu q_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
       },
-      "qe_2212": {
-        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "qe_2213": {
-        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
       "qe_2222": {
         "real": true,
         "tex": "\\left( \\bar q_2 \\gamma_\\mu q_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "qe_2223": {
-        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
       },
       "qe_2233": {
         "real": true,
@@ -2451,26 +1632,8 @@
       "qe_2311": {
         "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
       },
-      "qe_2312": {
-        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "qe_2313": {
-        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
-      "qe_2321": {
-        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_1 \\right)"
-      },
       "qe_2322": {
         "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "qe_2323": {
-        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
-      },
-      "qe_2331": {
-        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_1 \\right)"
-      },
-      "qe_2332": {
-        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_2 \\right)"
       },
       "qe_2333": {
         "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
@@ -2479,18 +1642,9 @@
         "real": true,
         "tex": "\\left( \\bar q_3 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
       },
-      "qe_3312": {
-        "tex": "\\left( \\bar q_3 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
-      },
-      "qe_3313": {
-        "tex": "\\left( \\bar q_3 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
-      },
       "qe_3322": {
         "real": true,
         "tex": "\\left( \\bar q_3 \\gamma_\\mu q_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
-      },
-      "qe_3323": {
-        "tex": "\\left( \\bar q_3 \\gamma_\\mu q_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
       },
       "qe_3333": {
         "real": true,
@@ -3099,87 +2253,6 @@
       "ledq_1133": {
         "tex": "\\left( \\bar \\ell_1 e_1 \\right) \\left( \\bar d_3 q_3 \\right)"
       },
-      "ledq_1211": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_1 q_1 \\right)"
-      },
-      "ledq_1212": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_1 q_2 \\right)"
-      },
-      "ledq_1213": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_1 q_3 \\right)"
-      },
-      "ledq_1221": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_2 q_1 \\right)"
-      },
-      "ledq_1222": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_2 q_2 \\right)"
-      },
-      "ledq_1223": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_2 q_3 \\right)"
-      },
-      "ledq_1231": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_3 q_1 \\right)"
-      },
-      "ledq_1232": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_3 q_2 \\right)"
-      },
-      "ledq_1233": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_3 q_3 \\right)"
-      },
-      "ledq_1311": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_1 q_1 \\right)"
-      },
-      "ledq_1312": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_1 q_2 \\right)"
-      },
-      "ledq_1313": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_1 q_3 \\right)"
-      },
-      "ledq_1321": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_2 q_1 \\right)"
-      },
-      "ledq_1322": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_2 q_2 \\right)"
-      },
-      "ledq_1323": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_2 q_3 \\right)"
-      },
-      "ledq_1331": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_3 q_1 \\right)"
-      },
-      "ledq_1332": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_3 q_2 \\right)"
-      },
-      "ledq_1333": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_3 q_3 \\right)"
-      },
-      "ledq_2111": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_1 q_1 \\right)"
-      },
-      "ledq_2112": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_1 q_2 \\right)"
-      },
-      "ledq_2113": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_1 q_3 \\right)"
-      },
-      "ledq_2121": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_2 q_1 \\right)"
-      },
-      "ledq_2122": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_2 q_2 \\right)"
-      },
-      "ledq_2123": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_2 q_3 \\right)"
-      },
-      "ledq_2131": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_3 q_1 \\right)"
-      },
-      "ledq_2132": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_3 q_2 \\right)"
-      },
-      "ledq_2133": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_3 q_3 \\right)"
-      },
       "ledq_2211": {
         "tex": "\\left( \\bar \\ell_2 e_2 \\right) \\left( \\bar d_1 q_1 \\right)"
       },
@@ -3206,87 +2279,6 @@
       },
       "ledq_2233": {
         "tex": "\\left( \\bar \\ell_2 e_2 \\right) \\left( \\bar d_3 q_3 \\right)"
-      },
-      "ledq_2311": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_1 q_1 \\right)"
-      },
-      "ledq_2312": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_1 q_2 \\right)"
-      },
-      "ledq_2313": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_1 q_3 \\right)"
-      },
-      "ledq_2321": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_2 q_1 \\right)"
-      },
-      "ledq_2322": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_2 q_2 \\right)"
-      },
-      "ledq_2323": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_2 q_3 \\right)"
-      },
-      "ledq_2331": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_3 q_1 \\right)"
-      },
-      "ledq_2332": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_3 q_2 \\right)"
-      },
-      "ledq_2333": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_3 q_3 \\right)"
-      },
-      "ledq_3111": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_1 q_1 \\right)"
-      },
-      "ledq_3112": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_1 q_2 \\right)"
-      },
-      "ledq_3113": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_1 q_3 \\right)"
-      },
-      "ledq_3121": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_2 q_1 \\right)"
-      },
-      "ledq_3122": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_2 q_2 \\right)"
-      },
-      "ledq_3123": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_2 q_3 \\right)"
-      },
-      "ledq_3131": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_3 q_1 \\right)"
-      },
-      "ledq_3132": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_3 q_2 \\right)"
-      },
-      "ledq_3133": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_3 q_3 \\right)"
-      },
-      "ledq_3211": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_1 q_1 \\right)"
-      },
-      "ledq_3212": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_1 q_2 \\right)"
-      },
-      "ledq_3213": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_1 q_3 \\right)"
-      },
-      "ledq_3221": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_2 q_1 \\right)"
-      },
-      "ledq_3222": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_2 q_2 \\right)"
-      },
-      "ledq_3223": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_2 q_3 \\right)"
-      },
-      "ledq_3231": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_3 q_1 \\right)"
-      },
-      "ledq_3232": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_3 q_2 \\right)"
-      },
-      "ledq_3233": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_3 q_3 \\right)"
       },
       "ledq_3311": {
         "tex": "\\left( \\bar \\ell_3 e_3 \\right) \\left( \\bar d_1 q_1 \\right)"
@@ -3828,87 +2820,6 @@
       "lequ1_1133": {
         "tex": "\\left( \\bar \\ell_1 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_3 \\right)"
       },
-      "lequ1_1211": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_1 \\right)"
-      },
-      "lequ1_1212": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_2 \\right)"
-      },
-      "lequ1_1213": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_3 \\right)"
-      },
-      "lequ1_1221": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_1 \\right)"
-      },
-      "lequ1_1222": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_2 \\right)"
-      },
-      "lequ1_1223": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_3 \\right)"
-      },
-      "lequ1_1231": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_1 \\right)"
-      },
-      "lequ1_1232": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_2 \\right)"
-      },
-      "lequ1_1233": {
-        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_3 \\right)"
-      },
-      "lequ1_1311": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_1 \\right)"
-      },
-      "lequ1_1312": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_2 \\right)"
-      },
-      "lequ1_1313": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_3 \\right)"
-      },
-      "lequ1_1321": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_1 \\right)"
-      },
-      "lequ1_1322": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_2 \\right)"
-      },
-      "lequ1_1323": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_3 \\right)"
-      },
-      "lequ1_1331": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_1 \\right)"
-      },
-      "lequ1_1332": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_2 \\right)"
-      },
-      "lequ1_1333": {
-        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_3 \\right)"
-      },
-      "lequ1_2111": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_1 \\right)"
-      },
-      "lequ1_2112": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_2 \\right)"
-      },
-      "lequ1_2113": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_3 \\right)"
-      },
-      "lequ1_2121": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_1 \\right)"
-      },
-      "lequ1_2122": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_2 \\right)"
-      },
-      "lequ1_2123": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_3 \\right)"
-      },
-      "lequ1_2131": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_1 \\right)"
-      },
-      "lequ1_2132": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_2 \\right)"
-      },
-      "lequ1_2133": {
-        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_3 \\right)"
-      },
       "lequ1_2211": {
         "tex": "\\left( \\bar \\ell_2 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_1 \\right)"
       },
@@ -3935,87 +2846,6 @@
       },
       "lequ1_2233": {
         "tex": "\\left( \\bar \\ell_2 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_3 \\right)"
-      },
-      "lequ1_2311": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_1 \\right)"
-      },
-      "lequ1_2312": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_2 \\right)"
-      },
-      "lequ1_2313": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_3 \\right)"
-      },
-      "lequ1_2321": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_1 \\right)"
-      },
-      "lequ1_2322": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_2 \\right)"
-      },
-      "lequ1_2323": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_3 \\right)"
-      },
-      "lequ1_2331": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_1 \\right)"
-      },
-      "lequ1_2332": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_2 \\right)"
-      },
-      "lequ1_2333": {
-        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_3 \\right)"
-      },
-      "lequ1_3111": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_1 \\right)"
-      },
-      "lequ1_3112": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_2 \\right)"
-      },
-      "lequ1_3113": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_3 \\right)"
-      },
-      "lequ1_3121": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_1 \\right)"
-      },
-      "lequ1_3122": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_2 \\right)"
-      },
-      "lequ1_3123": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_3 \\right)"
-      },
-      "lequ1_3131": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_1 \\right)"
-      },
-      "lequ1_3132": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_2 \\right)"
-      },
-      "lequ1_3133": {
-        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_3 \\right)"
-      },
-      "lequ1_3211": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_1 \\right)"
-      },
-      "lequ1_3212": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_2 \\right)"
-      },
-      "lequ1_3213": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_3 \\right)"
-      },
-      "lequ1_3221": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_1 \\right)"
-      },
-      "lequ1_3222": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_2 \\right)"
-      },
-      "lequ1_3223": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_3 \\right)"
-      },
-      "lequ1_3231": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_1 \\right)"
-      },
-      "lequ1_3232": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_2 \\right)"
-      },
-      "lequ1_3233": {
-        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_3 \\right)"
       },
       "lequ1_3311": {
         "tex": "\\left( \\bar \\ell_3 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_1 \\right)"
@@ -4071,6 +2901,431 @@
       "lequ3_1133": {
         "tex": "\\left( \\bar \\ell_1 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_3 \\right)"
       },
+      "lequ3_2211": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_1 \\right)"
+      },
+      "lequ3_2212": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_2 \\right)"
+      },
+      "lequ3_2213": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_3 \\right)"
+      },
+      "lequ3_2221": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_1 \\right)"
+      },
+      "lequ3_2222": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_2 \\right)"
+      },
+      "lequ3_2223": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_3 \\right)"
+      },
+      "lequ3_2231": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_1 \\right)"
+      },
+      "lequ3_2232": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_2 \\right)"
+      },
+      "lequ3_2233": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_3 \\right)"
+      },
+      "lequ3_3311": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_1 \\right)"
+      },
+      "lequ3_3312": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_2 \\right)"
+      },
+      "lequ3_3313": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_3 \\right)"
+      },
+      "lequ3_3321": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_1 \\right)"
+      },
+      "lequ3_3322": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_2 \\right)"
+      },
+      "lequ3_3323": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_3 \\right)"
+      },
+      "lequ3_3331": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_1 \\right)"
+      },
+      "lequ3_3332": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_2 \\right)"
+      },
+      "lequ3_3333": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_3 \\right)"
+      }
+    },
+    "mue": {
+      "ephi_12": {
+        "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_1 e_2 \\varphi \\right)"
+      },
+      "ephi_21": {
+        "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_2 e_1 \\varphi \\right)"
+      },
+      "eW_12": {
+        "tex": "\\left( \\bar \\ell_1 \\sigma^{\\mu \\nu} e_2 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
+      },
+      "eW_21": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma^{\\mu \\nu} e_1 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
+      },
+      "eB_12": {
+        "tex": "\\left( \\bar \\ell_1 \\sigma^{\\mu \\nu} e_2 \\right) \\varphi B_{\\mu \\nu}"
+      },
+      "eB_21": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma^{\\mu \\nu} e_1 \\right) \\varphi B_{\\mu \\nu}"
+      },
+      "phil1_12": {
+        "tex": "\\left( \\varphi^\\dagger i \\overset\\leftrightarrow{D}_\\mu \\varphi \\right) \\left( \\bar \\ell_1 \\gamma^\\mu \\ell_2 \\right)"
+      },
+      "phil3_12": {
+        "tex": "\\left( \\varphi^\\dagger i \\overset\\leftrightarrow{D}^I_\\mu \\varphi \\right) \\left( \\bar \\ell_1 \\tau^I \\gamma^\\mu \\ell_2 \\right)"
+      },
+      "phie_12": {
+        "tex": "\\left( \\varphi^\\dagger i \\overset\\leftrightarrow{D}_\\mu \\varphi \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
+      },
+      "ll_1112": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar \\ell_1 \\gamma^\\mu \\ell_2 \\right)"
+      },
+      "ll_1222": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_2 \\right)"
+      },
+      "ll_1233": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_3 \\right)"
+      },
+      "ll_1332": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_2 \\right)"
+      },
+      "lq1_1211": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_1 \\gamma^\\mu q_1 \\right)"
+      },
+      "lq1_1212": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_1 \\gamma^\\mu q_2 \\right)"
+      },
+      "lq1_1213": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_1 \\gamma^\\mu q_3 \\right)"
+      },
+      "lq1_1221": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_2 \\gamma^\\mu q_1 \\right)"
+      },
+      "lq1_1222": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_2 \\gamma^\\mu q_2 \\right)"
+      },
+      "lq1_1223": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_2 \\gamma^\\mu q_3 \\right)"
+      },
+      "lq1_1231": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_3 \\gamma^\\mu q_1 \\right)"
+      },
+      "lq1_1232": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_3 \\gamma^\\mu q_2 \\right)"
+      },
+      "lq1_1233": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar q_3 \\gamma^\\mu q_3 \\right)"
+      },
+      "lq3_1211": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_1 \\right)"
+      },
+      "lq3_1212": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_2 \\right)"
+      },
+      "lq3_1213": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_3 \\right)"
+      },
+      "lq3_1221": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_1 \\right)"
+      },
+      "lq3_1222": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_2 \\right)"
+      },
+      "lq3_1223": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_3 \\right)"
+      },
+      "lq3_1231": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_1 \\right)"
+      },
+      "lq3_1232": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_2 \\right)"
+      },
+      "lq3_1233": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_2 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_3 \\right)"
+      },
+      "ee_1112": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
+      },
+      "ee_1222": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
+      },
+      "ee_1233": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
+      },
+      "eu_1211": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_1 \\gamma^\\mu u_1 \\right)"
+      },
+      "eu_1212": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_1 \\gamma^\\mu u_2 \\right)"
+      },
+      "eu_1213": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_1 \\gamma^\\mu u_3 \\right)"
+      },
+      "eu_1221": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_2 \\gamma^\\mu u_1 \\right)"
+      },
+      "eu_1222": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_2 \\gamma^\\mu u_2 \\right)"
+      },
+      "eu_1223": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_2 \\gamma^\\mu u_3 \\right)"
+      },
+      "eu_1231": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_3 \\gamma^\\mu u_1 \\right)"
+      },
+      "eu_1232": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_3 \\gamma^\\mu u_2 \\right)"
+      },
+      "eu_1233": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
+      },
+      "ed_1211": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_1 \\gamma^\\mu d_1 \\right)"
+      },
+      "ed_1212": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_1 \\gamma^\\mu d_2 \\right)"
+      },
+      "ed_1213": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_1 \\gamma^\\mu d_3 \\right)"
+      },
+      "ed_1221": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_2 \\gamma^\\mu d_1 \\right)"
+      },
+      "ed_1222": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_2 \\gamma^\\mu d_2 \\right)"
+      },
+      "ed_1223": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_2 \\gamma^\\mu d_3 \\right)"
+      },
+      "ed_1231": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_3 \\gamma^\\mu d_1 \\right)"
+      },
+      "ed_1232": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_3 \\gamma^\\mu d_2 \\right)"
+      },
+      "ed_1233": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
+      },
+      "le_1112": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
+      },
+      "le_1211": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
+      },
+      "le_1222": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
+      },
+      "le_1233": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
+      },
+      "le_1332": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_2 \\right)"
+      },
+      "le_2212": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
+      },
+      "le_2331": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_1 \\right)"
+      },
+      "le_3312": {
+        "tex": "\\left( \\bar \\ell_3 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
+      },
+      "lu_1211": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_1 \\gamma^\\mu u_1 \\right)"
+      },
+      "lu_1212": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_1 \\gamma^\\mu u_2 \\right)"
+      },
+      "lu_1213": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_1 \\gamma^\\mu u_3 \\right)"
+      },
+      "lu_1221": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_2 \\gamma^\\mu u_1 \\right)"
+      },
+      "lu_1222": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_2 \\gamma^\\mu u_2 \\right)"
+      },
+      "lu_1223": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_2 \\gamma^\\mu u_3 \\right)"
+      },
+      "lu_1231": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_3 \\gamma^\\mu u_1 \\right)"
+      },
+      "lu_1232": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_3 \\gamma^\\mu u_2 \\right)"
+      },
+      "lu_1233": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
+      },
+      "ld_1211": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_1 \\gamma^\\mu d_1 \\right)"
+      },
+      "ld_1212": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_1 \\gamma^\\mu d_2 \\right)"
+      },
+      "ld_1213": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_1 \\gamma^\\mu d_3 \\right)"
+      },
+      "ld_1221": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_2 \\gamma^\\mu d_1 \\right)"
+      },
+      "ld_1222": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_2 \\gamma^\\mu d_2 \\right)"
+      },
+      "ld_1223": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_2 \\gamma^\\mu d_3 \\right)"
+      },
+      "ld_1231": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_3 \\gamma^\\mu d_1 \\right)"
+      },
+      "ld_1232": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_3 \\gamma^\\mu d_2 \\right)"
+      },
+      "ld_1233": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
+      },
+      "qe_1112": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
+      },
+      "qe_1212": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
+      },
+      "qe_1221": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_1 \\right)"
+      },
+      "qe_1312": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
+      },
+      "qe_1321": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_1 \\right)"
+      },
+      "qe_2212": {
+        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
+      },
+      "qe_2312": {
+        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
+      },
+      "qe_2321": {
+        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_1 \\right)"
+      },
+      "qe_3312": {
+        "tex": "\\left( \\bar q_3 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
+      },
+      "ledq_1211": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_1 q_1 \\right)"
+      },
+      "ledq_1212": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_1 q_2 \\right)"
+      },
+      "ledq_1213": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_1 q_3 \\right)"
+      },
+      "ledq_1221": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_2 q_1 \\right)"
+      },
+      "ledq_1222": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_2 q_2 \\right)"
+      },
+      "ledq_1223": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_2 q_3 \\right)"
+      },
+      "ledq_1231": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_3 q_1 \\right)"
+      },
+      "ledq_1232": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_3 q_2 \\right)"
+      },
+      "ledq_1233": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\left( \\bar d_3 q_3 \\right)"
+      },
+      "ledq_2111": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_1 q_1 \\right)"
+      },
+      "ledq_2112": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_1 q_2 \\right)"
+      },
+      "ledq_2113": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_1 q_3 \\right)"
+      },
+      "ledq_2121": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_2 q_1 \\right)"
+      },
+      "ledq_2122": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_2 q_2 \\right)"
+      },
+      "ledq_2123": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_2 q_3 \\right)"
+      },
+      "ledq_2131": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_3 q_1 \\right)"
+      },
+      "ledq_2132": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_3 q_2 \\right)"
+      },
+      "ledq_2133": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\left( \\bar d_3 q_3 \\right)"
+      },
+      "lequ1_1211": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_1 \\right)"
+      },
+      "lequ1_1212": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_2 \\right)"
+      },
+      "lequ1_1213": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_3 \\right)"
+      },
+      "lequ1_1221": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_1 \\right)"
+      },
+      "lequ1_1222": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_2 \\right)"
+      },
+      "lequ1_1223": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_3 \\right)"
+      },
+      "lequ1_1231": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_1 \\right)"
+      },
+      "lequ1_1232": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_2 \\right)"
+      },
+      "lequ1_1233": {
+        "tex": "\\left( \\bar \\ell_1 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_3 \\right)"
+      },
+      "lequ1_2111": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_1 \\right)"
+      },
+      "lequ1_2112": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_2 \\right)"
+      },
+      "lequ1_2113": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_3 \\right)"
+      },
+      "lequ1_2121": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_1 \\right)"
+      },
+      "lequ1_2122": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_2 \\right)"
+      },
+      "lequ1_2123": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_3 \\right)"
+      },
+      "lequ1_2131": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_1 \\right)"
+      },
+      "lequ1_2132": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_2 \\right)"
+      },
+      "lequ1_2133": {
+        "tex": "\\left( \\bar \\ell_2 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_3 \\right)"
+      },
       "lequ3_1211": {
         "tex": "\\left( \\bar \\ell_1 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_1 \\right)"
       },
@@ -4097,6 +3352,404 @@
       },
       "lequ3_1233": {
         "tex": "\\left( \\bar \\ell_1 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_3 \\right)"
+      },
+      "lequ3_2111": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_1 \\right)"
+      },
+      "lequ3_2112": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_2 \\right)"
+      },
+      "lequ3_2113": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_3 \\right)"
+      },
+      "lequ3_2121": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_1 \\right)"
+      },
+      "lequ3_2122": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_2 \\right)"
+      },
+      "lequ3_2123": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_3 \\right)"
+      },
+      "lequ3_2131": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_1 \\right)"
+      },
+      "lequ3_2132": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_2 \\right)"
+      },
+      "lequ3_2133": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_3 \\right)"
+      }
+    },
+    "taue": {
+      "ephi_13": {
+        "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_1 e_3 \\varphi \\right)"
+      },
+      "ephi_31": {
+        "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_3 e_1 \\varphi \\right)"
+      },
+      "eW_13": {
+        "tex": "\\left( \\bar \\ell_1 \\sigma^{\\mu \\nu} e_3 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
+      },
+      "eW_31": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma^{\\mu \\nu} e_1 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
+      },
+      "eB_13": {
+        "tex": "\\left( \\bar \\ell_1 \\sigma^{\\mu \\nu} e_3 \\right) \\varphi B_{\\mu \\nu}"
+      },
+      "eB_31": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma^{\\mu \\nu} e_1 \\right) \\varphi B_{\\mu \\nu}"
+      },
+      "phil1_13": {
+        "tex": "\\left( \\varphi^\\dagger i \\overset\\leftrightarrow{D}_\\mu \\varphi \\right) \\left( \\bar \\ell_1 \\gamma^\\mu \\ell_3 \\right)"
+      },
+      "phil3_13": {
+        "tex": "\\left( \\varphi^\\dagger i \\overset\\leftrightarrow{D}^I_\\mu \\varphi \\right) \\left( \\bar \\ell_1 \\tau^I \\gamma^\\mu \\ell_3 \\right)"
+      },
+      "phie_13": {
+        "tex": "\\left( \\varphi^\\dagger i \\overset\\leftrightarrow{D}_\\mu \\varphi \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
+      },
+      "ll_1113": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar \\ell_1 \\gamma^\\mu \\ell_3 \\right)"
+      },
+      "ll_1223": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_3 \\right)"
+      },
+      "ll_1322": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_2 \\right)"
+      },
+      "ll_1333": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_3 \\right)"
+      },
+      "lq1_1311": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu q_1 \\right)"
+      },
+      "lq1_1312": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu q_2 \\right)"
+      },
+      "lq1_1313": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu q_3 \\right)"
+      },
+      "lq1_1321": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu q_1 \\right)"
+      },
+      "lq1_1322": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu q_2 \\right)"
+      },
+      "lq1_1323": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu q_3 \\right)"
+      },
+      "lq1_1331": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu q_1 \\right)"
+      },
+      "lq1_1332": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu q_2 \\right)"
+      },
+      "lq1_1333": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu q_3 \\right)"
+      },
+      "lq3_1311": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_1 \\right)"
+      },
+      "lq3_1312": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_2 \\right)"
+      },
+      "lq3_1313": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_3 \\right)"
+      },
+      "lq3_1321": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_1 \\right)"
+      },
+      "lq3_1322": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_2 \\right)"
+      },
+      "lq3_1323": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_3 \\right)"
+      },
+      "lq3_1331": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_1 \\right)"
+      },
+      "lq3_1332": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_2 \\right)"
+      },
+      "lq3_1333": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_3 \\right)"
+      },
+      "ee_1113": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
+      },
+      "ee_1223": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "ee_1333": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
+      },
+      "eu_1311": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_1 \\right)"
+      },
+      "eu_1312": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_2 \\right)"
+      },
+      "eu_1313": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_3 \\right)"
+      },
+      "eu_1321": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_1 \\right)"
+      },
+      "eu_1322": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_2 \\right)"
+      },
+      "eu_1323": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_3 \\right)"
+      },
+      "eu_1331": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_1 \\right)"
+      },
+      "eu_1332": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_2 \\right)"
+      },
+      "eu_1333": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
+      },
+      "ed_1311": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_1 \\right)"
+      },
+      "ed_1312": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_2 \\right)"
+      },
+      "ed_1313": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_3 \\right)"
+      },
+      "ed_1321": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_1 \\right)"
+      },
+      "ed_1322": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_2 \\right)"
+      },
+      "ed_1323": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_3 \\right)"
+      },
+      "ed_1331": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_1 \\right)"
+      },
+      "ed_1332": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_2 \\right)"
+      },
+      "ed_1333": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
+      },
+      "le_1113": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
+      },
+      "le_1223": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "le_1311": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
+      },
+      "le_1322": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
+      },
+      "le_1333": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
+      },
+      "le_2213": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
+      },
+      "le_2312": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
+      },
+      "le_3313": {
+        "tex": "\\left( \\bar \\ell_3 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
+      },
+      "lu_1311": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_1 \\right)"
+      },
+      "lu_1312": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_2 \\right)"
+      },
+      "lu_1313": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_3 \\right)"
+      },
+      "lu_1321": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_1 \\right)"
+      },
+      "lu_1322": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_2 \\right)"
+      },
+      "lu_1323": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_3 \\right)"
+      },
+      "lu_1331": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_1 \\right)"
+      },
+      "lu_1332": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_2 \\right)"
+      },
+      "lu_1333": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
+      },
+      "ld_1311": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_1 \\right)"
+      },
+      "ld_1312": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_2 \\right)"
+      },
+      "ld_1313": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_3 \\right)"
+      },
+      "ld_1321": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_1 \\right)"
+      },
+      "ld_1322": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_2 \\right)"
+      },
+      "ld_1323": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_3 \\right)"
+      },
+      "ld_1331": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_1 \\right)"
+      },
+      "ld_1332": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_2 \\right)"
+      },
+      "ld_1333": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
+      },
+      "qe_1113": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_1 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
+      },
+      "qe_1213": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
+      },
+      "qe_1231": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_1 \\right)"
+      },
+      "qe_1313": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
+      },
+      "qe_1331": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_1 \\right)"
+      },
+      "qe_2213": {
+        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
+      },
+      "qe_2313": {
+        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
+      },
+      "qe_2331": {
+        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_1 \\right)"
+      },
+      "qe_3313": {
+        "tex": "\\left( \\bar q_3 \\gamma_\\mu q_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
+      },
+      "ledq_1311": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_1 q_1 \\right)"
+      },
+      "ledq_1312": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_1 q_2 \\right)"
+      },
+      "ledq_1313": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_1 q_3 \\right)"
+      },
+      "ledq_1321": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_2 q_1 \\right)"
+      },
+      "ledq_1322": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_2 q_2 \\right)"
+      },
+      "ledq_1323": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_2 q_3 \\right)"
+      },
+      "ledq_1331": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_3 q_1 \\right)"
+      },
+      "ledq_1332": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_3 q_2 \\right)"
+      },
+      "ledq_1333": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\left( \\bar d_3 q_3 \\right)"
+      },
+      "ledq_3111": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_1 q_1 \\right)"
+      },
+      "ledq_3112": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_1 q_2 \\right)"
+      },
+      "ledq_3113": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_1 q_3 \\right)"
+      },
+      "ledq_3121": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_2 q_1 \\right)"
+      },
+      "ledq_3122": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_2 q_2 \\right)"
+      },
+      "ledq_3123": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_2 q_3 \\right)"
+      },
+      "ledq_3131": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_3 q_1 \\right)"
+      },
+      "ledq_3132": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_3 q_2 \\right)"
+      },
+      "ledq_3133": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\left( \\bar d_3 q_3 \\right)"
+      },
+      "lequ1_1311": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_1 \\right)"
+      },
+      "lequ1_1312": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_2 \\right)"
+      },
+      "lequ1_1313": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_3 \\right)"
+      },
+      "lequ1_1321": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_1 \\right)"
+      },
+      "lequ1_1322": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_2 \\right)"
+      },
+      "lequ1_1323": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_3 \\right)"
+      },
+      "lequ1_1331": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_1 \\right)"
+      },
+      "lequ1_1332": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_2 \\right)"
+      },
+      "lequ1_1333": {
+        "tex": "\\left( \\bar \\ell_1 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_3 \\right)"
+      },
+      "lequ1_3111": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_1 \\right)"
+      },
+      "lequ1_3112": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_2 \\right)"
+      },
+      "lequ1_3113": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_3 \\right)"
+      },
+      "lequ1_3121": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_1 \\right)"
+      },
+      "lequ1_3122": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_2 \\right)"
+      },
+      "lequ1_3123": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_3 \\right)"
+      },
+      "lequ1_3131": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_1 \\right)"
+      },
+      "lequ1_3132": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_2 \\right)"
+      },
+      "lequ1_3133": {
+        "tex": "\\left( \\bar \\ell_3 e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_3 \\right)"
       },
       "lequ3_1311": {
         "tex": "\\left( \\bar \\ell_1 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_1 \\right)"
@@ -4125,59 +3778,403 @@
       "lequ3_1333": {
         "tex": "\\left( \\bar \\ell_1 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_3 \\right)"
       },
-      "lequ3_2111": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_1 \\right)"
+      "lequ3_3111": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_1 \\right)"
       },
-      "lequ3_2112": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_2 \\right)"
+      "lequ3_3112": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_2 \\right)"
       },
-      "lequ3_2113": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_3 \\right)"
+      "lequ3_3113": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_3 \\right)"
       },
-      "lequ3_2121": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_1 \\right)"
+      "lequ3_3121": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_1 \\right)"
       },
-      "lequ3_2122": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_2 \\right)"
+      "lequ3_3122": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_2 \\right)"
       },
-      "lequ3_2123": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_3 \\right)"
+      "lequ3_3123": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_3 \\right)"
       },
-      "lequ3_2131": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_1 \\right)"
+      "lequ3_3131": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_1 \\right)"
       },
-      "lequ3_2132": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_2 \\right)"
+      "lequ3_3132": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_2 \\right)"
       },
-      "lequ3_2133": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_3 \\right)"
+      "lequ3_3133": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_3 \\right)"
+      }
+    },
+    "mutau": {
+      "ephi_23": {
+        "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_2 e_3 \\varphi \\right)"
       },
-      "lequ3_2211": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_1 \\right)"
+      "ephi_32": {
+        "tex": "\\left( \\varphi^\\dagger \\varphi \\right) \\left( \\bar \\ell_3 e_2 \\varphi \\right)"
       },
-      "lequ3_2212": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_2 \\right)"
+      "eW_23": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma^{\\mu \\nu} e_3 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
       },
-      "lequ3_2213": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_3 \\right)"
+      "eW_32": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma^{\\mu \\nu} e_2 \\right) \\tau^I \\varphi W_{\\mu \\nu}^I"
       },
-      "lequ3_2221": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_1 \\right)"
+      "eB_23": {
+        "tex": "\\left( \\bar \\ell_2 \\sigma^{\\mu \\nu} e_3 \\right) \\varphi B_{\\mu \\nu}"
       },
-      "lequ3_2222": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_2 \\right)"
+      "eB_32": {
+        "tex": "\\left( \\bar \\ell_3 \\sigma^{\\mu \\nu} e_2 \\right) \\varphi B_{\\mu \\nu}"
       },
-      "lequ3_2223": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_3 \\right)"
+      "phil1_23": {
+        "tex": "\\left( \\varphi^\\dagger i \\overset\\leftrightarrow{D}_\\mu \\varphi \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_3 \\right)"
       },
-      "lequ3_2231": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_1 \\right)"
+      "phil3_23": {
+        "tex": "\\left( \\varphi^\\dagger i \\overset\\leftrightarrow{D}^I_\\mu \\varphi \\right) \\left( \\bar \\ell_2 \\tau^I \\gamma^\\mu \\ell_3 \\right)"
       },
-      "lequ3_2232": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_2 \\right)"
+      "phie_23": {
+        "tex": "\\left( \\varphi^\\dagger i \\overset\\leftrightarrow{D}_\\mu \\varphi \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
       },
-      "lequ3_2233": {
-        "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_3 \\right)"
+      "ll_1123": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_3 \\right)"
+      },
+      "ll_1231": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_1 \\right)"
+      },
+      "ll_2223": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_3 \\right)"
+      },
+      "ll_2333": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_3 \\right)"
+      },
+      "lq1_2311": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu q_1 \\right)"
+      },
+      "lq1_2312": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu q_2 \\right)"
+      },
+      "lq1_2313": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu q_3 \\right)"
+      },
+      "lq1_2321": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu q_1 \\right)"
+      },
+      "lq1_2322": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu q_2 \\right)"
+      },
+      "lq1_2323": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu q_3 \\right)"
+      },
+      "lq1_2331": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu q_1 \\right)"
+      },
+      "lq1_2332": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu q_2 \\right)"
+      },
+      "lq1_2333": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu q_3 \\right)"
+      },
+      "lq3_2311": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_1 \\right)"
+      },
+      "lq3_2312": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_2 \\right)"
+      },
+      "lq3_2313": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_1 \\gamma^\\mu \\tau^I q_3 \\right)"
+      },
+      "lq3_2321": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_1 \\right)"
+      },
+      "lq3_2322": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_2 \\right)"
+      },
+      "lq3_2323": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_2 \\gamma^\\mu \\tau^I q_3 \\right)"
+      },
+      "lq3_2331": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_1 \\right)"
+      },
+      "lq3_2332": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_2 \\right)"
+      },
+      "lq3_2333": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\tau^I \\ell_3 \\right) \\left( \\bar q_3 \\gamma^\\mu \\tau^I q_3 \\right)"
+      },
+      "ee_1123": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_1 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "ee_2223": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "ee_2333": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
+      },
+      "eu_2311": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_1 \\right)"
+      },
+      "eu_2312": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_2 \\right)"
+      },
+      "eu_2313": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_3 \\right)"
+      },
+      "eu_2321": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_1 \\right)"
+      },
+      "eu_2322": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_2 \\right)"
+      },
+      "eu_2323": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_3 \\right)"
+      },
+      "eu_2331": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_1 \\right)"
+      },
+      "eu_2332": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_2 \\right)"
+      },
+      "eu_2333": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
+      },
+      "ed_2311": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_1 \\right)"
+      },
+      "ed_2312": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_2 \\right)"
+      },
+      "ed_2313": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_3 \\right)"
+      },
+      "ed_2321": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_1 \\right)"
+      },
+      "ed_2322": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_2 \\right)"
+      },
+      "ed_2323": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_3 \\right)"
+      },
+      "ed_2331": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_1 \\right)"
+      },
+      "ed_2332": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_2 \\right)"
+      },
+      "ed_2333": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
+      },
+      "le_1123": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_1 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "le_1231": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_1 \\right)"
+      },
+      "le_1321": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_1 \\right)"
+      },
+      "le_2223": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "le_2311": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_1 \\right)"
+      },
+      "le_2322": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_2 \\right)"
+      },
+      "le_2333": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_3 \\right)"
+      },
+      "le_3323": {
+        "tex": "\\left( \\bar \\ell_3 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "lu_2311": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_1 \\right)"
+      },
+      "lu_2312": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_2 \\right)"
+      },
+      "lu_2313": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_1 \\gamma^\\mu u_3 \\right)"
+      },
+      "lu_2321": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_1 \\right)"
+      },
+      "lu_2322": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_2 \\right)"
+      },
+      "lu_2323": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_2 \\gamma^\\mu u_3 \\right)"
+      },
+      "lu_2331": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_1 \\right)"
+      },
+      "lu_2332": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_2 \\right)"
+      },
+      "lu_2333": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar u_3 \\gamma^\\mu u_3 \\right)"
+      },
+      "ld_2311": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_1 \\right)"
+      },
+      "ld_2312": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_2 \\right)"
+      },
+      "ld_2313": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_1 \\gamma^\\mu d_3 \\right)"
+      },
+      "ld_2321": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_1 \\right)"
+      },
+      "ld_2322": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_2 \\right)"
+      },
+      "ld_2323": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_2 \\gamma^\\mu d_3 \\right)"
+      },
+      "ld_2331": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_1 \\right)"
+      },
+      "ld_2332": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_2 \\right)"
+      },
+      "ld_2333": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar d_3 \\gamma^\\mu d_3 \\right)"
+      },
+      "qe_1123": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_1 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "qe_1223": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "qe_1232": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_2 \\right)"
+      },
+      "qe_1323": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "qe_1332": {
+        "tex": "\\left( \\bar q_1 \\gamma_\\mu q_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_2 \\right)"
+      },
+      "qe_2223": {
+        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_2 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "qe_2323": {
+        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "qe_2332": {
+        "tex": "\\left( \\bar q_2 \\gamma_\\mu q_3 \\right) \\left( \\bar e_3 \\gamma^\\mu e_2 \\right)"
+      },
+      "qe_3323": {
+        "tex": "\\left( \\bar q_3 \\gamma_\\mu q_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "ledq_2311": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_1 q_1 \\right)"
+      },
+      "ledq_2312": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_1 q_2 \\right)"
+      },
+      "ledq_2313": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_1 q_3 \\right)"
+      },
+      "ledq_2321": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_2 q_1 \\right)"
+      },
+      "ledq_2322": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_2 q_2 \\right)"
+      },
+      "ledq_2323": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_2 q_3 \\right)"
+      },
+      "ledq_2331": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_3 q_1 \\right)"
+      },
+      "ledq_2332": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_3 q_2 \\right)"
+      },
+      "ledq_2333": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\left( \\bar d_3 q_3 \\right)"
+      },
+      "ledq_3211": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_1 q_1 \\right)"
+      },
+      "ledq_3212": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_1 q_2 \\right)"
+      },
+      "ledq_3213": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_1 q_3 \\right)"
+      },
+      "ledq_3221": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_2 q_1 \\right)"
+      },
+      "ledq_3222": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_2 q_2 \\right)"
+      },
+      "ledq_3223": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_2 q_3 \\right)"
+      },
+      "ledq_3231": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_3 q_1 \\right)"
+      },
+      "ledq_3232": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_3 q_2 \\right)"
+      },
+      "ledq_3233": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\left( \\bar d_3 q_3 \\right)"
+      },
+      "lequ1_2311": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_1 \\right)"
+      },
+      "lequ1_2312": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_2 \\right)"
+      },
+      "lequ1_2313": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_3 \\right)"
+      },
+      "lequ1_2321": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_1 \\right)"
+      },
+      "lequ1_2322": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_2 \\right)"
+      },
+      "lequ1_2323": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_3 \\right)"
+      },
+      "lequ1_2331": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_1 \\right)"
+      },
+      "lequ1_2332": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_2 \\right)"
+      },
+      "lequ1_2333": {
+        "tex": "\\left( \\bar \\ell_2 e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_3 \\right)"
+      },
+      "lequ1_3211": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_1 \\right)"
+      },
+      "lequ1_3212": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_2 \\right)"
+      },
+      "lequ1_3213": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 u_3 \\right)"
+      },
+      "lequ1_3221": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_1 \\right)"
+      },
+      "lequ1_3222": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_2 \\right)"
+      },
+      "lequ1_3223": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_2 u_3 \\right)"
+      },
+      "lequ1_3231": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_1 \\right)"
+      },
+      "lequ1_3232": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_2 \\right)"
+      },
+      "lequ1_3233": {
+        "tex": "\\left( \\bar \\ell_3 e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 u_3 \\right)"
       },
       "lequ3_2311": {
         "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_1 \\right)"
@@ -4206,33 +4203,6 @@
       "lequ3_2333": {
         "tex": "\\left( \\bar \\ell_2 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_3 \\right)"
       },
-      "lequ3_3111": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_1 \\right)"
-      },
-      "lequ3_3112": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_2 \\right)"
-      },
-      "lequ3_3113": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_3 \\right)"
-      },
-      "lequ3_3121": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_1 \\right)"
-      },
-      "lequ3_3122": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_2 \\right)"
-      },
-      "lequ3_3123": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_3 \\right)"
-      },
-      "lequ3_3131": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_1 \\right)"
-      },
-      "lequ3_3132": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_2 \\right)"
-      },
-      "lequ3_3133": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_1 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_3 \\right)"
-      },
       "lequ3_3211": {
         "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_1 \\right)"
       },
@@ -4259,33 +4229,81 @@
       },
       "lequ3_3233": {
         "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_2 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_3 \\right)"
+      }
+    },
+    "muemue": {
+      "ll_1212": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_1 \\gamma^\\mu \\ell_2 \\right)"
       },
-      "lequ3_3311": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_1 \\right)"
+      "ee_1212": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
       },
-      "lequ3_3312": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_2 \\right)"
+      "le_1212": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
+      }
+    },
+    "etauemu": {
+      "ll_1213": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_1 \\gamma^\\mu \\ell_3 \\right)"
       },
-      "lequ3_3313": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_1 \\sigma^{\\mu \\nu} u_3 \\right)"
+      "ee_1213": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
       },
-      "lequ3_3321": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_1 \\right)"
+      "le_1213": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
       },
-      "lequ3_3322": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_2 \\right)"
+      "le_1312": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_2 \\right)"
+      }
+    },
+    "muemutau": {
+      "ll_1232": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar \\ell_3 \\gamma^\\mu \\ell_2 \\right)"
       },
-      "lequ3_3323": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_2 \\sigma^{\\mu \\nu} u_3 \\right)"
+      "ee_1232": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_2 \\right)"
       },
-      "lequ3_3331": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_1 \\right)"
+      "le_1232": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_2 \\right) \\left( \\bar e_3 \\gamma^\\mu e_2 \\right)"
       },
-      "lequ3_3332": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_2 \\right)"
+      "le_2321": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_1 \\right)"
+      }
+    },
+    "tauetaue": {
+      "ll_1313": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_1 \\gamma^\\mu \\ell_3 \\right)"
       },
-      "lequ3_3333": {
-        "tex": "\\left( \\bar \\ell_3 \\sigma_{\\mu \\nu} e_3 \\right) \\epsilon_{jk} \\left( \\bar q_3 \\sigma^{\\mu \\nu} u_3 \\right)"
+      "ee_1313": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
+      },
+      "le_1313": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
+      }
+    },
+    "tauetaumu": {
+      "ll_1323": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_3 \\right)"
+      },
+      "ee_1323": {
+        "tex": "\\left( \\bar e_1 \\gamma_\\mu e_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "le_1323": {
+        "tex": "\\left( \\bar \\ell_1 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "le_2313": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_1 \\gamma^\\mu e_3 \\right)"
+      }
+    },
+    "taumutaumu": {
+      "ll_2323": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar \\ell_2 \\gamma^\\mu \\ell_3 \\right)"
+      },
+      "ee_2323": {
+        "tex": "\\left( \\bar e_2 \\gamma_\\mu e_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
+      },
+      "le_2323": {
+        "tex": "\\left( \\bar \\ell_2 \\gamma_\\mu \\ell_3 \\right) \\left( \\bar e_2 \\gamma^\\mu e_3 \\right)"
       }
     },
     "dB=dL=1": {

--- a/smeft.warsaw.basis.yml
+++ b/smeft.warsaw.basis.yml
@@ -2938,551 +2938,553 @@ sectors:
       tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
     le_2323:
       tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
-  dB=dL=1:
+  dB=de=1:
     duql_1111:
       tex: \left( d_1 C u_1 \right) \left( q_1 C \ell_1 \right)
-    duql_1112:
-      tex: \left( d_1 C u_1 \right) \left( q_1 C \ell_2 \right)
-    duql_1113:
-      tex: \left( d_1 C u_1 \right) \left( q_1 C \ell_3 \right)
     duql_1121:
       tex: \left( d_1 C u_1 \right) \left( q_2 C \ell_1 \right)
-    duql_1122:
-      tex: \left( d_1 C u_1 \right) \left( q_2 C \ell_2 \right)
-    duql_1123:
-      tex: \left( d_1 C u_1 \right) \left( q_2 C \ell_3 \right)
     duql_1131:
       tex: \left( d_1 C u_1 \right) \left( q_3 C \ell_1 \right)
-    duql_1132:
-      tex: \left( d_1 C u_1 \right) \left( q_3 C \ell_2 \right)
-    duql_1133:
-      tex: \left( d_1 C u_1 \right) \left( q_3 C \ell_3 \right)
     duql_1211:
       tex: \left( d_1 C u_2 \right) \left( q_1 C \ell_1 \right)
-    duql_1212:
-      tex: \left( d_1 C u_2 \right) \left( q_1 C \ell_2 \right)
-    duql_1213:
-      tex: \left( d_1 C u_2 \right) \left( q_1 C \ell_3 \right)
     duql_1221:
       tex: \left( d_1 C u_2 \right) \left( q_2 C \ell_1 \right)
-    duql_1222:
-      tex: \left( d_1 C u_2 \right) \left( q_2 C \ell_2 \right)
-    duql_1223:
-      tex: \left( d_1 C u_2 \right) \left( q_2 C \ell_3 \right)
     duql_1231:
       tex: \left( d_1 C u_2 \right) \left( q_3 C \ell_1 \right)
-    duql_1232:
-      tex: \left( d_1 C u_2 \right) \left( q_3 C \ell_2 \right)
-    duql_1233:
-      tex: \left( d_1 C u_2 \right) \left( q_3 C \ell_3 \right)
     duql_1311:
       tex: \left( d_1 C u_3 \right) \left( q_1 C \ell_1 \right)
-    duql_1312:
-      tex: \left( d_1 C u_3 \right) \left( q_1 C \ell_2 \right)
-    duql_1313:
-      tex: \left( d_1 C u_3 \right) \left( q_1 C \ell_3 \right)
     duql_1321:
       tex: \left( d_1 C u_3 \right) \left( q_2 C \ell_1 \right)
-    duql_1322:
-      tex: \left( d_1 C u_3 \right) \left( q_2 C \ell_2 \right)
-    duql_1323:
-      tex: \left( d_1 C u_3 \right) \left( q_2 C \ell_3 \right)
     duql_1331:
       tex: \left( d_1 C u_3 \right) \left( q_3 C \ell_1 \right)
-    duql_1332:
-      tex: \left( d_1 C u_3 \right) \left( q_3 C \ell_2 \right)
-    duql_1333:
-      tex: \left( d_1 C u_3 \right) \left( q_3 C \ell_3 \right)
     duql_2111:
       tex: \left( d_2 C u_1 \right) \left( q_1 C \ell_1 \right)
-    duql_2112:
-      tex: \left( d_2 C u_1 \right) \left( q_1 C \ell_2 \right)
-    duql_2113:
-      tex: \left( d_2 C u_1 \right) \left( q_1 C \ell_3 \right)
     duql_2121:
       tex: \left( d_2 C u_1 \right) \left( q_2 C \ell_1 \right)
-    duql_2122:
-      tex: \left( d_2 C u_1 \right) \left( q_2 C \ell_2 \right)
-    duql_2123:
-      tex: \left( d_2 C u_1 \right) \left( q_2 C \ell_3 \right)
     duql_2131:
       tex: \left( d_2 C u_1 \right) \left( q_3 C \ell_1 \right)
-    duql_2132:
-      tex: \left( d_2 C u_1 \right) \left( q_3 C \ell_2 \right)
-    duql_2133:
-      tex: \left( d_2 C u_1 \right) \left( q_3 C \ell_3 \right)
     duql_2211:
       tex: \left( d_2 C u_2 \right) \left( q_1 C \ell_1 \right)
-    duql_2212:
-      tex: \left( d_2 C u_2 \right) \left( q_1 C \ell_2 \right)
-    duql_2213:
-      tex: \left( d_2 C u_2 \right) \left( q_1 C \ell_3 \right)
     duql_2221:
       tex: \left( d_2 C u_2 \right) \left( q_2 C \ell_1 \right)
-    duql_2222:
-      tex: \left( d_2 C u_2 \right) \left( q_2 C \ell_2 \right)
-    duql_2223:
-      tex: \left( d_2 C u_2 \right) \left( q_2 C \ell_3 \right)
     duql_2231:
       tex: \left( d_2 C u_2 \right) \left( q_3 C \ell_1 \right)
-    duql_2232:
-      tex: \left( d_2 C u_2 \right) \left( q_3 C \ell_2 \right)
-    duql_2233:
-      tex: \left( d_2 C u_2 \right) \left( q_3 C \ell_3 \right)
     duql_2311:
       tex: \left( d_2 C u_3 \right) \left( q_1 C \ell_1 \right)
-    duql_2312:
-      tex: \left( d_2 C u_3 \right) \left( q_1 C \ell_2 \right)
-    duql_2313:
-      tex: \left( d_2 C u_3 \right) \left( q_1 C \ell_3 \right)
     duql_2321:
       tex: \left( d_2 C u_3 \right) \left( q_2 C \ell_1 \right)
-    duql_2322:
-      tex: \left( d_2 C u_3 \right) \left( q_2 C \ell_2 \right)
-    duql_2323:
-      tex: \left( d_2 C u_3 \right) \left( q_2 C \ell_3 \right)
     duql_2331:
       tex: \left( d_2 C u_3 \right) \left( q_3 C \ell_1 \right)
-    duql_2332:
-      tex: \left( d_2 C u_3 \right) \left( q_3 C \ell_2 \right)
-    duql_2333:
-      tex: \left( d_2 C u_3 \right) \left( q_3 C \ell_3 \right)
     duql_3111:
       tex: \left( d_3 C u_1 \right) \left( q_1 C \ell_1 \right)
-    duql_3112:
-      tex: \left( d_3 C u_1 \right) \left( q_1 C \ell_2 \right)
-    duql_3113:
-      tex: \left( d_3 C u_1 \right) \left( q_1 C \ell_3 \right)
     duql_3121:
       tex: \left( d_3 C u_1 \right) \left( q_2 C \ell_1 \right)
-    duql_3122:
-      tex: \left( d_3 C u_1 \right) \left( q_2 C \ell_2 \right)
-    duql_3123:
-      tex: \left( d_3 C u_1 \right) \left( q_2 C \ell_3 \right)
     duql_3131:
       tex: \left( d_3 C u_1 \right) \left( q_3 C \ell_1 \right)
-    duql_3132:
-      tex: \left( d_3 C u_1 \right) \left( q_3 C \ell_2 \right)
-    duql_3133:
-      tex: \left( d_3 C u_1 \right) \left( q_3 C \ell_3 \right)
     duql_3211:
       tex: \left( d_3 C u_2 \right) \left( q_1 C \ell_1 \right)
-    duql_3212:
-      tex: \left( d_3 C u_2 \right) \left( q_1 C \ell_2 \right)
-    duql_3213:
-      tex: \left( d_3 C u_2 \right) \left( q_1 C \ell_3 \right)
     duql_3221:
       tex: \left( d_3 C u_2 \right) \left( q_2 C \ell_1 \right)
-    duql_3222:
-      tex: \left( d_3 C u_2 \right) \left( q_2 C \ell_2 \right)
-    duql_3223:
-      tex: \left( d_3 C u_2 \right) \left( q_2 C \ell_3 \right)
     duql_3231:
       tex: \left( d_3 C u_2 \right) \left( q_3 C \ell_1 \right)
-    duql_3232:
-      tex: \left( d_3 C u_2 \right) \left( q_3 C \ell_2 \right)
-    duql_3233:
-      tex: \left( d_3 C u_2 \right) \left( q_3 C \ell_3 \right)
     duql_3311:
       tex: \left( d_3 C u_3 \right) \left( q_1 C \ell_1 \right)
-    duql_3312:
-      tex: \left( d_3 C u_3 \right) \left( q_1 C \ell_2 \right)
-    duql_3313:
-      tex: \left( d_3 C u_3 \right) \left( q_1 C \ell_3 \right)
     duql_3321:
       tex: \left( d_3 C u_3 \right) \left( q_2 C \ell_1 \right)
-    duql_3322:
-      tex: \left( d_3 C u_3 \right) \left( q_2 C \ell_2 \right)
-    duql_3323:
-      tex: \left( d_3 C u_3 \right) \left( q_2 C \ell_3 \right)
     duql_3331:
       tex: \left( d_3 C u_3 \right) \left( q_3 C \ell_1 \right)
-    duql_3332:
-      tex: \left( d_3 C u_3 \right) \left( q_3 C \ell_2 \right)
-    duql_3333:
-      tex: \left( d_3 C u_3 \right) \left( q_3 C \ell_3 \right)
     qque_1111:
       tex: \left( q_1 C q_1 \right) \left( u_1 C e_1 \right)
-    qque_1112:
-      tex: \left( q_1 C q_1 \right) \left( u_1 C e_2 \right)
-    qque_1113:
-      tex: \left( q_1 C q_1 \right) \left( u_1 C e_3 \right)
     qque_1121:
       tex: \left( q_1 C q_1 \right) \left( u_2 C e_1 \right)
-    qque_1122:
-      tex: \left( q_1 C q_1 \right) \left( u_2 C e_2 \right)
-    qque_1123:
-      tex: \left( q_1 C q_1 \right) \left( u_2 C e_3 \right)
     qque_1131:
       tex: \left( q_1 C q_1 \right) \left( u_3 C e_1 \right)
-    qque_1132:
-      tex: \left( q_1 C q_1 \right) \left( u_3 C e_2 \right)
-    qque_1133:
-      tex: \left( q_1 C q_1 \right) \left( u_3 C e_3 \right)
     qque_1211:
       tex: \left( q_1 C q_2 \right) \left( u_1 C e_1 \right)
-    qque_1212:
-      tex: \left( q_1 C q_2 \right) \left( u_1 C e_2 \right)
-    qque_1213:
-      tex: \left( q_1 C q_2 \right) \left( u_1 C e_3 \right)
     qque_1221:
       tex: \left( q_1 C q_2 \right) \left( u_2 C e_1 \right)
-    qque_1222:
-      tex: \left( q_1 C q_2 \right) \left( u_2 C e_2 \right)
-    qque_1223:
-      tex: \left( q_1 C q_2 \right) \left( u_2 C e_3 \right)
     qque_1231:
       tex: \left( q_1 C q_2 \right) \left( u_3 C e_1 \right)
-    qque_1232:
-      tex: \left( q_1 C q_2 \right) \left( u_3 C e_2 \right)
-    qque_1233:
-      tex: \left( q_1 C q_2 \right) \left( u_3 C e_3 \right)
     qque_1311:
       tex: \left( q_1 C q_3 \right) \left( u_1 C e_1 \right)
-    qque_1312:
-      tex: \left( q_1 C q_3 \right) \left( u_1 C e_2 \right)
-    qque_1313:
-      tex: \left( q_1 C q_3 \right) \left( u_1 C e_3 \right)
     qque_1321:
       tex: \left( q_1 C q_3 \right) \left( u_2 C e_1 \right)
-    qque_1322:
-      tex: \left( q_1 C q_3 \right) \left( u_2 C e_2 \right)
-    qque_1323:
-      tex: \left( q_1 C q_3 \right) \left( u_2 C e_3 \right)
     qque_1331:
       tex: \left( q_1 C q_3 \right) \left( u_3 C e_1 \right)
-    qque_1332:
-      tex: \left( q_1 C q_3 \right) \left( u_3 C e_2 \right)
-    qque_1333:
-      tex: \left( q_1 C q_3 \right) \left( u_3 C e_3 \right)
     qque_2211:
       tex: \left( q_2 C q_2 \right) \left( u_1 C e_1 \right)
-    qque_2212:
-      tex: \left( q_2 C q_2 \right) \left( u_1 C e_2 \right)
-    qque_2213:
-      tex: \left( q_2 C q_2 \right) \left( u_1 C e_3 \right)
     qque_2221:
       tex: \left( q_2 C q_2 \right) \left( u_2 C e_1 \right)
-    qque_2222:
-      tex: \left( q_2 C q_2 \right) \left( u_2 C e_2 \right)
-    qque_2223:
-      tex: \left( q_2 C q_2 \right) \left( u_2 C e_3 \right)
     qque_2231:
       tex: \left( q_2 C q_2 \right) \left( u_3 C e_1 \right)
-    qque_2232:
-      tex: \left( q_2 C q_2 \right) \left( u_3 C e_2 \right)
-    qque_2233:
-      tex: \left( q_2 C q_2 \right) \left( u_3 C e_3 \right)
     qque_2311:
       tex: \left( q_2 C q_3 \right) \left( u_1 C e_1 \right)
-    qque_2312:
-      tex: \left( q_2 C q_3 \right) \left( u_1 C e_2 \right)
-    qque_2313:
-      tex: \left( q_2 C q_3 \right) \left( u_1 C e_3 \right)
     qque_2321:
       tex: \left( q_2 C q_3 \right) \left( u_2 C e_1 \right)
-    qque_2322:
-      tex: \left( q_2 C q_3 \right) \left( u_2 C e_2 \right)
-    qque_2323:
-      tex: \left( q_2 C q_3 \right) \left( u_2 C e_3 \right)
     qque_2331:
       tex: \left( q_2 C q_3 \right) \left( u_3 C e_1 \right)
-    qque_2332:
-      tex: \left( q_2 C q_3 \right) \left( u_3 C e_2 \right)
-    qque_2333:
-      tex: \left( q_2 C q_3 \right) \left( u_3 C e_3 \right)
     qque_3311:
       tex: \left( q_3 C q_3 \right) \left( u_1 C e_1 \right)
-    qque_3312:
-      tex: \left( q_3 C q_3 \right) \left( u_1 C e_2 \right)
-    qque_3313:
-      tex: \left( q_3 C q_3 \right) \left( u_1 C e_3 \right)
     qque_3321:
       tex: \left( q_3 C q_3 \right) \left( u_2 C e_1 \right)
-    qque_3322:
-      tex: \left( q_3 C q_3 \right) \left( u_2 C e_2 \right)
-    qque_3323:
-      tex: \left( q_3 C q_3 \right) \left( u_2 C e_3 \right)
     qque_3331:
       tex: \left( q_3 C q_3 \right) \left( u_3 C e_1 \right)
-    qque_3332:
-      tex: \left( q_3 C q_3 \right) \left( u_3 C e_2 \right)
-    qque_3333:
-      tex: \left( q_3 C q_3 \right) \left( u_3 C e_3 \right)
     qqql_1111:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_1 C \ell_1 \right)
-    qqql_1112:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_1 C \ell_2 \right)
-    qqql_1113:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_1 C \ell_3 \right)
     qqql_1121:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_2 C \ell_1 \right)
-    qqql_1122:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_2 C \ell_2 \right)
-    qqql_1123:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_2 C \ell_3 \right)
     qqql_1131:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_3 C \ell_1 \right)
-    qqql_1132:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_3 C \ell_2 \right)
-    qqql_1133:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_3 C \ell_3 \right)
     qqql_1211:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_1 C \ell_1 \right)
-    qqql_1212:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_1 C \ell_2 \right)
-    qqql_1213:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_1 C \ell_3 \right)
     qqql_1221:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_2 C \ell_1 \right)
-    qqql_1222:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_2 C \ell_2 \right)
-    qqql_1223:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_2 C \ell_3 \right)
     qqql_1231:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_3 C \ell_1 \right)
-    qqql_1232:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_3 C \ell_2 \right)
-    qqql_1233:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_3 C \ell_3 \right)
     qqql_1311:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_1 C \ell_1 \right)
-    qqql_1312:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_1 C \ell_2 \right)
-    qqql_1313:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_1 C \ell_3 \right)
     qqql_1321:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_2 C \ell_1 \right)
-    qqql_1322:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_2 C \ell_2 \right)
-    qqql_1323:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_2 C \ell_3 \right)
     qqql_1331:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_3 C \ell_1 \right)
-    qqql_1332:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_3 C \ell_2 \right)
-    qqql_1333:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_3 C \ell_3 \right)
     qqql_2121:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_1 \right) \left( q_2 C \ell_1 \right)
-    qqql_2122:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_1 \right) \left( q_2 C \ell_2 \right)
-    qqql_2123:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_1 \right) \left( q_2 C \ell_3 \right)
     qqql_2131:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_1 \right) \left( q_3 C \ell_1 \right)
-    qqql_2132:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_1 \right) \left( q_3 C \ell_2 \right)
-    qqql_2133:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_1 \right) \left( q_3 C \ell_3 \right)
     qqql_2221:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_2 \right) \left( q_2 C \ell_1 \right)
-    qqql_2222:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_2 \right) \left( q_2 C \ell_2 \right)
-    qqql_2223:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_2 \right) \left( q_2 C \ell_3 \right)
     qqql_2231:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_2 \right) \left( q_3 C \ell_1 \right)
-    qqql_2232:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_2 \right) \left( q_3 C \ell_2 \right)
-    qqql_2233:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_2 \right) \left( q_3 C \ell_3 \right)
     qqql_2311:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_1 C \ell_1 \right)
-    qqql_2312:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_1 C \ell_2 \right)
-    qqql_2313:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_1 C \ell_3 \right)
     qqql_2321:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_2 C \ell_1 \right)
-    qqql_2322:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_2 C \ell_2 \right)
-    qqql_2323:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_2 C \ell_3 \right)
     qqql_2331:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_3 C \ell_1 \right)
-    qqql_2332:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_3 C \ell_2 \right)
-    qqql_2333:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_3 C \ell_3 \right)
     qqql_3131:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_1 \right) \left( q_3 C \ell_1 \right)
-    qqql_3132:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_1 \right) \left( q_3 C \ell_2 \right)
-    qqql_3133:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_1 \right) \left( q_3 C \ell_3 \right)
     qqql_3231:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_2 \right) \left( q_3 C \ell_1 \right)
-    qqql_3232:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_2 \right) \left( q_3 C \ell_2 \right)
-    qqql_3233:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_2 \right) \left( q_3 C \ell_3 \right)
     qqql_3331:
       tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_3 \right) \left( q_3 C \ell_1 \right)
-    qqql_3332:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_3 \right) \left( q_3 C \ell_2 \right)
-    qqql_3333:
-      tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_3 \right) \left( q_3 C \ell_3 \right)
     duue_1111:
       tex: \left( d_1 C u_1 \right) \left( u_1 C e_1 \right)
-    duue_1112:
-      tex: \left( d_1 C u_1 \right) \left( u_1 C e_2 \right)
-    duue_1113:
-      tex: \left( d_1 C u_1 \right) \left( u_1 C e_3 \right)
     duue_1121:
       tex: \left( d_1 C u_1 \right) \left( u_2 C e_1 \right)
-    duue_1122:
-      tex: \left( d_1 C u_1 \right) \left( u_2 C e_2 \right)
-    duue_1123:
-      tex: \left( d_1 C u_1 \right) \left( u_2 C e_3 \right)
     duue_1131:
       tex: \left( d_1 C u_1 \right) \left( u_3 C e_1 \right)
-    duue_1132:
-      tex: \left( d_1 C u_1 \right) \left( u_3 C e_2 \right)
-    duue_1133:
-      tex: \left( d_1 C u_1 \right) \left( u_3 C e_3 \right)
     duue_1211:
       tex: \left( d_1 C u_2 \right) \left( u_1 C e_1 \right)
-    duue_1212:
-      tex: \left( d_1 C u_2 \right) \left( u_1 C e_2 \right)
-    duue_1213:
-      tex: \left( d_1 C u_2 \right) \left( u_1 C e_3 \right)
     duue_1221:
       tex: \left( d_1 C u_2 \right) \left( u_2 C e_1 \right)
-    duue_1222:
-      tex: \left( d_1 C u_2 \right) \left( u_2 C e_2 \right)
-    duue_1223:
-      tex: \left( d_1 C u_2 \right) \left( u_2 C e_3 \right)
     duue_1231:
       tex: \left( d_1 C u_2 \right) \left( u_3 C e_1 \right)
-    duue_1232:
-      tex: \left( d_1 C u_2 \right) \left( u_3 C e_2 \right)
-    duue_1233:
-      tex: \left( d_1 C u_2 \right) \left( u_3 C e_3 \right)
     duue_1311:
       tex: \left( d_1 C u_3 \right) \left( u_1 C e_1 \right)
-    duue_1312:
-      tex: \left( d_1 C u_3 \right) \left( u_1 C e_2 \right)
-    duue_1313:
-      tex: \left( d_1 C u_3 \right) \left( u_1 C e_3 \right)
     duue_1321:
       tex: \left( d_1 C u_3 \right) \left( u_2 C e_1 \right)
-    duue_1322:
-      tex: \left( d_1 C u_3 \right) \left( u_2 C e_2 \right)
-    duue_1323:
-      tex: \left( d_1 C u_3 \right) \left( u_2 C e_3 \right)
     duue_1331:
       tex: \left( d_1 C u_3 \right) \left( u_3 C e_1 \right)
-    duue_1332:
-      tex: \left( d_1 C u_3 \right) \left( u_3 C e_2 \right)
-    duue_1333:
-      tex: \left( d_1 C u_3 \right) \left( u_3 C e_3 \right)
     duue_2111:
       tex: \left( d_2 C u_1 \right) \left( u_1 C e_1 \right)
-    duue_2112:
-      tex: \left( d_2 C u_1 \right) \left( u_1 C e_2 \right)
-    duue_2113:
-      tex: \left( d_2 C u_1 \right) \left( u_1 C e_3 \right)
     duue_2121:
       tex: \left( d_2 C u_1 \right) \left( u_2 C e_1 \right)
-    duue_2122:
-      tex: \left( d_2 C u_1 \right) \left( u_2 C e_2 \right)
-    duue_2123:
-      tex: \left( d_2 C u_1 \right) \left( u_2 C e_3 \right)
     duue_2131:
       tex: \left( d_2 C u_1 \right) \left( u_3 C e_1 \right)
-    duue_2132:
-      tex: \left( d_2 C u_1 \right) \left( u_3 C e_2 \right)
-    duue_2133:
-      tex: \left( d_2 C u_1 \right) \left( u_3 C e_3 \right)
     duue_2211:
       tex: \left( d_2 C u_2 \right) \left( u_1 C e_1 \right)
-    duue_2212:
-      tex: \left( d_2 C u_2 \right) \left( u_1 C e_2 \right)
-    duue_2213:
-      tex: \left( d_2 C u_2 \right) \left( u_1 C e_3 \right)
     duue_2221:
       tex: \left( d_2 C u_2 \right) \left( u_2 C e_1 \right)
-    duue_2222:
-      tex: \left( d_2 C u_2 \right) \left( u_2 C e_2 \right)
-    duue_2223:
-      tex: \left( d_2 C u_2 \right) \left( u_2 C e_3 \right)
     duue_2231:
       tex: \left( d_2 C u_2 \right) \left( u_3 C e_1 \right)
-    duue_2232:
-      tex: \left( d_2 C u_2 \right) \left( u_3 C e_2 \right)
-    duue_2233:
-      tex: \left( d_2 C u_2 \right) \left( u_3 C e_3 \right)
     duue_2311:
       tex: \left( d_2 C u_3 \right) \left( u_1 C e_1 \right)
-    duue_2312:
-      tex: \left( d_2 C u_3 \right) \left( u_1 C e_2 \right)
-    duue_2313:
-      tex: \left( d_2 C u_3 \right) \left( u_1 C e_3 \right)
     duue_2321:
       tex: \left( d_2 C u_3 \right) \left( u_2 C e_1 \right)
-    duue_2322:
-      tex: \left( d_2 C u_3 \right) \left( u_2 C e_2 \right)
-    duue_2323:
-      tex: \left( d_2 C u_3 \right) \left( u_2 C e_3 \right)
     duue_2331:
       tex: \left( d_2 C u_3 \right) \left( u_3 C e_1 \right)
-    duue_2332:
-      tex: \left( d_2 C u_3 \right) \left( u_3 C e_2 \right)
-    duue_2333:
-      tex: \left( d_2 C u_3 \right) \left( u_3 C e_3 \right)
     duue_3111:
       tex: \left( d_3 C u_1 \right) \left( u_1 C e_1 \right)
-    duue_3112:
-      tex: \left( d_3 C u_1 \right) \left( u_1 C e_2 \right)
-    duue_3113:
-      tex: \left( d_3 C u_1 \right) \left( u_1 C e_3 \right)
     duue_3121:
       tex: \left( d_3 C u_1 \right) \left( u_2 C e_1 \right)
-    duue_3122:
-      tex: \left( d_3 C u_1 \right) \left( u_2 C e_2 \right)
-    duue_3123:
-      tex: \left( d_3 C u_1 \right) \left( u_2 C e_3 \right)
     duue_3131:
       tex: \left( d_3 C u_1 \right) \left( u_3 C e_1 \right)
-    duue_3132:
-      tex: \left( d_3 C u_1 \right) \left( u_3 C e_2 \right)
-    duue_3133:
-      tex: \left( d_3 C u_1 \right) \left( u_3 C e_3 \right)
     duue_3211:
       tex: \left( d_3 C u_2 \right) \left( u_1 C e_1 \right)
-    duue_3212:
-      tex: \left( d_3 C u_2 \right) \left( u_1 C e_2 \right)
-    duue_3213:
-      tex: \left( d_3 C u_2 \right) \left( u_1 C e_3 \right)
     duue_3221:
       tex: \left( d_3 C u_2 \right) \left( u_2 C e_1 \right)
-    duue_3222:
-      tex: \left( d_3 C u_2 \right) \left( u_2 C e_2 \right)
-    duue_3223:
-      tex: \left( d_3 C u_2 \right) \left( u_2 C e_3 \right)
     duue_3231:
       tex: \left( d_3 C u_2 \right) \left( u_3 C e_1 \right)
-    duue_3232:
-      tex: \left( d_3 C u_2 \right) \left( u_3 C e_2 \right)
-    duue_3233:
-      tex: \left( d_3 C u_2 \right) \left( u_3 C e_3 \right)
     duue_3311:
       tex: \left( d_3 C u_3 \right) \left( u_1 C e_1 \right)
-    duue_3312:
-      tex: \left( d_3 C u_3 \right) \left( u_1 C e_2 \right)
-    duue_3313:
-      tex: \left( d_3 C u_3 \right) \left( u_1 C e_3 \right)
     duue_3321:
       tex: \left( d_3 C u_3 \right) \left( u_2 C e_1 \right)
-    duue_3322:
-      tex: \left( d_3 C u_3 \right) \left( u_2 C e_2 \right)
-    duue_3323:
-      tex: \left( d_3 C u_3 \right) \left( u_2 C e_3 \right)
     duue_3331:
       tex: \left( d_3 C u_3 \right) \left( u_3 C e_1 \right)
+  dB=dmu=1:
+    duql_1112:
+      tex: \left( d_1 C u_1 \right) \left( q_1 C \ell_2 \right)
+    duql_1122:
+      tex: \left( d_1 C u_1 \right) \left( q_2 C \ell_2 \right)
+    duql_1132:
+      tex: \left( d_1 C u_1 \right) \left( q_3 C \ell_2 \right)
+    duql_1212:
+      tex: \left( d_1 C u_2 \right) \left( q_1 C \ell_2 \right)
+    duql_1222:
+      tex: \left( d_1 C u_2 \right) \left( q_2 C \ell_2 \right)
+    duql_1232:
+      tex: \left( d_1 C u_2 \right) \left( q_3 C \ell_2 \right)
+    duql_1312:
+      tex: \left( d_1 C u_3 \right) \left( q_1 C \ell_2 \right)
+    duql_1322:
+      tex: \left( d_1 C u_3 \right) \left( q_2 C \ell_2 \right)
+    duql_1332:
+      tex: \left( d_1 C u_3 \right) \left( q_3 C \ell_2 \right)
+    duql_2112:
+      tex: \left( d_2 C u_1 \right) \left( q_1 C \ell_2 \right)
+    duql_2122:
+      tex: \left( d_2 C u_1 \right) \left( q_2 C \ell_2 \right)
+    duql_2132:
+      tex: \left( d_2 C u_1 \right) \left( q_3 C \ell_2 \right)
+    duql_2212:
+      tex: \left( d_2 C u_2 \right) \left( q_1 C \ell_2 \right)
+    duql_2222:
+      tex: \left( d_2 C u_2 \right) \left( q_2 C \ell_2 \right)
+    duql_2232:
+      tex: \left( d_2 C u_2 \right) \left( q_3 C \ell_2 \right)
+    duql_2312:
+      tex: \left( d_2 C u_3 \right) \left( q_1 C \ell_2 \right)
+    duql_2322:
+      tex: \left( d_2 C u_3 \right) \left( q_2 C \ell_2 \right)
+    duql_2332:
+      tex: \left( d_2 C u_3 \right) \left( q_3 C \ell_2 \right)
+    duql_3112:
+      tex: \left( d_3 C u_1 \right) \left( q_1 C \ell_2 \right)
+    duql_3122:
+      tex: \left( d_3 C u_1 \right) \left( q_2 C \ell_2 \right)
+    duql_3132:
+      tex: \left( d_3 C u_1 \right) \left( q_3 C \ell_2 \right)
+    duql_3212:
+      tex: \left( d_3 C u_2 \right) \left( q_1 C \ell_2 \right)
+    duql_3222:
+      tex: \left( d_3 C u_2 \right) \left( q_2 C \ell_2 \right)
+    duql_3232:
+      tex: \left( d_3 C u_2 \right) \left( q_3 C \ell_2 \right)
+    duql_3312:
+      tex: \left( d_3 C u_3 \right) \left( q_1 C \ell_2 \right)
+    duql_3322:
+      tex: \left( d_3 C u_3 \right) \left( q_2 C \ell_2 \right)
+    duql_3332:
+      tex: \left( d_3 C u_3 \right) \left( q_3 C \ell_2 \right)
+    qque_1112:
+      tex: \left( q_1 C q_1 \right) \left( u_1 C e_2 \right)
+    qque_1122:
+      tex: \left( q_1 C q_1 \right) \left( u_2 C e_2 \right)
+    qque_1132:
+      tex: \left( q_1 C q_1 \right) \left( u_3 C e_2 \right)
+    qque_1212:
+      tex: \left( q_1 C q_2 \right) \left( u_1 C e_2 \right)
+    qque_1222:
+      tex: \left( q_1 C q_2 \right) \left( u_2 C e_2 \right)
+    qque_1232:
+      tex: \left( q_1 C q_2 \right) \left( u_3 C e_2 \right)
+    qque_1312:
+      tex: \left( q_1 C q_3 \right) \left( u_1 C e_2 \right)
+    qque_1322:
+      tex: \left( q_1 C q_3 \right) \left( u_2 C e_2 \right)
+    qque_1332:
+      tex: \left( q_1 C q_3 \right) \left( u_3 C e_2 \right)
+    qque_2212:
+      tex: \left( q_2 C q_2 \right) \left( u_1 C e_2 \right)
+    qque_2222:
+      tex: \left( q_2 C q_2 \right) \left( u_2 C e_2 \right)
+    qque_2232:
+      tex: \left( q_2 C q_2 \right) \left( u_3 C e_2 \right)
+    qque_2312:
+      tex: \left( q_2 C q_3 \right) \left( u_1 C e_2 \right)
+    qque_2322:
+      tex: \left( q_2 C q_3 \right) \left( u_2 C e_2 \right)
+    qque_2332:
+      tex: \left( q_2 C q_3 \right) \left( u_3 C e_2 \right)
+    qque_3312:
+      tex: \left( q_3 C q_3 \right) \left( u_1 C e_2 \right)
+    qque_3322:
+      tex: \left( q_3 C q_3 \right) \left( u_2 C e_2 \right)
+    qque_3332:
+      tex: \left( q_3 C q_3 \right) \left( u_3 C e_2 \right)
+    qqql_1112:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_1 C \ell_2 \right)
+    qqql_1122:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_2 C \ell_2 \right)
+    qqql_1132:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_3 C \ell_2 \right)
+    qqql_1212:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_1 C \ell_2 \right)
+    qqql_1222:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_2 C \ell_2 \right)
+    qqql_1232:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_3 C \ell_2 \right)
+    qqql_1312:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_1 C \ell_2 \right)
+    qqql_1322:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_2 C \ell_2 \right)
+    qqql_1332:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_3 C \ell_2 \right)
+    qqql_2122:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_1 \right) \left( q_2 C \ell_2 \right)
+    qqql_2132:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_1 \right) \left( q_3 C \ell_2 \right)
+    qqql_2222:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_2 \right) \left( q_2 C \ell_2 \right)
+    qqql_2232:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_2 \right) \left( q_3 C \ell_2 \right)
+    qqql_2312:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_1 C \ell_2 \right)
+    qqql_2322:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_2 C \ell_2 \right)
+    qqql_2332:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_3 C \ell_2 \right)
+    qqql_3132:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_1 \right) \left( q_3 C \ell_2 \right)
+    qqql_3232:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_2 \right) \left( q_3 C \ell_2 \right)
+    qqql_3332:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_3 \right) \left( q_3 C \ell_2 \right)
+    duue_1112:
+      tex: \left( d_1 C u_1 \right) \left( u_1 C e_2 \right)
+    duue_1122:
+      tex: \left( d_1 C u_1 \right) \left( u_2 C e_2 \right)
+    duue_1132:
+      tex: \left( d_1 C u_1 \right) \left( u_3 C e_2 \right)
+    duue_1212:
+      tex: \left( d_1 C u_2 \right) \left( u_1 C e_2 \right)
+    duue_1222:
+      tex: \left( d_1 C u_2 \right) \left( u_2 C e_2 \right)
+    duue_1232:
+      tex: \left( d_1 C u_2 \right) \left( u_3 C e_2 \right)
+    duue_1312:
+      tex: \left( d_1 C u_3 \right) \left( u_1 C e_2 \right)
+    duue_1322:
+      tex: \left( d_1 C u_3 \right) \left( u_2 C e_2 \right)
+    duue_1332:
+      tex: \left( d_1 C u_3 \right) \left( u_3 C e_2 \right)
+    duue_2112:
+      tex: \left( d_2 C u_1 \right) \left( u_1 C e_2 \right)
+    duue_2122:
+      tex: \left( d_2 C u_1 \right) \left( u_2 C e_2 \right)
+    duue_2132:
+      tex: \left( d_2 C u_1 \right) \left( u_3 C e_2 \right)
+    duue_2212:
+      tex: \left( d_2 C u_2 \right) \left( u_1 C e_2 \right)
+    duue_2222:
+      tex: \left( d_2 C u_2 \right) \left( u_2 C e_2 \right)
+    duue_2232:
+      tex: \left( d_2 C u_2 \right) \left( u_3 C e_2 \right)
+    duue_2312:
+      tex: \left( d_2 C u_3 \right) \left( u_1 C e_2 \right)
+    duue_2322:
+      tex: \left( d_2 C u_3 \right) \left( u_2 C e_2 \right)
+    duue_2332:
+      tex: \left( d_2 C u_3 \right) \left( u_3 C e_2 \right)
+    duue_3112:
+      tex: \left( d_3 C u_1 \right) \left( u_1 C e_2 \right)
+    duue_3122:
+      tex: \left( d_3 C u_1 \right) \left( u_2 C e_2 \right)
+    duue_3132:
+      tex: \left( d_3 C u_1 \right) \left( u_3 C e_2 \right)
+    duue_3212:
+      tex: \left( d_3 C u_2 \right) \left( u_1 C e_2 \right)
+    duue_3222:
+      tex: \left( d_3 C u_2 \right) \left( u_2 C e_2 \right)
+    duue_3232:
+      tex: \left( d_3 C u_2 \right) \left( u_3 C e_2 \right)
+    duue_3312:
+      tex: \left( d_3 C u_3 \right) \left( u_1 C e_2 \right)
+    duue_3322:
+      tex: \left( d_3 C u_3 \right) \left( u_2 C e_2 \right)
     duue_3332:
       tex: \left( d_3 C u_3 \right) \left( u_3 C e_2 \right)
+  dB=dtau=1:
+    duql_1113:
+      tex: \left( d_1 C u_1 \right) \left( q_1 C \ell_3 \right)
+    duql_1123:
+      tex: \left( d_1 C u_1 \right) \left( q_2 C \ell_3 \right)
+    duql_1133:
+      tex: \left( d_1 C u_1 \right) \left( q_3 C \ell_3 \right)
+    duql_1213:
+      tex: \left( d_1 C u_2 \right) \left( q_1 C \ell_3 \right)
+    duql_1223:
+      tex: \left( d_1 C u_2 \right) \left( q_2 C \ell_3 \right)
+    duql_1233:
+      tex: \left( d_1 C u_2 \right) \left( q_3 C \ell_3 \right)
+    duql_1313:
+      tex: \left( d_1 C u_3 \right) \left( q_1 C \ell_3 \right)
+    duql_1323:
+      tex: \left( d_1 C u_3 \right) \left( q_2 C \ell_3 \right)
+    duql_1333:
+      tex: \left( d_1 C u_3 \right) \left( q_3 C \ell_3 \right)
+    duql_2113:
+      tex: \left( d_2 C u_1 \right) \left( q_1 C \ell_3 \right)
+    duql_2123:
+      tex: \left( d_2 C u_1 \right) \left( q_2 C \ell_3 \right)
+    duql_2133:
+      tex: \left( d_2 C u_1 \right) \left( q_3 C \ell_3 \right)
+    duql_2213:
+      tex: \left( d_2 C u_2 \right) \left( q_1 C \ell_3 \right)
+    duql_2223:
+      tex: \left( d_2 C u_2 \right) \left( q_2 C \ell_3 \right)
+    duql_2233:
+      tex: \left( d_2 C u_2 \right) \left( q_3 C \ell_3 \right)
+    duql_2313:
+      tex: \left( d_2 C u_3 \right) \left( q_1 C \ell_3 \right)
+    duql_2323:
+      tex: \left( d_2 C u_3 \right) \left( q_2 C \ell_3 \right)
+    duql_2333:
+      tex: \left( d_2 C u_3 \right) \left( q_3 C \ell_3 \right)
+    duql_3113:
+      tex: \left( d_3 C u_1 \right) \left( q_1 C \ell_3 \right)
+    duql_3123:
+      tex: \left( d_3 C u_1 \right) \left( q_2 C \ell_3 \right)
+    duql_3133:
+      tex: \left( d_3 C u_1 \right) \left( q_3 C \ell_3 \right)
+    duql_3213:
+      tex: \left( d_3 C u_2 \right) \left( q_1 C \ell_3 \right)
+    duql_3223:
+      tex: \left( d_3 C u_2 \right) \left( q_2 C \ell_3 \right)
+    duql_3233:
+      tex: \left( d_3 C u_2 \right) \left( q_3 C \ell_3 \right)
+    duql_3313:
+      tex: \left( d_3 C u_3 \right) \left( q_1 C \ell_3 \right)
+    duql_3323:
+      tex: \left( d_3 C u_3 \right) \left( q_2 C \ell_3 \right)
+    duql_3333:
+      tex: \left( d_3 C u_3 \right) \left( q_3 C \ell_3 \right)
+    qque_1113:
+      tex: \left( q_1 C q_1 \right) \left( u_1 C e_3 \right)
+    qque_1123:
+      tex: \left( q_1 C q_1 \right) \left( u_2 C e_3 \right)
+    qque_1133:
+      tex: \left( q_1 C q_1 \right) \left( u_3 C e_3 \right)
+    qque_1213:
+      tex: \left( q_1 C q_2 \right) \left( u_1 C e_3 \right)
+    qque_1223:
+      tex: \left( q_1 C q_2 \right) \left( u_2 C e_3 \right)
+    qque_1233:
+      tex: \left( q_1 C q_2 \right) \left( u_3 C e_3 \right)
+    qque_1313:
+      tex: \left( q_1 C q_3 \right) \left( u_1 C e_3 \right)
+    qque_1323:
+      tex: \left( q_1 C q_3 \right) \left( u_2 C e_3 \right)
+    qque_1333:
+      tex: \left( q_1 C q_3 \right) \left( u_3 C e_3 \right)
+    qque_2213:
+      tex: \left( q_2 C q_2 \right) \left( u_1 C e_3 \right)
+    qque_2223:
+      tex: \left( q_2 C q_2 \right) \left( u_2 C e_3 \right)
+    qque_2233:
+      tex: \left( q_2 C q_2 \right) \left( u_3 C e_3 \right)
+    qque_2313:
+      tex: \left( q_2 C q_3 \right) \left( u_1 C e_3 \right)
+    qque_2323:
+      tex: \left( q_2 C q_3 \right) \left( u_2 C e_3 \right)
+    qque_2333:
+      tex: \left( q_2 C q_3 \right) \left( u_3 C e_3 \right)
+    qque_3313:
+      tex: \left( q_3 C q_3 \right) \left( u_1 C e_3 \right)
+    qque_3323:
+      tex: \left( q_3 C q_3 \right) \left( u_2 C e_3 \right)
+    qque_3333:
+      tex: \left( q_3 C q_3 \right) \left( u_3 C e_3 \right)
+    qqql_1113:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_1 C \ell_3 \right)
+    qqql_1123:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_2 C \ell_3 \right)
+    qqql_1133:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_1 \right) \left( q_3 C \ell_3 \right)
+    qqql_1213:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_1 C \ell_3 \right)
+    qqql_1223:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_2 C \ell_3 \right)
+    qqql_1233:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_2 \right) \left( q_3 C \ell_3 \right)
+    qqql_1313:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_1 C \ell_3 \right)
+    qqql_1323:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_2 C \ell_3 \right)
+    qqql_1333:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_1 C q_3 \right) \left( q_3 C \ell_3 \right)
+    qqql_2123:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_1 \right) \left( q_2 C \ell_3 \right)
+    qqql_2133:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_1 \right) \left( q_3 C \ell_3 \right)
+    qqql_2223:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_2 \right) \left( q_2 C \ell_3 \right)
+    qqql_2233:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_2 \right) \left( q_3 C \ell_3 \right)
+    qqql_2313:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_1 C \ell_3 \right)
+    qqql_2323:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_2 C \ell_3 \right)
+    qqql_2333:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_2 C q_3 \right) \left( q_3 C \ell_3 \right)
+    qqql_3133:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_1 \right) \left( q_3 C \ell_3 \right)
+    qqql_3233:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_2 \right) \left( q_3 C \ell_3 \right)
+    qqql_3333:
+      tex: \epsilon_{il} \epsilon_{jk} \left( q_3 C q_3 \right) \left( q_3 C \ell_3 \right)
+    duue_1113:
+      tex: \left( d_1 C u_1 \right) \left( u_1 C e_3 \right)
+    duue_1123:
+      tex: \left( d_1 C u_1 \right) \left( u_2 C e_3 \right)
+    duue_1133:
+      tex: \left( d_1 C u_1 \right) \left( u_3 C e_3 \right)
+    duue_1213:
+      tex: \left( d_1 C u_2 \right) \left( u_1 C e_3 \right)
+    duue_1223:
+      tex: \left( d_1 C u_2 \right) \left( u_2 C e_3 \right)
+    duue_1233:
+      tex: \left( d_1 C u_2 \right) \left( u_3 C e_3 \right)
+    duue_1313:
+      tex: \left( d_1 C u_3 \right) \left( u_1 C e_3 \right)
+    duue_1323:
+      tex: \left( d_1 C u_3 \right) \left( u_2 C e_3 \right)
+    duue_1333:
+      tex: \left( d_1 C u_3 \right) \left( u_3 C e_3 \right)
+    duue_2113:
+      tex: \left( d_2 C u_1 \right) \left( u_1 C e_3 \right)
+    duue_2123:
+      tex: \left( d_2 C u_1 \right) \left( u_2 C e_3 \right)
+    duue_2133:
+      tex: \left( d_2 C u_1 \right) \left( u_3 C e_3 \right)
+    duue_2213:
+      tex: \left( d_2 C u_2 \right) \left( u_1 C e_3 \right)
+    duue_2223:
+      tex: \left( d_2 C u_2 \right) \left( u_2 C e_3 \right)
+    duue_2233:
+      tex: \left( d_2 C u_2 \right) \left( u_3 C e_3 \right)
+    duue_2313:
+      tex: \left( d_2 C u_3 \right) \left( u_1 C e_3 \right)
+    duue_2323:
+      tex: \left( d_2 C u_3 \right) \left( u_2 C e_3 \right)
+    duue_2333:
+      tex: \left( d_2 C u_3 \right) \left( u_3 C e_3 \right)
+    duue_3113:
+      tex: \left( d_3 C u_1 \right) \left( u_1 C e_3 \right)
+    duue_3123:
+      tex: \left( d_3 C u_1 \right) \left( u_2 C e_3 \right)
+    duue_3133:
+      tex: \left( d_3 C u_1 \right) \left( u_3 C e_3 \right)
+    duue_3213:
+      tex: \left( d_3 C u_2 \right) \left( u_1 C e_3 \right)
+    duue_3223:
+      tex: \left( d_3 C u_2 \right) \left( u_2 C e_3 \right)
+    duue_3233:
+      tex: \left( d_3 C u_2 \right) \left( u_3 C e_3 \right)
+    duue_3313:
+      tex: \left( d_3 C u_3 \right) \left( u_1 C e_3 \right)
+    duue_3323:
+      tex: \left( d_3 C u_3 \right) \left( u_2 C e_3 \right)
     duue_3333:
       tex: \left( d_3 C u_3 \right) \left( u_3 C e_3 \right)
   dL=2:

--- a/smeft.warsaw.basis.yml
+++ b/smeft.warsaw.basis.yml
@@ -1,19 +1,9 @@
 eft: SMEFT
 basis: Warsaw
 metadata:
-  description: >
-    Basis suggested by Grzadkowski, Iskrzyński, Misiak, and Rosiek
-    (arXiv:1008.4884v3). At variance with their definition, the Wilson
-    coefficients are defined to be dimensionful, such that
-    $\mathcal L=\sum _i C_i O_i$. The set of redundant operators
-    coincides with the choice of DSixTools (arXiv:1704.04504).
-    The weak basis for the fermion fields is chosen such that the running
-    dimension-6 mass matrices of charged leptons and down-type quarks
-    are diagonal at the scale where the coefficient values are specified,
-    while up-type quark singlet field is rotated to diagonalise the
-    running dimension-6 up-type quark mass matrix "from the right".
+  description: "Basis suggested by Grzadkowski, Iskrzy\u0144ski, Misiak, and Rosiek (arXiv:1008.4884v3). At variance with their definition, the Wilson coefficients are defined to be dimensionful, such that $\\mathcal L=\\sum _i C_i O_i$. The set of redundant operators coincides with the choice of DSixTools (arXiv:1704.04504). The weak basis for the fermion fields is chosen such that the running dimension-6 mass matrices of charged leptons and down-type quarks are diagonal at the scale where the coefficient values are specified, while up-type quark singlet field is rotated to diagonalise the running dimension-6 up-type quark mass matrix \"from the right\".\n"
 sectors:
-  dB=dL=0:
+  dB=de=dmu=dtau=0:
     G:
       real: true
       tex: f^{ABC} G_\mu^{A \nu} G_\nu^{B \rho} G_\rho^{C \mu}
@@ -97,56 +87,20 @@ sectors:
       tex: \left( \varphi^\dagger \varphi \right) \left( \bar q_3 d_3 \varphi \right)
     ephi_11:
       tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_1 e_1 \varphi \right)
-    ephi_12:
-      tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_1 e_2 \varphi \right)
-    ephi_13:
-      tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_1 e_3 \varphi \right)
-    ephi_21:
-      tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_2 e_1 \varphi \right)
     ephi_22:
       tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_2 e_2 \varphi \right)
-    ephi_23:
-      tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_2 e_3 \varphi \right)
-    ephi_31:
-      tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_3 e_1 \varphi \right)
-    ephi_32:
-      tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_3 e_2 \varphi \right)
     ephi_33:
       tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_3 e_3 \varphi \right)
     eW_11:
       tex: \left( \bar \ell_1 \sigma^{\mu \nu} e_1 \right) \tau^I \varphi W_{\mu \nu}^I
-    eW_12:
-      tex: \left( \bar \ell_1 \sigma^{\mu \nu} e_2 \right) \tau^I \varphi W_{\mu \nu}^I
-    eW_13:
-      tex: \left( \bar \ell_1 \sigma^{\mu \nu} e_3 \right) \tau^I \varphi W_{\mu \nu}^I
-    eW_21:
-      tex: \left( \bar \ell_2 \sigma^{\mu \nu} e_1 \right) \tau^I \varphi W_{\mu \nu}^I
     eW_22:
       tex: \left( \bar \ell_2 \sigma^{\mu \nu} e_2 \right) \tau^I \varphi W_{\mu \nu}^I
-    eW_23:
-      tex: \left( \bar \ell_2 \sigma^{\mu \nu} e_3 \right) \tau^I \varphi W_{\mu \nu}^I
-    eW_31:
-      tex: \left( \bar \ell_3 \sigma^{\mu \nu} e_1 \right) \tau^I \varphi W_{\mu \nu}^I
-    eW_32:
-      tex: \left( \bar \ell_3 \sigma^{\mu \nu} e_2 \right) \tau^I \varphi W_{\mu \nu}^I
     eW_33:
       tex: \left( \bar \ell_3 \sigma^{\mu \nu} e_3 \right) \tau^I \varphi W_{\mu \nu}^I
     eB_11:
       tex: \left( \bar \ell_1 \sigma^{\mu \nu} e_1 \right) \varphi B_{\mu \nu}
-    eB_12:
-      tex: \left( \bar \ell_1 \sigma^{\mu \nu} e_2 \right) \varphi B_{\mu \nu}
-    eB_13:
-      tex: \left( \bar \ell_1 \sigma^{\mu \nu} e_3 \right) \varphi B_{\mu \nu}
-    eB_21:
-      tex: \left( \bar \ell_2 \sigma^{\mu \nu} e_1 \right) \varphi B_{\mu \nu}
     eB_22:
       tex: \left( \bar \ell_2 \sigma^{\mu \nu} e_2 \right) \varphi B_{\mu \nu}
-    eB_23:
-      tex: \left( \bar \ell_2 \sigma^{\mu \nu} e_3 \right) \varphi B_{\mu \nu}
-    eB_31:
-      tex: \left( \bar \ell_3 \sigma^{\mu \nu} e_1 \right) \varphi B_{\mu \nu}
-    eB_32:
-      tex: \left( \bar \ell_3 \sigma^{\mu \nu} e_2 \right) \varphi B_{\mu \nu}
     eB_33:
       tex: \left( \bar \ell_3 \sigma^{\mu \nu} e_3 \right) \varphi B_{\mu \nu}
     uG_11:
@@ -260,45 +214,27 @@ sectors:
     phil1_11:
       real: true
       tex: \left( \varphi^\dagger i \overset\leftrightarrow{D}_\mu \varphi \right) \left( \bar \ell_1 \gamma^\mu \ell_1 \right)
-    phil1_12:
-      tex: \left( \varphi^\dagger i \overset\leftrightarrow{D}_\mu \varphi \right) \left( \bar \ell_1 \gamma^\mu \ell_2 \right)
-    phil1_13:
-      tex: \left( \varphi^\dagger i \overset\leftrightarrow{D}_\mu \varphi \right) \left( \bar \ell_1 \gamma^\mu \ell_3 \right)
     phil1_22:
       real: true
       tex: \left( \varphi^\dagger i \overset\leftrightarrow{D}_\mu \varphi \right) \left( \bar \ell_2 \gamma^\mu \ell_2 \right)
-    phil1_23:
-      tex: \left( \varphi^\dagger i \overset\leftrightarrow{D}_\mu \varphi \right) \left( \bar \ell_2 \gamma^\mu \ell_3 \right)
     phil1_33:
       real: true
       tex: \left( \varphi^\dagger i \overset\leftrightarrow{D}_\mu \varphi \right) \left( \bar \ell_3 \gamma^\mu \ell_3 \right)
     phil3_11:
       real: true
       tex: \left( \varphi^\dagger i \overset\leftrightarrow{D}^I_\mu \varphi \right) \left( \bar \ell_1 \tau^I \gamma^\mu \ell_1 \right)
-    phil3_12:
-      tex: \left( \varphi^\dagger i \overset\leftrightarrow{D}^I_\mu \varphi \right) \left( \bar \ell_1 \tau^I \gamma^\mu \ell_2 \right)
-    phil3_13:
-      tex: \left( \varphi^\dagger i \overset\leftrightarrow{D}^I_\mu \varphi \right) \left( \bar \ell_1 \tau^I \gamma^\mu \ell_3 \right)
     phil3_22:
       real: true
       tex: \left( \varphi^\dagger i \overset\leftrightarrow{D}^I_\mu \varphi \right) \left( \bar \ell_2 \tau^I \gamma^\mu \ell_2 \right)
-    phil3_23:
-      tex: \left( \varphi^\dagger i \overset\leftrightarrow{D}^I_\mu \varphi \right) \left( \bar \ell_2 \tau^I \gamma^\mu \ell_3 \right)
     phil3_33:
       real: true
       tex: \left( \varphi^\dagger i \overset\leftrightarrow{D}^I_\mu \varphi \right) \left( \bar \ell_3 \tau^I \gamma^\mu \ell_3 \right)
     phie_11:
       real: true
       tex: \left( \varphi^\dagger i \overset\leftrightarrow{D}_\mu \varphi \right) \left( \bar e_1 \gamma^\mu e_1 \right)
-    phie_12:
-      tex: \left( \varphi^\dagger i \overset\leftrightarrow{D}_\mu \varphi \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    phie_13:
-      tex: \left( \varphi^\dagger i \overset\leftrightarrow{D}_\mu \varphi \right) \left( \bar e_1 \gamma^\mu e_3 \right)
     phie_22:
       real: true
       tex: \left( \varphi^\dagger i \overset\leftrightarrow{D}_\mu \varphi \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    phie_23:
-      tex: \left( \varphi^\dagger i \overset\leftrightarrow{D}_\mu \varphi \right) \left( \bar e_2 \gamma^\mu e_3 \right)
     phie_33:
       real: true
       tex: \left( \varphi^\dagger i \overset\leftrightarrow{D}_\mu \varphi \right) \left( \bar e_3 \gamma^\mu e_3 \right)
@@ -383,63 +319,27 @@ sectors:
     ll_1111:
       real: true
       tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar \ell_1 \gamma^\mu \ell_1 \right)
-    ll_1112:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar \ell_1 \gamma^\mu \ell_2 \right)
-    ll_1113:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar \ell_1 \gamma^\mu \ell_3 \right)
     ll_1122:
       real: true
       tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar \ell_2 \gamma^\mu \ell_2 \right)
-    ll_1123:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar \ell_2 \gamma^\mu \ell_3 \right)
     ll_1133:
       real: true
       tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar \ell_3 \gamma^\mu \ell_3 \right)
-    ll_1212:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_1 \gamma^\mu \ell_2 \right)
-    ll_1213:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_1 \gamma^\mu \ell_3 \right)
     ll_1221:
       real: true
       tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_2 \gamma^\mu \ell_1 \right)
-    ll_1222:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_2 \gamma^\mu \ell_2 \right)
-    ll_1223:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_2 \gamma^\mu \ell_3 \right)
-    ll_1231:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_3 \gamma^\mu \ell_1 \right)
-    ll_1232:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_3 \gamma^\mu \ell_2 \right)
-    ll_1233:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_3 \gamma^\mu \ell_3 \right)
-    ll_1313:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar \ell_1 \gamma^\mu \ell_3 \right)
-    ll_1322:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar \ell_2 \gamma^\mu \ell_2 \right)
-    ll_1323:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar \ell_2 \gamma^\mu \ell_3 \right)
     ll_1331:
       real: true
       tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar \ell_3 \gamma^\mu \ell_1 \right)
-    ll_1332:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar \ell_3 \gamma^\mu \ell_2 \right)
-    ll_1333:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar \ell_3 \gamma^\mu \ell_3 \right)
     ll_2222:
       real: true
       tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar \ell_2 \gamma^\mu \ell_2 \right)
-    ll_2223:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar \ell_2 \gamma^\mu \ell_3 \right)
     ll_2233:
       real: true
       tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar \ell_3 \gamma^\mu \ell_3 \right)
-    ll_2323:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar \ell_2 \gamma^\mu \ell_3 \right)
     ll_2332:
       real: true
       tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar \ell_3 \gamma^\mu \ell_2 \right)
-    ll_2333:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar \ell_3 \gamma^\mu \ell_3 \right)
     ll_3333:
       real: true
       tex: \left( \bar \ell_3 \gamma_\mu \ell_3 \right) \left( \bar \ell_3 \gamma^\mu \ell_3 \right)
@@ -584,42 +484,6 @@ sectors:
     lq1_1133:
       real: true
       tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar q_3 \gamma^\mu q_3 \right)
-    lq1_1211:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_1 \gamma^\mu q_1 \right)
-    lq1_1212:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_1 \gamma^\mu q_2 \right)
-    lq1_1213:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_1 \gamma^\mu q_3 \right)
-    lq1_1221:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_2 \gamma^\mu q_1 \right)
-    lq1_1222:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_2 \gamma^\mu q_2 \right)
-    lq1_1223:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_2 \gamma^\mu q_3 \right)
-    lq1_1231:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_3 \gamma^\mu q_1 \right)
-    lq1_1232:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_3 \gamma^\mu q_2 \right)
-    lq1_1233:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_3 \gamma^\mu q_3 \right)
-    lq1_1311:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_1 \gamma^\mu q_1 \right)
-    lq1_1312:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_1 \gamma^\mu q_2 \right)
-    lq1_1313:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_1 \gamma^\mu q_3 \right)
-    lq1_1321:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_2 \gamma^\mu q_1 \right)
-    lq1_1322:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_2 \gamma^\mu q_2 \right)
-    lq1_1323:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_2 \gamma^\mu q_3 \right)
-    lq1_1331:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_3 \gamma^\mu q_1 \right)
-    lq1_1332:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_3 \gamma^\mu q_2 \right)
-    lq1_1333:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_3 \gamma^\mu q_3 \right)
     lq1_2211:
       real: true
       tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar q_1 \gamma^\mu q_1 \right)
@@ -635,24 +499,6 @@ sectors:
     lq1_2233:
       real: true
       tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar q_3 \gamma^\mu q_3 \right)
-    lq1_2311:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_1 \gamma^\mu q_1 \right)
-    lq1_2312:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_1 \gamma^\mu q_2 \right)
-    lq1_2313:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_1 \gamma^\mu q_3 \right)
-    lq1_2321:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_2 \gamma^\mu q_1 \right)
-    lq1_2322:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_2 \gamma^\mu q_2 \right)
-    lq1_2323:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_2 \gamma^\mu q_3 \right)
-    lq1_2331:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_3 \gamma^\mu q_1 \right)
-    lq1_2332:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_3 \gamma^\mu q_2 \right)
-    lq1_2333:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_3 \gamma^\mu q_3 \right)
     lq1_3311:
       real: true
       tex: \left( \bar \ell_3 \gamma_\mu \ell_3 \right) \left( \bar q_1 \gamma^\mu q_1 \right)
@@ -683,42 +529,6 @@ sectors:
     lq3_1133:
       real: true
       tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_1 \right) \left( \bar q_3 \gamma^\mu \tau^I q_3 \right)
-    lq3_1211:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_1 \gamma^\mu \tau^I q_1 \right)
-    lq3_1212:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_1 \gamma^\mu \tau^I q_2 \right)
-    lq3_1213:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_1 \gamma^\mu \tau^I q_3 \right)
-    lq3_1221:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_2 \gamma^\mu \tau^I q_1 \right)
-    lq3_1222:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_2 \gamma^\mu \tau^I q_2 \right)
-    lq3_1223:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_2 \gamma^\mu \tau^I q_3 \right)
-    lq3_1231:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_3 \gamma^\mu \tau^I q_1 \right)
-    lq3_1232:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_3 \gamma^\mu \tau^I q_2 \right)
-    lq3_1233:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_3 \gamma^\mu \tau^I q_3 \right)
-    lq3_1311:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_1 \gamma^\mu \tau^I q_1 \right)
-    lq3_1312:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_1 \gamma^\mu \tau^I q_2 \right)
-    lq3_1313:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_1 \gamma^\mu \tau^I q_3 \right)
-    lq3_1321:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_2 \gamma^\mu \tau^I q_1 \right)
-    lq3_1322:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_2 \gamma^\mu \tau^I q_2 \right)
-    lq3_1323:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_2 \gamma^\mu \tau^I q_3 \right)
-    lq3_1331:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_3 \gamma^\mu \tau^I q_1 \right)
-    lq3_1332:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_3 \gamma^\mu \tau^I q_2 \right)
-    lq3_1333:
-      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_3 \gamma^\mu \tau^I q_3 \right)
     lq3_2211:
       real: true
       tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_1 \gamma^\mu \tau^I q_1 \right)
@@ -734,24 +544,6 @@ sectors:
     lq3_2233:
       real: true
       tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_3 \gamma^\mu \tau^I q_3 \right)
-    lq3_2311:
-      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_1 \gamma^\mu \tau^I q_1 \right)
-    lq3_2312:
-      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_1 \gamma^\mu \tau^I q_2 \right)
-    lq3_2313:
-      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_1 \gamma^\mu \tau^I q_3 \right)
-    lq3_2321:
-      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_2 \gamma^\mu \tau^I q_1 \right)
-    lq3_2322:
-      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_2 \gamma^\mu \tau^I q_2 \right)
-    lq3_2323:
-      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_2 \gamma^\mu \tau^I q_3 \right)
-    lq3_2331:
-      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_3 \gamma^\mu \tau^I q_1 \right)
-    lq3_2332:
-      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_3 \gamma^\mu \tau^I q_2 \right)
-    lq3_2333:
-      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_3 \gamma^\mu \tau^I q_3 \right)
     lq3_3311:
       real: true
       tex: \left( \bar \ell_3 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_1 \gamma^\mu \tau^I q_1 \right)
@@ -770,48 +562,18 @@ sectors:
     ee_1111:
       real: true
       tex: \left( \bar e_1 \gamma_\mu e_1 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
-    ee_1112:
-      tex: \left( \bar e_1 \gamma_\mu e_1 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    ee_1113:
-      tex: \left( \bar e_1 \gamma_\mu e_1 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
     ee_1122:
       real: true
       tex: \left( \bar e_1 \gamma_\mu e_1 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    ee_1123:
-      tex: \left( \bar e_1 \gamma_\mu e_1 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
     ee_1133:
       real: true
       tex: \left( \bar e_1 \gamma_\mu e_1 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
-    ee_1212:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    ee_1213:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
-    ee_1222:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    ee_1223:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
-    ee_1232:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar e_3 \gamma^\mu e_2 \right)
-    ee_1233:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
-    ee_1313:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
-    ee_1323:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
-    ee_1333:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
     ee_2222:
       real: true
       tex: \left( \bar e_2 \gamma_\mu e_2 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    ee_2223:
-      tex: \left( \bar e_2 \gamma_\mu e_2 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
     ee_2233:
       real: true
       tex: \left( \bar e_2 \gamma_\mu e_2 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
-    ee_2323:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
-    ee_2333:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
     ee_3333:
       real: true
       tex: \left( \bar e_3 \gamma_\mu e_3 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
@@ -956,42 +718,6 @@ sectors:
     eu_1133:
       real: true
       tex: \left( \bar e_1 \gamma_\mu e_1 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
-    eu_1211:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
-    eu_1212:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_1 \gamma^\mu u_2 \right)
-    eu_1213:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_1 \gamma^\mu u_3 \right)
-    eu_1221:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_2 \gamma^\mu u_1 \right)
-    eu_1222:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_2 \gamma^\mu u_2 \right)
-    eu_1223:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_2 \gamma^\mu u_3 \right)
-    eu_1231:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_3 \gamma^\mu u_1 \right)
-    eu_1232:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_3 \gamma^\mu u_2 \right)
-    eu_1233:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
-    eu_1311:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
-    eu_1312:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_1 \gamma^\mu u_2 \right)
-    eu_1313:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_1 \gamma^\mu u_3 \right)
-    eu_1321:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_2 \gamma^\mu u_1 \right)
-    eu_1322:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_2 \gamma^\mu u_2 \right)
-    eu_1323:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_2 \gamma^\mu u_3 \right)
-    eu_1331:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_3 \gamma^\mu u_1 \right)
-    eu_1332:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_3 \gamma^\mu u_2 \right)
-    eu_1333:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
     eu_2211:
       real: true
       tex: \left( \bar e_2 \gamma_\mu e_2 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
@@ -1007,24 +733,6 @@ sectors:
     eu_2233:
       real: true
       tex: \left( \bar e_2 \gamma_\mu e_2 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
-    eu_2311:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
-    eu_2312:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_1 \gamma^\mu u_2 \right)
-    eu_2313:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_1 \gamma^\mu u_3 \right)
-    eu_2321:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_2 \gamma^\mu u_1 \right)
-    eu_2322:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_2 \gamma^\mu u_2 \right)
-    eu_2323:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_2 \gamma^\mu u_3 \right)
-    eu_2331:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_3 \gamma^\mu u_1 \right)
-    eu_2332:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_3 \gamma^\mu u_2 \right)
-    eu_2333:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
     eu_3311:
       real: true
       tex: \left( \bar e_3 \gamma_\mu e_3 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
@@ -1055,42 +763,6 @@ sectors:
     ed_1133:
       real: true
       tex: \left( \bar e_1 \gamma_\mu e_1 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
-    ed_1211:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
-    ed_1212:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_1 \gamma^\mu d_2 \right)
-    ed_1213:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_1 \gamma^\mu d_3 \right)
-    ed_1221:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_2 \gamma^\mu d_1 \right)
-    ed_1222:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_2 \gamma^\mu d_2 \right)
-    ed_1223:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_2 \gamma^\mu d_3 \right)
-    ed_1231:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_3 \gamma^\mu d_1 \right)
-    ed_1232:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_3 \gamma^\mu d_2 \right)
-    ed_1233:
-      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
-    ed_1311:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
-    ed_1312:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_1 \gamma^\mu d_2 \right)
-    ed_1313:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_1 \gamma^\mu d_3 \right)
-    ed_1321:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_2 \gamma^\mu d_1 \right)
-    ed_1322:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_2 \gamma^\mu d_2 \right)
-    ed_1323:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_2 \gamma^\mu d_3 \right)
-    ed_1331:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_3 \gamma^\mu d_1 \right)
-    ed_1332:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_3 \gamma^\mu d_2 \right)
-    ed_1333:
-      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
     ed_2211:
       real: true
       tex: \left( \bar e_2 \gamma_\mu e_2 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
@@ -1106,24 +778,6 @@ sectors:
     ed_2233:
       real: true
       tex: \left( \bar e_2 \gamma_\mu e_2 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
-    ed_2311:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
-    ed_2312:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_1 \gamma^\mu d_2 \right)
-    ed_2313:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_1 \gamma^\mu d_3 \right)
-    ed_2321:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_2 \gamma^\mu d_1 \right)
-    ed_2322:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_2 \gamma^\mu d_2 \right)
-    ed_2323:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_2 \gamma^\mu d_3 \right)
-    ed_2331:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_3 \gamma^\mu d_1 \right)
-    ed_2332:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_3 \gamma^\mu d_2 \right)
-    ed_2333:
-      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
     ed_3311:
       real: true
       tex: \left( \bar e_3 \gamma_\mu e_3 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
@@ -1340,99 +994,33 @@ sectors:
     le_1111:
       real: true
       tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
-    le_1112:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    le_1113:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
     le_1122:
       real: true
       tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    le_1123:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
     le_1133:
       real: true
       tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
-    le_1211:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
-    le_1212:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    le_1213:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
     le_1221:
       tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_2 \gamma^\mu e_1 \right)
-    le_1222:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    le_1223:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
-    le_1231:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_3 \gamma^\mu e_1 \right)
-    le_1232:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_3 \gamma^\mu e_2 \right)
-    le_1233:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
-    le_1311:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
-    le_1312:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    le_1313:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
-    le_1321:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_1 \right)
-    le_1322:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    le_1323:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
     le_1331:
       tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_3 \gamma^\mu e_1 \right)
-    le_1332:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_3 \gamma^\mu e_2 \right)
-    le_1333:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
     le_2211:
       real: true
       tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
-    le_2212:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    le_2213:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
     le_2222:
       real: true
       tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    le_2223:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
     le_2233:
       real: true
       tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
-    le_2311:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
-    le_2312:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    le_2313:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
-    le_2321:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_1 \right)
-    le_2322:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    le_2323:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
-    le_2331:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_3 \gamma^\mu e_1 \right)
     le_2332:
       tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_3 \gamma^\mu e_2 \right)
-    le_2333:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
     le_3311:
       real: true
       tex: \left( \bar \ell_3 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
-    le_3312:
-      tex: \left( \bar \ell_3 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    le_3313:
-      tex: \left( \bar \ell_3 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
     le_3322:
       real: true
       tex: \left( \bar \ell_3 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    le_3323:
-      tex: \left( \bar \ell_3 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
     le_3333:
       real: true
       tex: \left( \bar \ell_3 \gamma_\mu \ell_3 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
@@ -1451,42 +1039,6 @@ sectors:
     lu_1133:
       real: true
       tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
-    lu_1211:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
-    lu_1212:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_1 \gamma^\mu u_2 \right)
-    lu_1213:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_1 \gamma^\mu u_3 \right)
-    lu_1221:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_2 \gamma^\mu u_1 \right)
-    lu_1222:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_2 \gamma^\mu u_2 \right)
-    lu_1223:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_2 \gamma^\mu u_3 \right)
-    lu_1231:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_3 \gamma^\mu u_1 \right)
-    lu_1232:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_3 \gamma^\mu u_2 \right)
-    lu_1233:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
-    lu_1311:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
-    lu_1312:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_1 \gamma^\mu u_2 \right)
-    lu_1313:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_1 \gamma^\mu u_3 \right)
-    lu_1321:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_2 \gamma^\mu u_1 \right)
-    lu_1322:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_2 \gamma^\mu u_2 \right)
-    lu_1323:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_2 \gamma^\mu u_3 \right)
-    lu_1331:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_3 \gamma^\mu u_1 \right)
-    lu_1332:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_3 \gamma^\mu u_2 \right)
-    lu_1333:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
     lu_2211:
       real: true
       tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
@@ -1502,24 +1054,6 @@ sectors:
     lu_2233:
       real: true
       tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
-    lu_2311:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
-    lu_2312:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_1 \gamma^\mu u_2 \right)
-    lu_2313:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_1 \gamma^\mu u_3 \right)
-    lu_2321:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_2 \gamma^\mu u_1 \right)
-    lu_2322:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_2 \gamma^\mu u_2 \right)
-    lu_2323:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_2 \gamma^\mu u_3 \right)
-    lu_2331:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_3 \gamma^\mu u_1 \right)
-    lu_2332:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_3 \gamma^\mu u_2 \right)
-    lu_2333:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
     lu_3311:
       real: true
       tex: \left( \bar \ell_3 \gamma_\mu \ell_3 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
@@ -1550,42 +1084,6 @@ sectors:
     ld_1133:
       real: true
       tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
-    ld_1211:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
-    ld_1212:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_1 \gamma^\mu d_2 \right)
-    ld_1213:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_1 \gamma^\mu d_3 \right)
-    ld_1221:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_2 \gamma^\mu d_1 \right)
-    ld_1222:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_2 \gamma^\mu d_2 \right)
-    ld_1223:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_2 \gamma^\mu d_3 \right)
-    ld_1231:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_3 \gamma^\mu d_1 \right)
-    ld_1232:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_3 \gamma^\mu d_2 \right)
-    ld_1233:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
-    ld_1311:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
-    ld_1312:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_1 \gamma^\mu d_2 \right)
-    ld_1313:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_1 \gamma^\mu d_3 \right)
-    ld_1321:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_2 \gamma^\mu d_1 \right)
-    ld_1322:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_2 \gamma^\mu d_2 \right)
-    ld_1323:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_2 \gamma^\mu d_3 \right)
-    ld_1331:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_3 \gamma^\mu d_1 \right)
-    ld_1332:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_3 \gamma^\mu d_2 \right)
-    ld_1333:
-      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
     ld_2211:
       real: true
       tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
@@ -1601,24 +1099,6 @@ sectors:
     ld_2233:
       real: true
       tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
-    ld_2311:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
-    ld_2312:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_1 \gamma^\mu d_2 \right)
-    ld_2313:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_1 \gamma^\mu d_3 \right)
-    ld_2321:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_2 \gamma^\mu d_1 \right)
-    ld_2322:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_2 \gamma^\mu d_2 \right)
-    ld_2323:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_2 \gamma^\mu d_3 \right)
-    ld_2331:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_3 \gamma^\mu d_1 \right)
-    ld_2332:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_3 \gamma^\mu d_2 \right)
-    ld_2333:
-      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
     ld_3311:
       real: true
       tex: \left( \bar \ell_3 \gamma_\mu \ell_3 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
@@ -1637,99 +1117,45 @@ sectors:
     qe_1111:
       real: true
       tex: \left( \bar q_1 \gamma_\mu q_1 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
-    qe_1112:
-      tex: \left( \bar q_1 \gamma_\mu q_1 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    qe_1113:
-      tex: \left( \bar q_1 \gamma_\mu q_1 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
     qe_1122:
       real: true
       tex: \left( \bar q_1 \gamma_\mu q_1 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    qe_1123:
-      tex: \left( \bar q_1 \gamma_\mu q_1 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
     qe_1133:
       real: true
       tex: \left( \bar q_1 \gamma_\mu q_1 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
     qe_1211:
       tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
-    qe_1212:
-      tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    qe_1213:
-      tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
-    qe_1221:
-      tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_2 \gamma^\mu e_1 \right)
     qe_1222:
       tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    qe_1223:
-      tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
-    qe_1231:
-      tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_3 \gamma^\mu e_1 \right)
-    qe_1232:
-      tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_3 \gamma^\mu e_2 \right)
     qe_1233:
       tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
     qe_1311:
       tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
-    qe_1312:
-      tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    qe_1313:
-      tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
-    qe_1321:
-      tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_2 \gamma^\mu e_1 \right)
     qe_1322:
       tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    qe_1323:
-      tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
-    qe_1331:
-      tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_3 \gamma^\mu e_1 \right)
-    qe_1332:
-      tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_3 \gamma^\mu e_2 \right)
     qe_1333:
       tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
     qe_2211:
       real: true
       tex: \left( \bar q_2 \gamma_\mu q_2 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
-    qe_2212:
-      tex: \left( \bar q_2 \gamma_\mu q_2 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    qe_2213:
-      tex: \left( \bar q_2 \gamma_\mu q_2 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
     qe_2222:
       real: true
       tex: \left( \bar q_2 \gamma_\mu q_2 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    qe_2223:
-      tex: \left( \bar q_2 \gamma_\mu q_2 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
     qe_2233:
       real: true
       tex: \left( \bar q_2 \gamma_\mu q_2 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
     qe_2311:
       tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
-    qe_2312:
-      tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    qe_2313:
-      tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
-    qe_2321:
-      tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_2 \gamma^\mu e_1 \right)
     qe_2322:
       tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    qe_2323:
-      tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
-    qe_2331:
-      tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_3 \gamma^\mu e_1 \right)
-    qe_2332:
-      tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_3 \gamma^\mu e_2 \right)
     qe_2333:
       tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
     qe_3311:
       real: true
       tex: \left( \bar q_3 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
-    qe_3312:
-      tex: \left( \bar q_3 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
-    qe_3313:
-      tex: \left( \bar q_3 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
     qe_3322:
       real: true
       tex: \left( \bar q_3 \gamma_\mu q_3 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
-    qe_3323:
-      tex: \left( \bar q_3 \gamma_\mu q_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
     qe_3333:
       real: true
       tex: \left( \bar q_3 \gamma_\mu q_3 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
@@ -2147,60 +1573,6 @@ sectors:
       tex: \left( \bar \ell_1 e_1 \right) \left( \bar d_3 q_2 \right)
     ledq_1133:
       tex: \left( \bar \ell_1 e_1 \right) \left( \bar d_3 q_3 \right)
-    ledq_1211:
-      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_1 q_1 \right)
-    ledq_1212:
-      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_1 q_2 \right)
-    ledq_1213:
-      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_1 q_3 \right)
-    ledq_1221:
-      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_2 q_1 \right)
-    ledq_1222:
-      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_2 q_2 \right)
-    ledq_1223:
-      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_2 q_3 \right)
-    ledq_1231:
-      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_3 q_1 \right)
-    ledq_1232:
-      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_3 q_2 \right)
-    ledq_1233:
-      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_3 q_3 \right)
-    ledq_1311:
-      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_1 q_1 \right)
-    ledq_1312:
-      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_1 q_2 \right)
-    ledq_1313:
-      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_1 q_3 \right)
-    ledq_1321:
-      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_2 q_1 \right)
-    ledq_1322:
-      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_2 q_2 \right)
-    ledq_1323:
-      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_2 q_3 \right)
-    ledq_1331:
-      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_3 q_1 \right)
-    ledq_1332:
-      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_3 q_2 \right)
-    ledq_1333:
-      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_3 q_3 \right)
-    ledq_2111:
-      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_1 q_1 \right)
-    ledq_2112:
-      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_1 q_2 \right)
-    ledq_2113:
-      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_1 q_3 \right)
-    ledq_2121:
-      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_2 q_1 \right)
-    ledq_2122:
-      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_2 q_2 \right)
-    ledq_2123:
-      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_2 q_3 \right)
-    ledq_2131:
-      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_3 q_1 \right)
-    ledq_2132:
-      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_3 q_2 \right)
-    ledq_2133:
-      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_3 q_3 \right)
     ledq_2211:
       tex: \left( \bar \ell_2 e_2 \right) \left( \bar d_1 q_1 \right)
     ledq_2212:
@@ -2219,60 +1591,6 @@ sectors:
       tex: \left( \bar \ell_2 e_2 \right) \left( \bar d_3 q_2 \right)
     ledq_2233:
       tex: \left( \bar \ell_2 e_2 \right) \left( \bar d_3 q_3 \right)
-    ledq_2311:
-      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_1 q_1 \right)
-    ledq_2312:
-      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_1 q_2 \right)
-    ledq_2313:
-      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_1 q_3 \right)
-    ledq_2321:
-      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_2 q_1 \right)
-    ledq_2322:
-      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_2 q_2 \right)
-    ledq_2323:
-      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_2 q_3 \right)
-    ledq_2331:
-      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_3 q_1 \right)
-    ledq_2332:
-      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_3 q_2 \right)
-    ledq_2333:
-      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_3 q_3 \right)
-    ledq_3111:
-      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_1 q_1 \right)
-    ledq_3112:
-      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_1 q_2 \right)
-    ledq_3113:
-      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_1 q_3 \right)
-    ledq_3121:
-      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_2 q_1 \right)
-    ledq_3122:
-      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_2 q_2 \right)
-    ledq_3123:
-      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_2 q_3 \right)
-    ledq_3131:
-      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_3 q_1 \right)
-    ledq_3132:
-      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_3 q_2 \right)
-    ledq_3133:
-      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_3 q_3 \right)
-    ledq_3211:
-      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_1 q_1 \right)
-    ledq_3212:
-      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_1 q_2 \right)
-    ledq_3213:
-      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_1 q_3 \right)
-    ledq_3221:
-      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_2 q_1 \right)
-    ledq_3222:
-      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_2 q_2 \right)
-    ledq_3223:
-      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_2 q_3 \right)
-    ledq_3231:
-      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_3 q_1 \right)
-    ledq_3232:
-      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_3 q_2 \right)
-    ledq_3233:
-      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_3 q_3 \right)
     ledq_3311:
       tex: \left( \bar \ell_3 e_3 \right) \left( \bar d_1 q_1 \right)
     ledq_3312:
@@ -2633,60 +1951,6 @@ sectors:
       tex: \left( \bar \ell_1 e_1 \right) \epsilon_{jk} \left( \bar q_3 u_2 \right)
     lequ1_1133:
       tex: \left( \bar \ell_1 e_1 \right) \epsilon_{jk} \left( \bar q_3 u_3 \right)
-    lequ1_1211:
-      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_1 u_1 \right)
-    lequ1_1212:
-      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_1 u_2 \right)
-    lequ1_1213:
-      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_1 u_3 \right)
-    lequ1_1221:
-      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_2 u_1 \right)
-    lequ1_1222:
-      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_2 u_2 \right)
-    lequ1_1223:
-      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_2 u_3 \right)
-    lequ1_1231:
-      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_3 u_1 \right)
-    lequ1_1232:
-      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_3 u_2 \right)
-    lequ1_1233:
-      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_3 u_3 \right)
-    lequ1_1311:
-      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_1 u_1 \right)
-    lequ1_1312:
-      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_1 u_2 \right)
-    lequ1_1313:
-      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_1 u_3 \right)
-    lequ1_1321:
-      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_2 u_1 \right)
-    lequ1_1322:
-      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_2 u_2 \right)
-    lequ1_1323:
-      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_2 u_3 \right)
-    lequ1_1331:
-      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_3 u_1 \right)
-    lequ1_1332:
-      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_3 u_2 \right)
-    lequ1_1333:
-      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_3 u_3 \right)
-    lequ1_2111:
-      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_1 u_1 \right)
-    lequ1_2112:
-      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_1 u_2 \right)
-    lequ1_2113:
-      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_1 u_3 \right)
-    lequ1_2121:
-      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_2 u_1 \right)
-    lequ1_2122:
-      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_2 u_2 \right)
-    lequ1_2123:
-      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_2 u_3 \right)
-    lequ1_2131:
-      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_3 u_1 \right)
-    lequ1_2132:
-      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_3 u_2 \right)
-    lequ1_2133:
-      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_3 u_3 \right)
     lequ1_2211:
       tex: \left( \bar \ell_2 e_2 \right) \epsilon_{jk} \left( \bar q_1 u_1 \right)
     lequ1_2212:
@@ -2705,60 +1969,6 @@ sectors:
       tex: \left( \bar \ell_2 e_2 \right) \epsilon_{jk} \left( \bar q_3 u_2 \right)
     lequ1_2233:
       tex: \left( \bar \ell_2 e_2 \right) \epsilon_{jk} \left( \bar q_3 u_3 \right)
-    lequ1_2311:
-      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_1 u_1 \right)
-    lequ1_2312:
-      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_1 u_2 \right)
-    lequ1_2313:
-      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_1 u_3 \right)
-    lequ1_2321:
-      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_2 u_1 \right)
-    lequ1_2322:
-      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_2 u_2 \right)
-    lequ1_2323:
-      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_2 u_3 \right)
-    lequ1_2331:
-      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_3 u_1 \right)
-    lequ1_2332:
-      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_3 u_2 \right)
-    lequ1_2333:
-      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_3 u_3 \right)
-    lequ1_3111:
-      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_1 u_1 \right)
-    lequ1_3112:
-      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_1 u_2 \right)
-    lequ1_3113:
-      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_1 u_3 \right)
-    lequ1_3121:
-      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_2 u_1 \right)
-    lequ1_3122:
-      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_2 u_2 \right)
-    lequ1_3123:
-      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_2 u_3 \right)
-    lequ1_3131:
-      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_3 u_1 \right)
-    lequ1_3132:
-      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_3 u_2 \right)
-    lequ1_3133:
-      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_3 u_3 \right)
-    lequ1_3211:
-      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_1 u_1 \right)
-    lequ1_3212:
-      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_1 u_2 \right)
-    lequ1_3213:
-      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_1 u_3 \right)
-    lequ1_3221:
-      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_2 u_1 \right)
-    lequ1_3222:
-      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_2 u_2 \right)
-    lequ1_3223:
-      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_2 u_3 \right)
-    lequ1_3231:
-      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_3 u_1 \right)
-    lequ1_3232:
-      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_3 u_2 \right)
-    lequ1_3233:
-      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_3 u_3 \right)
     lequ1_3311:
       tex: \left( \bar \ell_3 e_3 \right) \epsilon_{jk} \left( \bar q_1 u_1 \right)
     lequ1_3312:
@@ -2795,60 +2005,6 @@ sectors:
       tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
     lequ3_1133:
       tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
-    lequ3_1211:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_1 \right)
-    lequ3_1212:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_2 \right)
-    lequ3_1213:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_3 \right)
-    lequ3_1221:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_1 \right)
-    lequ3_1222:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_2 \right)
-    lequ3_1223:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_3 \right)
-    lequ3_1231:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_1 \right)
-    lequ3_1232:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
-    lequ3_1233:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
-    lequ3_1311:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_1 \right)
-    lequ3_1312:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_2 \right)
-    lequ3_1313:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_3 \right)
-    lequ3_1321:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_1 \right)
-    lequ3_1322:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_2 \right)
-    lequ3_1323:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_3 \right)
-    lequ3_1331:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_1 \right)
-    lequ3_1332:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
-    lequ3_1333:
-      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
-    lequ3_2111:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_1 \right)
-    lequ3_2112:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_2 \right)
-    lequ3_2113:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_3 \right)
-    lequ3_2121:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_1 \right)
-    lequ3_2122:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_2 \right)
-    lequ3_2123:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_3 \right)
-    lequ3_2131:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_1 \right)
-    lequ3_2132:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
-    lequ3_2133:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
     lequ3_2211:
       tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_1 \right)
     lequ3_2212:
@@ -2867,60 +2023,6 @@ sectors:
       tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
     lequ3_2233:
       tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
-    lequ3_2311:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_1 \right)
-    lequ3_2312:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_2 \right)
-    lequ3_2313:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_3 \right)
-    lequ3_2321:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_1 \right)
-    lequ3_2322:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_2 \right)
-    lequ3_2323:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_3 \right)
-    lequ3_2331:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_1 \right)
-    lequ3_2332:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
-    lequ3_2333:
-      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
-    lequ3_3111:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_1 \right)
-    lequ3_3112:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_2 \right)
-    lequ3_3113:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_3 \right)
-    lequ3_3121:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_1 \right)
-    lequ3_3122:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_2 \right)
-    lequ3_3123:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_3 \right)
-    lequ3_3131:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_1 \right)
-    lequ3_3132:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
-    lequ3_3133:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
-    lequ3_3211:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_1 \right)
-    lequ3_3212:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_2 \right)
-    lequ3_3213:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_3 \right)
-    lequ3_3221:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_1 \right)
-    lequ3_3222:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_2 \right)
-    lequ3_3223:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_3 \right)
-    lequ3_3231:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_1 \right)
-    lequ3_3232:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
-    lequ3_3233:
-      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
     lequ3_3311:
       tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_1 \right)
     lequ3_3312:
@@ -2939,6 +2041,903 @@ sectors:
       tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
     lequ3_3333:
       tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
+  mue:
+    ephi_12:
+      tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_1 e_2 \varphi \right)
+    ephi_21:
+      tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_2 e_1 \varphi \right)
+    eW_12:
+      tex: \left( \bar \ell_1 \sigma^{\mu \nu} e_2 \right) \tau^I \varphi W_{\mu \nu}^I
+    eW_21:
+      tex: \left( \bar \ell_2 \sigma^{\mu \nu} e_1 \right) \tau^I \varphi W_{\mu \nu}^I
+    eB_12:
+      tex: \left( \bar \ell_1 \sigma^{\mu \nu} e_2 \right) \varphi B_{\mu \nu}
+    eB_21:
+      tex: \left( \bar \ell_2 \sigma^{\mu \nu} e_1 \right) \varphi B_{\mu \nu}
+    phil1_12:
+      tex: \left( \varphi^\dagger i \overset\leftrightarrow{D}_\mu \varphi \right) \left( \bar \ell_1 \gamma^\mu \ell_2 \right)
+    phil3_12:
+      tex: \left( \varphi^\dagger i \overset\leftrightarrow{D}^I_\mu \varphi \right) \left( \bar \ell_1 \tau^I \gamma^\mu \ell_2 \right)
+    phie_12:
+      tex: \left( \varphi^\dagger i \overset\leftrightarrow{D}_\mu \varphi \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+    ll_1112:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar \ell_1 \gamma^\mu \ell_2 \right)
+    ll_1222:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_2 \gamma^\mu \ell_2 \right)
+    ll_1233:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_3 \gamma^\mu \ell_3 \right)
+    ll_1332:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar \ell_3 \gamma^\mu \ell_2 \right)
+    lq1_1211:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_1 \gamma^\mu q_1 \right)
+    lq1_1212:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_1 \gamma^\mu q_2 \right)
+    lq1_1213:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_1 \gamma^\mu q_3 \right)
+    lq1_1221:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_2 \gamma^\mu q_1 \right)
+    lq1_1222:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_2 \gamma^\mu q_2 \right)
+    lq1_1223:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_2 \gamma^\mu q_3 \right)
+    lq1_1231:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_3 \gamma^\mu q_1 \right)
+    lq1_1232:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_3 \gamma^\mu q_2 \right)
+    lq1_1233:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar q_3 \gamma^\mu q_3 \right)
+    lq3_1211:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_1 \gamma^\mu \tau^I q_1 \right)
+    lq3_1212:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_1 \gamma^\mu \tau^I q_2 \right)
+    lq3_1213:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_1 \gamma^\mu \tau^I q_3 \right)
+    lq3_1221:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_2 \gamma^\mu \tau^I q_1 \right)
+    lq3_1222:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_2 \gamma^\mu \tau^I q_2 \right)
+    lq3_1223:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_2 \gamma^\mu \tau^I q_3 \right)
+    lq3_1231:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_3 \gamma^\mu \tau^I q_1 \right)
+    lq3_1232:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_3 \gamma^\mu \tau^I q_2 \right)
+    lq3_1233:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_2 \right) \left( \bar q_3 \gamma^\mu \tau^I q_3 \right)
+    ee_1112:
+      tex: \left( \bar e_1 \gamma_\mu e_1 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+    ee_1222:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
+    ee_1233:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
+    eu_1211:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
+    eu_1212:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_1 \gamma^\mu u_2 \right)
+    eu_1213:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_1 \gamma^\mu u_3 \right)
+    eu_1221:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_2 \gamma^\mu u_1 \right)
+    eu_1222:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_2 \gamma^\mu u_2 \right)
+    eu_1223:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_2 \gamma^\mu u_3 \right)
+    eu_1231:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_3 \gamma^\mu u_1 \right)
+    eu_1232:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_3 \gamma^\mu u_2 \right)
+    eu_1233:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
+    ed_1211:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
+    ed_1212:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_1 \gamma^\mu d_2 \right)
+    ed_1213:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_1 \gamma^\mu d_3 \right)
+    ed_1221:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_2 \gamma^\mu d_1 \right)
+    ed_1222:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_2 \gamma^\mu d_2 \right)
+    ed_1223:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_2 \gamma^\mu d_3 \right)
+    ed_1231:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_3 \gamma^\mu d_1 \right)
+    ed_1232:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_3 \gamma^\mu d_2 \right)
+    ed_1233:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
+    le_1112:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+    le_1211:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
+    le_1222:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
+    le_1233:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
+    le_1332:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_3 \gamma^\mu e_2 \right)
+    le_2212:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+    le_2331:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_3 \gamma^\mu e_1 \right)
+    le_3312:
+      tex: \left( \bar \ell_3 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+    lu_1211:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
+    lu_1212:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_1 \gamma^\mu u_2 \right)
+    lu_1213:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_1 \gamma^\mu u_3 \right)
+    lu_1221:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_2 \gamma^\mu u_1 \right)
+    lu_1222:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_2 \gamma^\mu u_2 \right)
+    lu_1223:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_2 \gamma^\mu u_3 \right)
+    lu_1231:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_3 \gamma^\mu u_1 \right)
+    lu_1232:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_3 \gamma^\mu u_2 \right)
+    lu_1233:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
+    ld_1211:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
+    ld_1212:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_1 \gamma^\mu d_2 \right)
+    ld_1213:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_1 \gamma^\mu d_3 \right)
+    ld_1221:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_2 \gamma^\mu d_1 \right)
+    ld_1222:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_2 \gamma^\mu d_2 \right)
+    ld_1223:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_2 \gamma^\mu d_3 \right)
+    ld_1231:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_3 \gamma^\mu d_1 \right)
+    ld_1232:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_3 \gamma^\mu d_2 \right)
+    ld_1233:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
+    qe_1112:
+      tex: \left( \bar q_1 \gamma_\mu q_1 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+    qe_1212:
+      tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+    qe_1221:
+      tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_2 \gamma^\mu e_1 \right)
+    qe_1312:
+      tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+    qe_1321:
+      tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_2 \gamma^\mu e_1 \right)
+    qe_2212:
+      tex: \left( \bar q_2 \gamma_\mu q_2 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+    qe_2312:
+      tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+    qe_2321:
+      tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_2 \gamma^\mu e_1 \right)
+    qe_3312:
+      tex: \left( \bar q_3 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+    ledq_1211:
+      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_1 q_1 \right)
+    ledq_1212:
+      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_1 q_2 \right)
+    ledq_1213:
+      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_1 q_3 \right)
+    ledq_1221:
+      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_2 q_1 \right)
+    ledq_1222:
+      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_2 q_2 \right)
+    ledq_1223:
+      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_2 q_3 \right)
+    ledq_1231:
+      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_3 q_1 \right)
+    ledq_1232:
+      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_3 q_2 \right)
+    ledq_1233:
+      tex: \left( \bar \ell_1 e_2 \right) \left( \bar d_3 q_3 \right)
+    ledq_2111:
+      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_1 q_1 \right)
+    ledq_2112:
+      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_1 q_2 \right)
+    ledq_2113:
+      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_1 q_3 \right)
+    ledq_2121:
+      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_2 q_1 \right)
+    ledq_2122:
+      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_2 q_2 \right)
+    ledq_2123:
+      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_2 q_3 \right)
+    ledq_2131:
+      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_3 q_1 \right)
+    ledq_2132:
+      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_3 q_2 \right)
+    ledq_2133:
+      tex: \left( \bar \ell_2 e_1 \right) \left( \bar d_3 q_3 \right)
+    lequ1_1211:
+      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_1 u_1 \right)
+    lequ1_1212:
+      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_1 u_2 \right)
+    lequ1_1213:
+      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_1 u_3 \right)
+    lequ1_1221:
+      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_2 u_1 \right)
+    lequ1_1222:
+      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_2 u_2 \right)
+    lequ1_1223:
+      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_2 u_3 \right)
+    lequ1_1231:
+      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_3 u_1 \right)
+    lequ1_1232:
+      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_3 u_2 \right)
+    lequ1_1233:
+      tex: \left( \bar \ell_1 e_2 \right) \epsilon_{jk} \left( \bar q_3 u_3 \right)
+    lequ1_2111:
+      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_1 u_1 \right)
+    lequ1_2112:
+      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_1 u_2 \right)
+    lequ1_2113:
+      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_1 u_3 \right)
+    lequ1_2121:
+      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_2 u_1 \right)
+    lequ1_2122:
+      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_2 u_2 \right)
+    lequ1_2123:
+      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_2 u_3 \right)
+    lequ1_2131:
+      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_3 u_1 \right)
+    lequ1_2132:
+      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_3 u_2 \right)
+    lequ1_2133:
+      tex: \left( \bar \ell_2 e_1 \right) \epsilon_{jk} \left( \bar q_3 u_3 \right)
+    lequ3_1211:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_1 \right)
+    lequ3_1212:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_2 \right)
+    lequ3_1213:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_3 \right)
+    lequ3_1221:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_1 \right)
+    lequ3_1222:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_2 \right)
+    lequ3_1223:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_3 \right)
+    lequ3_1231:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_1 \right)
+    lequ3_1232:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
+    lequ3_1233:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
+    lequ3_2111:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_1 \right)
+    lequ3_2112:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_2 \right)
+    lequ3_2113:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_3 \right)
+    lequ3_2121:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_1 \right)
+    lequ3_2122:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_2 \right)
+    lequ3_2123:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_3 \right)
+    lequ3_2131:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_1 \right)
+    lequ3_2132:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
+    lequ3_2133:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
+  taue:
+    ephi_13:
+      tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_1 e_3 \varphi \right)
+    ephi_31:
+      tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_3 e_1 \varphi \right)
+    eW_13:
+      tex: \left( \bar \ell_1 \sigma^{\mu \nu} e_3 \right) \tau^I \varphi W_{\mu \nu}^I
+    eW_31:
+      tex: \left( \bar \ell_3 \sigma^{\mu \nu} e_1 \right) \tau^I \varphi W_{\mu \nu}^I
+    eB_13:
+      tex: \left( \bar \ell_1 \sigma^{\mu \nu} e_3 \right) \varphi B_{\mu \nu}
+    eB_31:
+      tex: \left( \bar \ell_3 \sigma^{\mu \nu} e_1 \right) \varphi B_{\mu \nu}
+    phil1_13:
+      tex: \left( \varphi^\dagger i \overset\leftrightarrow{D}_\mu \varphi \right) \left( \bar \ell_1 \gamma^\mu \ell_3 \right)
+    phil3_13:
+      tex: \left( \varphi^\dagger i \overset\leftrightarrow{D}^I_\mu \varphi \right) \left( \bar \ell_1 \tau^I \gamma^\mu \ell_3 \right)
+    phie_13:
+      tex: \left( \varphi^\dagger i \overset\leftrightarrow{D}_\mu \varphi \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+    ll_1113:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar \ell_1 \gamma^\mu \ell_3 \right)
+    ll_1223:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_2 \gamma^\mu \ell_3 \right)
+    ll_1322:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar \ell_2 \gamma^\mu \ell_2 \right)
+    ll_1333:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar \ell_3 \gamma^\mu \ell_3 \right)
+    lq1_1311:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_1 \gamma^\mu q_1 \right)
+    lq1_1312:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_1 \gamma^\mu q_2 \right)
+    lq1_1313:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_1 \gamma^\mu q_3 \right)
+    lq1_1321:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_2 \gamma^\mu q_1 \right)
+    lq1_1322:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_2 \gamma^\mu q_2 \right)
+    lq1_1323:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_2 \gamma^\mu q_3 \right)
+    lq1_1331:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_3 \gamma^\mu q_1 \right)
+    lq1_1332:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_3 \gamma^\mu q_2 \right)
+    lq1_1333:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar q_3 \gamma^\mu q_3 \right)
+    lq3_1311:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_1 \gamma^\mu \tau^I q_1 \right)
+    lq3_1312:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_1 \gamma^\mu \tau^I q_2 \right)
+    lq3_1313:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_1 \gamma^\mu \tau^I q_3 \right)
+    lq3_1321:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_2 \gamma^\mu \tau^I q_1 \right)
+    lq3_1322:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_2 \gamma^\mu \tau^I q_2 \right)
+    lq3_1323:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_2 \gamma^\mu \tau^I q_3 \right)
+    lq3_1331:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_3 \gamma^\mu \tau^I q_1 \right)
+    lq3_1332:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_3 \gamma^\mu \tau^I q_2 \right)
+    lq3_1333:
+      tex: \left( \bar \ell_1 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_3 \gamma^\mu \tau^I q_3 \right)
+    ee_1113:
+      tex: \left( \bar e_1 \gamma_\mu e_1 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+    ee_1223:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    ee_1333:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
+    eu_1311:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
+    eu_1312:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_1 \gamma^\mu u_2 \right)
+    eu_1313:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_1 \gamma^\mu u_3 \right)
+    eu_1321:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_2 \gamma^\mu u_1 \right)
+    eu_1322:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_2 \gamma^\mu u_2 \right)
+    eu_1323:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_2 \gamma^\mu u_3 \right)
+    eu_1331:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_3 \gamma^\mu u_1 \right)
+    eu_1332:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_3 \gamma^\mu u_2 \right)
+    eu_1333:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
+    ed_1311:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
+    ed_1312:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_1 \gamma^\mu d_2 \right)
+    ed_1313:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_1 \gamma^\mu d_3 \right)
+    ed_1321:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_2 \gamma^\mu d_1 \right)
+    ed_1322:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_2 \gamma^\mu d_2 \right)
+    ed_1323:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_2 \gamma^\mu d_3 \right)
+    ed_1331:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_3 \gamma^\mu d_1 \right)
+    ed_1332:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_3 \gamma^\mu d_2 \right)
+    ed_1333:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
+    le_1113:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+    le_1223:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    le_1311:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
+    le_1322:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
+    le_1333:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
+    le_2213:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+    le_2312:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+    le_3313:
+      tex: \left( \bar \ell_3 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+    lu_1311:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
+    lu_1312:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_1 \gamma^\mu u_2 \right)
+    lu_1313:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_1 \gamma^\mu u_3 \right)
+    lu_1321:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_2 \gamma^\mu u_1 \right)
+    lu_1322:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_2 \gamma^\mu u_2 \right)
+    lu_1323:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_2 \gamma^\mu u_3 \right)
+    lu_1331:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_3 \gamma^\mu u_1 \right)
+    lu_1332:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_3 \gamma^\mu u_2 \right)
+    lu_1333:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
+    ld_1311:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
+    ld_1312:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_1 \gamma^\mu d_2 \right)
+    ld_1313:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_1 \gamma^\mu d_3 \right)
+    ld_1321:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_2 \gamma^\mu d_1 \right)
+    ld_1322:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_2 \gamma^\mu d_2 \right)
+    ld_1323:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_2 \gamma^\mu d_3 \right)
+    ld_1331:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_3 \gamma^\mu d_1 \right)
+    ld_1332:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_3 \gamma^\mu d_2 \right)
+    ld_1333:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
+    qe_1113:
+      tex: \left( \bar q_1 \gamma_\mu q_1 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+    qe_1213:
+      tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+    qe_1231:
+      tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_3 \gamma^\mu e_1 \right)
+    qe_1313:
+      tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+    qe_1331:
+      tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_3 \gamma^\mu e_1 \right)
+    qe_2213:
+      tex: \left( \bar q_2 \gamma_\mu q_2 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+    qe_2313:
+      tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+    qe_2331:
+      tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_3 \gamma^\mu e_1 \right)
+    qe_3313:
+      tex: \left( \bar q_3 \gamma_\mu q_3 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+    ledq_1311:
+      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_1 q_1 \right)
+    ledq_1312:
+      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_1 q_2 \right)
+    ledq_1313:
+      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_1 q_3 \right)
+    ledq_1321:
+      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_2 q_1 \right)
+    ledq_1322:
+      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_2 q_2 \right)
+    ledq_1323:
+      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_2 q_3 \right)
+    ledq_1331:
+      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_3 q_1 \right)
+    ledq_1332:
+      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_3 q_2 \right)
+    ledq_1333:
+      tex: \left( \bar \ell_1 e_3 \right) \left( \bar d_3 q_3 \right)
+    ledq_3111:
+      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_1 q_1 \right)
+    ledq_3112:
+      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_1 q_2 \right)
+    ledq_3113:
+      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_1 q_3 \right)
+    ledq_3121:
+      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_2 q_1 \right)
+    ledq_3122:
+      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_2 q_2 \right)
+    ledq_3123:
+      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_2 q_3 \right)
+    ledq_3131:
+      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_3 q_1 \right)
+    ledq_3132:
+      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_3 q_2 \right)
+    ledq_3133:
+      tex: \left( \bar \ell_3 e_1 \right) \left( \bar d_3 q_3 \right)
+    lequ1_1311:
+      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_1 u_1 \right)
+    lequ1_1312:
+      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_1 u_2 \right)
+    lequ1_1313:
+      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_1 u_3 \right)
+    lequ1_1321:
+      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_2 u_1 \right)
+    lequ1_1322:
+      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_2 u_2 \right)
+    lequ1_1323:
+      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_2 u_3 \right)
+    lequ1_1331:
+      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_3 u_1 \right)
+    lequ1_1332:
+      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_3 u_2 \right)
+    lequ1_1333:
+      tex: \left( \bar \ell_1 e_3 \right) \epsilon_{jk} \left( \bar q_3 u_3 \right)
+    lequ1_3111:
+      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_1 u_1 \right)
+    lequ1_3112:
+      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_1 u_2 \right)
+    lequ1_3113:
+      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_1 u_3 \right)
+    lequ1_3121:
+      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_2 u_1 \right)
+    lequ1_3122:
+      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_2 u_2 \right)
+    lequ1_3123:
+      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_2 u_3 \right)
+    lequ1_3131:
+      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_3 u_1 \right)
+    lequ1_3132:
+      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_3 u_2 \right)
+    lequ1_3133:
+      tex: \left( \bar \ell_3 e_1 \right) \epsilon_{jk} \left( \bar q_3 u_3 \right)
+    lequ3_1311:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_1 \right)
+    lequ3_1312:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_2 \right)
+    lequ3_1313:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_3 \right)
+    lequ3_1321:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_1 \right)
+    lequ3_1322:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_2 \right)
+    lequ3_1323:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_3 \right)
+    lequ3_1331:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_1 \right)
+    lequ3_1332:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
+    lequ3_1333:
+      tex: \left( \bar \ell_1 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
+    lequ3_3111:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_1 \right)
+    lequ3_3112:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_2 \right)
+    lequ3_3113:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_3 \right)
+    lequ3_3121:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_1 \right)
+    lequ3_3122:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_2 \right)
+    lequ3_3123:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_3 \right)
+    lequ3_3131:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_1 \right)
+    lequ3_3132:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
+    lequ3_3133:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_1 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
+  mutau:
+    ephi_23:
+      tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_2 e_3 \varphi \right)
+    ephi_32:
+      tex: \left( \varphi^\dagger \varphi \right) \left( \bar \ell_3 e_2 \varphi \right)
+    eW_23:
+      tex: \left( \bar \ell_2 \sigma^{\mu \nu} e_3 \right) \tau^I \varphi W_{\mu \nu}^I
+    eW_32:
+      tex: \left( \bar \ell_3 \sigma^{\mu \nu} e_2 \right) \tau^I \varphi W_{\mu \nu}^I
+    eB_23:
+      tex: \left( \bar \ell_2 \sigma^{\mu \nu} e_3 \right) \varphi B_{\mu \nu}
+    eB_32:
+      tex: \left( \bar \ell_3 \sigma^{\mu \nu} e_2 \right) \varphi B_{\mu \nu}
+    phil1_23:
+      tex: \left( \varphi^\dagger i \overset\leftrightarrow{D}_\mu \varphi \right) \left( \bar \ell_2 \gamma^\mu \ell_3 \right)
+    phil3_23:
+      tex: \left( \varphi^\dagger i \overset\leftrightarrow{D}^I_\mu \varphi \right) \left( \bar \ell_2 \tau^I \gamma^\mu \ell_3 \right)
+    phie_23:
+      tex: \left( \varphi^\dagger i \overset\leftrightarrow{D}_\mu \varphi \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    ll_1123:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar \ell_2 \gamma^\mu \ell_3 \right)
+    ll_1231:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_3 \gamma^\mu \ell_1 \right)
+    ll_2223:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar \ell_2 \gamma^\mu \ell_3 \right)
+    ll_2333:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar \ell_3 \gamma^\mu \ell_3 \right)
+    lq1_2311:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_1 \gamma^\mu q_1 \right)
+    lq1_2312:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_1 \gamma^\mu q_2 \right)
+    lq1_2313:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_1 \gamma^\mu q_3 \right)
+    lq1_2321:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_2 \gamma^\mu q_1 \right)
+    lq1_2322:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_2 \gamma^\mu q_2 \right)
+    lq1_2323:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_2 \gamma^\mu q_3 \right)
+    lq1_2331:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_3 \gamma^\mu q_1 \right)
+    lq1_2332:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_3 \gamma^\mu q_2 \right)
+    lq1_2333:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar q_3 \gamma^\mu q_3 \right)
+    lq3_2311:
+      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_1 \gamma^\mu \tau^I q_1 \right)
+    lq3_2312:
+      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_1 \gamma^\mu \tau^I q_2 \right)
+    lq3_2313:
+      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_1 \gamma^\mu \tau^I q_3 \right)
+    lq3_2321:
+      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_2 \gamma^\mu \tau^I q_1 \right)
+    lq3_2322:
+      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_2 \gamma^\mu \tau^I q_2 \right)
+    lq3_2323:
+      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_2 \gamma^\mu \tau^I q_3 \right)
+    lq3_2331:
+      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_3 \gamma^\mu \tau^I q_1 \right)
+    lq3_2332:
+      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_3 \gamma^\mu \tau^I q_2 \right)
+    lq3_2333:
+      tex: \left( \bar \ell_2 \gamma_\mu \tau^I \ell_3 \right) \left( \bar q_3 \gamma^\mu \tau^I q_3 \right)
+    ee_1123:
+      tex: \left( \bar e_1 \gamma_\mu e_1 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    ee_2223:
+      tex: \left( \bar e_2 \gamma_\mu e_2 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    ee_2333:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
+    eu_2311:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
+    eu_2312:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_1 \gamma^\mu u_2 \right)
+    eu_2313:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_1 \gamma^\mu u_3 \right)
+    eu_2321:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_2 \gamma^\mu u_1 \right)
+    eu_2322:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_2 \gamma^\mu u_2 \right)
+    eu_2323:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_2 \gamma^\mu u_3 \right)
+    eu_2331:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_3 \gamma^\mu u_1 \right)
+    eu_2332:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_3 \gamma^\mu u_2 \right)
+    eu_2333:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
+    ed_2311:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
+    ed_2312:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_1 \gamma^\mu d_2 \right)
+    ed_2313:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_1 \gamma^\mu d_3 \right)
+    ed_2321:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_2 \gamma^\mu d_1 \right)
+    ed_2322:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_2 \gamma^\mu d_2 \right)
+    ed_2323:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_2 \gamma^\mu d_3 \right)
+    ed_2331:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_3 \gamma^\mu d_1 \right)
+    ed_2332:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_3 \gamma^\mu d_2 \right)
+    ed_2333:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
+    le_1123:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_1 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    le_1231:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_3 \gamma^\mu e_1 \right)
+    le_1321:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_1 \right)
+    le_2223:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_2 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    le_2311:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_1 \right)
+    le_2322:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_2 \right)
+    le_2333:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_3 \gamma^\mu e_3 \right)
+    le_3323:
+      tex: \left( \bar \ell_3 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    lu_2311:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_1 \gamma^\mu u_1 \right)
+    lu_2312:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_1 \gamma^\mu u_2 \right)
+    lu_2313:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_1 \gamma^\mu u_3 \right)
+    lu_2321:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_2 \gamma^\mu u_1 \right)
+    lu_2322:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_2 \gamma^\mu u_2 \right)
+    lu_2323:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_2 \gamma^\mu u_3 \right)
+    lu_2331:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_3 \gamma^\mu u_1 \right)
+    lu_2332:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_3 \gamma^\mu u_2 \right)
+    lu_2333:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar u_3 \gamma^\mu u_3 \right)
+    ld_2311:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_1 \gamma^\mu d_1 \right)
+    ld_2312:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_1 \gamma^\mu d_2 \right)
+    ld_2313:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_1 \gamma^\mu d_3 \right)
+    ld_2321:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_2 \gamma^\mu d_1 \right)
+    ld_2322:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_2 \gamma^\mu d_2 \right)
+    ld_2323:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_2 \gamma^\mu d_3 \right)
+    ld_2331:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_3 \gamma^\mu d_1 \right)
+    ld_2332:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_3 \gamma^\mu d_2 \right)
+    ld_2333:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar d_3 \gamma^\mu d_3 \right)
+    qe_1123:
+      tex: \left( \bar q_1 \gamma_\mu q_1 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    qe_1223:
+      tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    qe_1232:
+      tex: \left( \bar q_1 \gamma_\mu q_2 \right) \left( \bar e_3 \gamma^\mu e_2 \right)
+    qe_1323:
+      tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    qe_1332:
+      tex: \left( \bar q_1 \gamma_\mu q_3 \right) \left( \bar e_3 \gamma^\mu e_2 \right)
+    qe_2223:
+      tex: \left( \bar q_2 \gamma_\mu q_2 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    qe_2323:
+      tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    qe_2332:
+      tex: \left( \bar q_2 \gamma_\mu q_3 \right) \left( \bar e_3 \gamma^\mu e_2 \right)
+    qe_3323:
+      tex: \left( \bar q_3 \gamma_\mu q_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    ledq_2311:
+      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_1 q_1 \right)
+    ledq_2312:
+      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_1 q_2 \right)
+    ledq_2313:
+      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_1 q_3 \right)
+    ledq_2321:
+      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_2 q_1 \right)
+    ledq_2322:
+      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_2 q_2 \right)
+    ledq_2323:
+      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_2 q_3 \right)
+    ledq_2331:
+      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_3 q_1 \right)
+    ledq_2332:
+      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_3 q_2 \right)
+    ledq_2333:
+      tex: \left( \bar \ell_2 e_3 \right) \left( \bar d_3 q_3 \right)
+    ledq_3211:
+      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_1 q_1 \right)
+    ledq_3212:
+      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_1 q_2 \right)
+    ledq_3213:
+      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_1 q_3 \right)
+    ledq_3221:
+      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_2 q_1 \right)
+    ledq_3222:
+      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_2 q_2 \right)
+    ledq_3223:
+      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_2 q_3 \right)
+    ledq_3231:
+      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_3 q_1 \right)
+    ledq_3232:
+      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_3 q_2 \right)
+    ledq_3233:
+      tex: \left( \bar \ell_3 e_2 \right) \left( \bar d_3 q_3 \right)
+    lequ1_2311:
+      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_1 u_1 \right)
+    lequ1_2312:
+      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_1 u_2 \right)
+    lequ1_2313:
+      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_1 u_3 \right)
+    lequ1_2321:
+      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_2 u_1 \right)
+    lequ1_2322:
+      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_2 u_2 \right)
+    lequ1_2323:
+      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_2 u_3 \right)
+    lequ1_2331:
+      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_3 u_1 \right)
+    lequ1_2332:
+      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_3 u_2 \right)
+    lequ1_2333:
+      tex: \left( \bar \ell_2 e_3 \right) \epsilon_{jk} \left( \bar q_3 u_3 \right)
+    lequ1_3211:
+      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_1 u_1 \right)
+    lequ1_3212:
+      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_1 u_2 \right)
+    lequ1_3213:
+      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_1 u_3 \right)
+    lequ1_3221:
+      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_2 u_1 \right)
+    lequ1_3222:
+      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_2 u_2 \right)
+    lequ1_3223:
+      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_2 u_3 \right)
+    lequ1_3231:
+      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_3 u_1 \right)
+    lequ1_3232:
+      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_3 u_2 \right)
+    lequ1_3233:
+      tex: \left( \bar \ell_3 e_2 \right) \epsilon_{jk} \left( \bar q_3 u_3 \right)
+    lequ3_2311:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_1 \right)
+    lequ3_2312:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_2 \right)
+    lequ3_2313:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_3 \right)
+    lequ3_2321:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_1 \right)
+    lequ3_2322:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_2 \right)
+    lequ3_2323:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_3 \right)
+    lequ3_2331:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_1 \right)
+    lequ3_2332:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
+    lequ3_2333:
+      tex: \left( \bar \ell_2 \sigma_{\mu \nu} e_3 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
+    lequ3_3211:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_1 \right)
+    lequ3_3212:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_2 \right)
+    lequ3_3213:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_1 \sigma^{\mu \nu} u_3 \right)
+    lequ3_3221:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_1 \right)
+    lequ3_3222:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_2 \right)
+    lequ3_3223:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_2 \sigma^{\mu \nu} u_3 \right)
+    lequ3_3231:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_1 \right)
+    lequ3_3232:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_2 \right)
+    lequ3_3233:
+      tex: \left( \bar \ell_3 \sigma_{\mu \nu} e_2 \right) \epsilon_{jk} \left( \bar q_3 \sigma^{\mu \nu} u_3 \right)
+  muemue:
+    ll_1212:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_1 \gamma^\mu \ell_2 \right)
+    ee_1212:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+    le_1212:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+  etauemu:
+    ll_1213:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_1 \gamma^\mu \ell_3 \right)
+    ee_1213:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+    le_1213:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+    le_1312:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_2 \right)
+  muemutau:
+    ll_1232:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar \ell_3 \gamma^\mu \ell_2 \right)
+    ee_1232:
+      tex: \left( \bar e_1 \gamma_\mu e_2 \right) \left( \bar e_3 \gamma^\mu e_2 \right)
+    le_1232:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_2 \right) \left( \bar e_3 \gamma^\mu e_2 \right)
+    le_2321:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_1 \right)
+  tauetaue:
+    ll_1313:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar \ell_1 \gamma^\mu \ell_3 \right)
+    ee_1313:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+    le_1313:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+  tauetaumu:
+    ll_1323:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar \ell_2 \gamma^\mu \ell_3 \right)
+    ee_1323:
+      tex: \left( \bar e_1 \gamma_\mu e_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    le_1323:
+      tex: \left( \bar \ell_1 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    le_2313:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_1 \gamma^\mu e_3 \right)
+  taumutaumu:
+    ll_2323:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar \ell_2 \gamma^\mu \ell_3 \right)
+    ee_2323:
+      tex: \left( \bar e_2 \gamma_\mu e_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
+    le_2323:
+      tex: \left( \bar \ell_2 \gamma_\mu \ell_3 \right) \left( \bar e_2 \gamma^\mu e_3 \right)
   dB=dL=1:
     duql_1111:
       tex: \left( d_1 C u_1 \right) \left( q_1 C \ell_1 \right)


### PR DESCRIPTION
In the SMEFT, the previously defined sector `dB=dL=0` contains 10 different sectors that are closed under RG evolution. This PR splits `dB=dL=0` into these 10 sectors.

**Reason for the change:**
While the previous `dB=dL=0` sector has $N=2499$ real parameters, the largest RG-closed sector has only $N=1611$ real parameters. Since the number of operations required for matrix-matrix multiplication scales as $O(N^3)$, and for matrix-vector multiplication as $O(N^2)$, smaller matrices significantly reduce computation time. This is in particular relevant for implementing the SMEFT RG evolution using evolution matrices, but also for basis changes and matching to the WET.

**Choice of sector names:**
- The largest sector is renamed from `dB=dL=0`  to `dB=de=dmu=dtau=0`, making clear that all individual lepton numbers are conserved by its operators, and avoiding possible confusion with the previously defined `dB=dL=0` sector that also contained lepton flavour violating operators.
- The remaining new SMEFT sectors have corresponding sectors already defined for the WET and their names are taken to be equal. This is particularly convenient for the SMEFT to WET matching, as these new SMEFT sectors match directly to the WET sectors with the same names.

**Backwards compatibility:**
While different sectors defined in the WET are used throughout many codes based on WCxf, to my knowledge this is currently not the case for the SMEFT sectors:
- RG evolution, basis change, and matching in `wilson` is always done for the entire SMEFT, and all optional `sector` arguments of the related functions are currently ignored throughout the package.
The only place where the `dB=dL=0` sector is used in `wilson` is the the new translator from and to the `SMEFTsim-general` basis, which was released just one week ago and can be easily adapted.
- Packages like `flavio` and `smelli` that make use of the WET sectors, do not distinguish between different SMEFT sectors.
The only exception is the Drell-Yan implementation in flavio, which selects Wilson coefficients from the `dB=dL=0` sector using `wilson`. But since `wilson` ignores the `sector` argument and just returns the entire set of SMEFT Wilson coefficients, the use of this sector in `flavio` has no effect.
- WCxf files used to exchange Wilson coefficients between different codes only contain the names of the operators (which are not modified by this PR), but never mention any sector.
- The [WCxf paper](https://arxiv.org/abs/1712.05298) mentions the `dB=dL=0` sector in sections 2.1 and 2.2. But the paper only gives examples of valid file structures and explicitly writes that the files "could look like" those shown in these examples. It should be clear from the paper that these examples do not define the EFTs and bases, which is only done by the JSON and YAML files in this repository.

Given these points, I believe the changes made in this PR do not break backwards compatibility.

**Possible further splitting of other sectors:**
- ~~The sector `dB=dL=1` could be split into three sectors corresponding to electron, muon, and tau number, `dB=de=1`, `dB=dmu=1`, `dB=dtau=1`. This is not done in this PR yet, but could be a possible addition.~~ (this has been done; see commit and comment below)
- The operators in the `dL=2` sector don't mix into each other and would in principle constitute their own sectors. But since the `dL=2` sector is already very small, containing only six operators, I think it is unnecessary to split it.

@jasonaebischerGIT, @dvandyk, @DavidMStraub, I would be happy to hear your opinions on this PR before merging it. Do you think I should also split the `dB=dL=1` sector?